### PR TITLE
Fix HEIR config path typo

### DIFF
--- a/frontend/heir/heir_cli/heir_cli_config.py
+++ b/frontend/heir/heir_cli/heir_cli_config.py
@@ -37,7 +37,7 @@ def development_heir_config() -> HEIRConfig:
       / "yosys"
   )
   if not techmap_dir_path.exists():
-    techmap_path = ""
+    techmap_dir_path = ""
 
   abc_path = (
       repo_root


### PR DESCRIPTION
## Summary
- fix a typo in `development_heir_config` where non-existent techmap path
  wasn't cleared correctly
- run formatter

## Testing
- `pyink frontend/heir/heir_cli/heir_cli_config.py --check -v`
- `pytest scripts/test_lit_to_bazel.py -q`

------
https://chatgpt.com/codex/tasks/task_e_6840c0a608a08328aa3a829641fa4d2c