### PR TITLE
Add SimFHE backend emitter

### DIFF
--- a/lib/Target/CMakeLists.txt
+++ b/lib/Target/CMakeLists.txt
@@ -3,6 +3,7 @@ add_library(HEIRTarget INTERFACE)
 
 add_subdirectory(Jaxite)
 add_subdirectory(JaxiteWord)
+add_subdirectory(SimFHE)
 add_subdirectory(Metadata)
 add_subdirectory(OpenFhePke)
 add_subdirectory(TfheRust)

--- a/lib/Target/SimFHE/BUILD
+++ b/lib/Target/SimFHE/BUILD
@@ -15,6 +15,11 @@ cc_library(
     deps = [
         "@heir//lib/Analysis/SelectVariableNames",
         "@heir//lib/Dialect/CKKS/IR:Dialect",
+        "@heir//lib/Dialect/LWE/IR:Dialect",
+        "@heir//lib/Dialect/ModArith/IR:Dialect",
+        "@heir//lib/Dialect/Polynomial/IR:Dialect",
+        "@heir//lib/Dialect/RNS/IR:Dialect",
+        "@heir//lib/Dialect/RNS/IR:RNSTypeInterfaces",
         "@heir//lib/Utils:TargetUtils",
         "@llvm-project//llvm:Support",
         "@llvm-project//mlir:FuncDialect",

--- a/lib/Target/SimFHE/BUILD
+++ b/lib/Target/SimFHE/BUILD
@@ -1,0 +1,25 @@
+# SimFHE Emitter
+
+package(
+    default_applicable_licenses = ["@heir//:license"],
+    default_visibility = ["//visibility:public"],
+)
+
+cc_library(
+    name = "SimFHEEmitter",
+    srcs = ["SimFHEEmitter.cpp"],
+    hdrs = [
+        "SimFHEEmitter.h",
+        "SimFHETemplates.h",
+    ],
+    deps = [
+        "@heir//lib/Analysis/SelectVariableNames",
+        "@heir//lib/Dialect/CKKS/IR:Dialect",
+        "@heir//lib/Utils:TargetUtils",
+        "@llvm-project//llvm:Support",
+        "@llvm-project//mlir:FuncDialect",
+        "@llvm-project//mlir:IR",
+        "@llvm-project//mlir:Support",
+        "@llvm-project//mlir:TranslateLib",
+    ],
+)

--- a/lib/Target/SimFHE/CMakeLists.txt
+++ b/lib/Target/SimFHE/CMakeLists.txt
@@ -1,0 +1,15 @@
+add_mlir_library(HEIRSimFHEEmitter
+    SimFHEEmitter.cpp
+
+    LINK_LIBS PUBLIC
+    HEIRSelectVariableNames
+    HEIRCKKS
+    HEIRTargetUtils
+    MLIRFuncDialect
+    MLIRIR
+    MLIRSupport
+    MLIRTranslateLib
+    LLVMSupport
+)
+
+target_link_libraries(HEIRTarget INTERFACE HEIRSimFHEEmitter)

--- a/lib/Target/SimFHE/CMakeLists.txt
+++ b/lib/Target/SimFHE/CMakeLists.txt
@@ -4,8 +4,12 @@ add_mlir_library(HEIRSimFHEEmitter
     LINK_LIBS PUBLIC
     HEIRSelectVariableNames
     HEIRCKKS
+    HEIRLWE
+    HEIRModArith
+    HEIRRNS
     HEIRTargetUtils
     MLIRFuncDialect
+    MLIRPolynomialDialect
     MLIRIR
     MLIRSupport
     MLIRTranslateLib

--- a/lib/Target/SimFHE/SimFHEEmitter.cpp
+++ b/lib/Target/SimFHE/SimFHEEmitter.cpp
@@ -131,7 +131,12 @@ BINARY_EMIT(ckks::MulOp, getLhs, "multiply");
 BINARY_EMIT(ckks::MulPlainOp, getLhs, "multiply_plain");
 UNARY_EMIT(ckks::NegateOp, getInput, "negate");
 UNARY_EMIT(ckks::RotateOp, getInput, "rotate");
-UNARY_EMIT(ckks::RelinearizeOp, getInput, "key_switch");
+LogicalResult SimFHEEmitter::printOperation(ckks::RelinearizeOp op) {
+  std::string name = getName(op.getInput());
+  os << "stats += evaluator.key_switch(" << name << ", " << name
+     << ", arch_params)\n";
+  return success();
+}
 UNARY_EMIT(ckks::RescaleOp, getInput, "mod_reduce_rescale");
 UNARY_EMIT(ckks::LevelReduceOp, getInput, "mod_down_reduce");
 UNARY_EMIT(ckks::BootstrapOp, getInput, "bootstrap");

--- a/lib/Target/SimFHE/SimFHEEmitter.cpp
+++ b/lib/Target/SimFHE/SimFHEEmitter.cpp
@@ -94,32 +94,32 @@ LogicalResult SimFHEEmitter::printOperation(func::ReturnOp op) {
   return success();
 }
 
-#define UNARY_EMIT(OPTYPE, FUNCNAME)                               \
-  LogicalResult SimFHEEmitter::printOperation(OPTYPE op) {         \
-    os << "stats += evaluator." FUNCNAME "("                       \
-       << getName(op.getOperands().front()) << ", arch_params)\n"; \
-    return success();                                              \
+#define UNARY_EMIT(OPTYPE, GETTER, FUNCNAME)                         \
+  LogicalResult SimFHEEmitter::printOperation(OPTYPE op) {           \
+    os << "stats += evaluator." FUNCNAME "(" << getName(op.GETTER()) \
+       << ", arch_params)\n";                                        \
+    return success();                                                \
   }
 
-#define BINARY_EMIT(OPTYPE, FUNCNAME)                              \
-  LogicalResult SimFHEEmitter::printOperation(OPTYPE op) {         \
-    os << "stats += evaluator." FUNCNAME "("                       \
-       << getName(op.getOperands().front()) << ", arch_params)\n"; \
-    return success();                                              \
+#define BINARY_EMIT(OPTYPE, GETTER, FUNCNAME)                        \
+  LogicalResult SimFHEEmitter::printOperation(OPTYPE op) {           \
+    os << "stats += evaluator." FUNCNAME "(" << getName(op.GETTER()) \
+       << ", arch_params)\n";                                        \
+    return success();                                                \
   }
 
-BINARY_EMIT(ckks::AddOp, "add");
-BINARY_EMIT(ckks::AddPlainOp, "add_plain");
-BINARY_EMIT(ckks::SubOp, "subtract");
-BINARY_EMIT(ckks::SubPlainOp, "subtract_plain");
-BINARY_EMIT(ckks::MulOp, "multiply");
-BINARY_EMIT(ckks::MulPlainOp, "multiply_plain");
-UNARY_EMIT(ckks::NegateOp, "negate");
-UNARY_EMIT(ckks::RotateOp, "rotate");
-UNARY_EMIT(ckks::RelinearizeOp, "key_switch");
-UNARY_EMIT(ckks::RescaleOp, "mod_reduce_rescale");
-UNARY_EMIT(ckks::LevelReduceOp, "mod_down_reduce");
-UNARY_EMIT(ckks::BootstrapOp, "bootstrap");
+BINARY_EMIT(ckks::AddOp, getLhs, "add");
+BINARY_EMIT(ckks::AddPlainOp, getLhs, "add_plain");
+BINARY_EMIT(ckks::SubOp, getLhs, "subtract");
+BINARY_EMIT(ckks::SubPlainOp, getLhs, "subtract_plain");
+BINARY_EMIT(ckks::MulOp, getLhs, "multiply");
+BINARY_EMIT(ckks::MulPlainOp, getLhs, "multiply_plain");
+UNARY_EMIT(ckks::NegateOp, getInput, "negate");
+UNARY_EMIT(ckks::RotateOp, getInput, "rotate");
+UNARY_EMIT(ckks::RelinearizeOp, getInput, "key_switch");
+UNARY_EMIT(ckks::RescaleOp, getInput, "mod_reduce_rescale");
+UNARY_EMIT(ckks::LevelReduceOp, getInput, "mod_down_reduce");
+UNARY_EMIT(ckks::BootstrapOp, getInput, "bootstrap");
 
 #undef UNARY_EMIT
 #undef BINARY_EMIT

--- a/lib/Target/SimFHE/SimFHEEmitter.cpp
+++ b/lib/Target/SimFHE/SimFHEEmitter.cpp
@@ -94,18 +94,18 @@ LogicalResult SimFHEEmitter::printOperation(func::ReturnOp op) {
   return success();
 }
 
-#define UNARY_EMIT(OPTYPE, FUNCNAME)                                   \
-  LogicalResult SimFHEEmitter::printOperation(OPTYPE op) {             \
-    os << "stats += evaluator." FUNCNAME "(" << getName(op.getInput()) \
-       << ", arch_params)\n";                                          \
-    return success();                                                  \
+#define UNARY_EMIT(OPTYPE, FUNCNAME)                               \
+  LogicalResult SimFHEEmitter::printOperation(OPTYPE op) {         \
+    os << "stats += evaluator." FUNCNAME "("                       \
+       << getName(op.getOperands().front()) << ", arch_params)\n"; \
+    return success();                                              \
   }
 
-#define BINARY_EMIT(OPTYPE, FUNCNAME)                                        \
-  LogicalResult SimFHEEmitter::printOperation(OPTYPE op) {                   \
-    os << "stats += evaluator." FUNCNAME "(" << getName(op.getLhs()) << ", " \
-       << getName(op.getRhs()) << ", arch_params)\n";                        \
-    return success();                                                        \
+#define BINARY_EMIT(OPTYPE, FUNCNAME)                              \
+  LogicalResult SimFHEEmitter::printOperation(OPTYPE op) {         \
+    os << "stats += evaluator." FUNCNAME "("                       \
+       << getName(op.getOperands().front()) << ", arch_params)\n"; \
+    return success();                                              \
   }
 
 BINARY_EMIT(ckks::AddOp, "add");

--- a/lib/Target/SimFHE/SimFHEEmitter.cpp
+++ b/lib/Target/SimFHE/SimFHEEmitter.cpp
@@ -63,8 +63,8 @@ LogicalResult SimFHEEmitter::printOperation(ModuleOp moduleOp) {
 
 LogicalResult SimFHEEmitter::printOperation(func::FuncOp funcOp) {
   os << "def " << funcOp.getName() << "(";
-  os << commaSeparatedValues(funcOp.getArguments(),
-                             [&](Value value) { return getName(value); });
+  os << heir::commaSeparatedValues(funcOp.getArguments(),
+                                   [&](Value value) { return getName(value); });
   os << "):\n";
   os.indent();
   os << "stats = PerfCounter()\n";
@@ -93,17 +93,17 @@ LogicalResult SimFHEEmitter::printOperation(func::ReturnOp op) {
     return success();                                                  \
   }
 
-#define BINARY_EMIT(OPTYPE, FUNCNAME)                                \
-  LogicalResult SimFHEEmitter::printOperation(OPTYPE op) {           \
-    os << "stats += evaluator." FUNCNAME "(" << getName(op.getLhs()) \
-       << ", arch_params)\n";                                        \
-    return success();                                                \
+#define BINARY_EMIT(OPTYPE, FUNCNAME)                                        \
+  LogicalResult SimFHEEmitter::printOperation(OPTYPE op) {                   \
+    os << "stats += evaluator." FUNCNAME "(" << getName(op.getLhs()) << ", " \
+       << getName(op.getRhs()) << ", arch_params)\n";                        \
+    return success();                                                        \
   }
 
 BINARY_EMIT(ckks::AddOp, "add");
 BINARY_EMIT(ckks::AddPlainOp, "add_plain");
-BINARY_EMIT(ckks::SubOp, "add");
-BINARY_EMIT(ckks::SubPlainOp, "add_plain");
+BINARY_EMIT(ckks::SubOp, "subtract");
+BINARY_EMIT(ckks::SubPlainOp, "subtract_plain");
 BINARY_EMIT(ckks::MulOp, "multiply");
 BINARY_EMIT(ckks::MulPlainOp, "multiply_plain");
 UNARY_EMIT(ckks::NegateOp, "negate");

--- a/lib/Target/SimFHE/SimFHEEmitter.cpp
+++ b/lib/Target/SimFHE/SimFHEEmitter.cpp
@@ -1,0 +1,112 @@
+#include "lib/Target/SimFHE/SimFHEEmitter.h"
+
+#include "lib/Analysis/SelectVariableNames/SelectVariableNames.h"
+#include "lib/Dialect/CKKS/IR/CKKSDialect.h"
+#include "llvm/include/llvm/ADT/TypeSwitch.h"      // from @llvm-project
+#include "mlir/include/mlir/IR/DialectRegistry.h"  // from @llvm-project
+#include "mlir/include/mlir/Tools/mlir-translate/Translation.h"  // from @llvm-project
+
+namespace mlir {
+namespace heir {
+namespace simfhe {
+
+void registerToSimFHETranslation() {
+  TranslateFromMLIRRegistration reg(
+      "emit-simfhe", "translate ckks dialect to SimFHE python code",
+      [](Operation *op, llvm::raw_ostream &output) {
+        return translateToSimFHE(op, output);
+      },
+      [](DialectRegistry &registry) {
+        registry.insert<func::FuncDialect, ckks::CKKSDialect>();
+      });
+}
+
+LogicalResult translateToSimFHE(Operation *op, llvm::raw_ostream &os) {
+  SelectVariableNames variableNames(op);
+  SimFHEEmitter emitter(os, &variableNames);
+  return emitter.translate(*op);
+}
+
+SimFHEEmitter::SimFHEEmitter(llvm::raw_ostream &os,
+                             SelectVariableNames *variableNames)
+    : os(os), variableNames(variableNames) {}
+
+LogicalResult SimFHEEmitter::translate(Operation &op) {
+  LogicalResult status =
+      llvm::TypeSwitch<Operation &, LogicalResult>(op)
+          .Case<ModuleOp, func::FuncOp, func::ReturnOp, ckks::AddOp,
+                ckks::AddPlainOp, ckks::SubOp, ckks::SubPlainOp, ckks::MulOp,
+                ckks::MulPlainOp, ckks::NegateOp, ckks::RotateOp,
+                ckks::RelinearizeOp, ckks::RescaleOp, ckks::LevelReduceOp,
+                ckks::BootstrapOp>(
+              [&](auto innerOp) { return printOperation(innerOp); })
+          .Default([&](Operation &) {
+            return op.emitOpError("unable to find printer for op");
+          });
+  if (failed(status)) {
+    return op.emitOpError(
+        llvm::formatv("Failed to translate op {0}", op.getName()));
+  }
+  return success();
+}
+
+LogicalResult SimFHEEmitter::printOperation(ModuleOp moduleOp) {
+  os << kModulePrelude << "\n";
+  for (Operation &op : moduleOp) {
+    if (failed(translate(op))) {
+      return failure();
+    }
+  }
+  return success();
+}
+
+LogicalResult SimFHEEmitter::printOperation(func::FuncOp funcOp) {
+  os << "def " << funcOp.getName() << "(";
+  os << commaSeparatedValues(funcOp.getArguments(),
+                             [&](Value value) { return getName(value); });
+  os << "):\n";
+  os.indent();
+  os << "stats = PerfCounter()\n";
+  for (Block &block : funcOp.getBlocks()) {
+    for (Operation &op : block.getOperations()) {
+      if (failed(translate(op))) {
+        return failure();
+      }
+    }
+  }
+  os << "return stats\n";
+  os.unindent();
+  os << "\n";
+  return success();
+}
+
+LogicalResult SimFHEEmitter::printOperation(func::ReturnOp op) {
+  // return is handled via accumulating stats; nothing to do
+  return success();
+}
+
+#define SIMPLE_EMIT(OPTYPE, FUNCNAME)                               \
+  LogicalResult SimFHEEmitter::printOperation(OPTYPE op) {          \
+    os << "evaluator." FUNCNAME "(" << getName(op.getOperands()[0]) \
+       << ", arch_params)\n";                                       \
+    return success();                                               \
+  }
+
+SIMPLE_EMIT(ckks::AddOp, "add");
+SIMPLE_EMIT(ckks::AddPlainOp, "add_plain");
+SIMPLE_EMIT(ckks::SubOp, "add");
+SIMPLE_EMIT(ckks::SubPlainOp, "add_plain");
+SIMPLE_EMIT(ckks::MulOp, "multiply");
+SIMPLE_EMIT(ckks::MulPlainOp, "multiply_plain");
+SIMPLE_EMIT(ckks::NegateOp, "negate");
+SIMPLE_EMIT(ckks::RotateOp, "rotate");
+SIMPLE_EMIT(ckks::RelinearizeOp, "key_switch");
+SIMPLE_EMIT(ckks::RescaleOp, "mod_reduce_rescale");
+SIMPLE_EMIT(ckks::LevelReduceOp, "mod_down_reduce");
+SIMPLE_EMIT(ckks::BootstrapOp, "bootstrap");
+
+#undef SIMPLE_EMIT
+
+}  // namespace simfhe
+}  // namespace heir
+}  // namespace mlir

--- a/lib/Target/SimFHE/SimFHEEmitter.cpp
+++ b/lib/Target/SimFHE/SimFHEEmitter.cpp
@@ -2,6 +2,11 @@
 
 #include "lib/Analysis/SelectVariableNames/SelectVariableNames.h"
 #include "lib/Dialect/CKKS/IR/CKKSDialect.h"
+#include "lib/Dialect/LWE/IR/LWEDialect.h"
+#include "lib/Dialect/ModArith/IR/ModArithDialect.h"
+#include "lib/Dialect/Polynomial/IR/PolynomialDialect.h"
+#include "lib/Dialect/RNS/IR/RNSDialect.h"
+#include "lib/Dialect/RNS/IR/RNSTypeInterfaces.h"
 #include "llvm/include/llvm/ADT/TypeSwitch.h"          // from @llvm-project
 #include "llvm/include/llvm/Support/FormatVariadic.h"  // from @llvm-project
 #include "mlir/include/mlir/IR/DialectRegistry.h"      // from @llvm-project
@@ -18,7 +23,10 @@ void registerToSimFHETranslation() {
         return translateToSimFHE(op, output);
       },
       [](DialectRegistry &registry) {
-        registry.insert<func::FuncDialect, ckks::CKKSDialect>();
+        registry.insert<func::FuncDialect, ckks::CKKSDialect, lwe::LWEDialect,
+                        polynomial::PolynomialDialect,
+                        mod_arith::ModArithDialect, rns::RNSDialect>();
+        rns::registerExternalRNSTypeInterfaces(registry);
       });
 }
 

--- a/lib/Target/SimFHE/SimFHEEmitter.h
+++ b/lib/Target/SimFHE/SimFHEEmitter.h
@@ -1,0 +1,58 @@
+#ifndef LIB_TARGET_SIMFHE_SIMFHEEMITTER_H_
+#define LIB_TARGET_SIMFHE_SIMFHEEMITTER_H_
+
+#include <string>
+
+#include "lib/Analysis/SelectVariableNames/SelectVariableNames.h"
+#include "lib/Dialect/CKKS/IR/CKKSOps.h"
+#include "lib/Target/SimFHE/SimFHETemplates.h"
+#include "llvm/include/llvm/Support/raw_ostream.h"      // from @llvm-project
+#include "mlir/include/mlir/Dialect/Func/IR/FuncOps.h"  // from @llvm-project
+#include "mlir/include/mlir/IR/BuiltinOps.h"            // from @llvm-project
+#include "mlir/include/mlir/IR/Operation.h"             // from @llvm-project
+#include "mlir/include/mlir/Support/IndentedOstream.h"  // from @llvm-project
+#include "mlir/include/mlir/Support/LogicalResult.h"    // from @llvm-project
+
+namespace mlir {
+namespace heir {
+namespace simfhe {
+
+void registerToSimFHETranslation();
+
+LogicalResult translateToSimFHE(Operation *op, llvm::raw_ostream &os);
+
+class SimFHEEmitter {
+ public:
+  SimFHEEmitter(llvm::raw_ostream &os, SelectVariableNames *variableNames);
+  LogicalResult translate(Operation &operation);
+
+ private:
+  raw_indented_ostream os;
+  SelectVariableNames *variableNames;
+
+  LogicalResult printOperation(ModuleOp moduleOp);
+  LogicalResult printOperation(func::FuncOp funcOp);
+  LogicalResult printOperation(func::ReturnOp op);
+  LogicalResult printOperation(ckks::AddOp op);
+  LogicalResult printOperation(ckks::AddPlainOp op);
+  LogicalResult printOperation(ckks::SubOp op);
+  LogicalResult printOperation(ckks::SubPlainOp op);
+  LogicalResult printOperation(ckks::MulOp op);
+  LogicalResult printOperation(ckks::MulPlainOp op);
+  LogicalResult printOperation(ckks::NegateOp op);
+  LogicalResult printOperation(ckks::RotateOp op);
+  LogicalResult printOperation(ckks::RelinearizeOp op);
+  LogicalResult printOperation(ckks::RescaleOp op);
+  LogicalResult printOperation(ckks::LevelReduceOp op);
+  LogicalResult printOperation(ckks::BootstrapOp op);
+
+  std::string getName(Value value) const {
+    return variableNames->getNameForValue(value);
+  }
+};
+
+}  // namespace simfhe
+}  // namespace heir
+}  // namespace mlir
+
+#endif  // LIB_TARGET_SIMFHE_SIMFHEEMITTER_H_

--- a/lib/Target/SimFHE/SimFHEEmitter.h
+++ b/lib/Target/SimFHE/SimFHEEmitter.h
@@ -6,6 +6,7 @@
 #include "lib/Analysis/SelectVariableNames/SelectVariableNames.h"
 #include "lib/Dialect/CKKS/IR/CKKSOps.h"
 #include "lib/Target/SimFHE/SimFHETemplates.h"
+#include "lib/Utils/TargetUtils.h"
 #include "llvm/include/llvm/Support/raw_ostream.h"      // from @llvm-project
 #include "mlir/include/mlir/Dialect/Func/IR/FuncOps.h"  // from @llvm-project
 #include "mlir/include/mlir/IR/BuiltinOps.h"            // from @llvm-project

--- a/lib/Target/SimFHE/SimFHETemplates.h
+++ b/lib/Target/SimFHE/SimFHETemplates.h
@@ -1,0 +1,19 @@
+#ifndef LIB_TARGET_SIMFHE_SIMFHETEMPLATES_H_
+#define LIB_TARGET_SIMFHE_SIMFHETEMPLATES_H_
+
+#include <string_view>
+
+namespace mlir {
+namespace heir {
+namespace simfhe {
+
+constexpr std::string_view kModulePrelude = R"python(
+import evaluator
+from perf_counter import PerfCounter
+)python";
+
+}  // namespace simfhe
+}  // namespace heir
+}  // namespace mlir
+
+#endif  // LIB_TARGET_SIMFHE_SIMFHETEMPLATES_H_

--- a/lib/Target/SimFHE/SimFHETemplates.h
+++ b/lib/Target/SimFHE/SimFHETemplates.h
@@ -19,9 +19,8 @@ def run_workload(fn):
     headers = ["params", "total_ops", "mult", "dram_total"]
     rows = []
     for sp in schemes:
-        global arch_params
-        arch_params = sp.arch_param
-        args = [sp.fresh_ctxt] * fn.__code__.co_argcount
+        args = [sp.fresh_ctxt] * (fn.__code__.co_argcount - 1)
+        args.append(sp)
         stats = fn(*args)
         rows.append(
             [

--- a/lib/Target/SimFHE/SimFHETemplates.h
+++ b/lib/Target/SimFHE/SimFHETemplates.h
@@ -11,6 +11,27 @@ constexpr std::string_view kModulePrelude = R"python(
 import params
 import evaluator
 from perf_counter import PerfCounter
+import tabulate
+
+
+def run_workload(fn):
+    schemes = params.get_alg_params()
+    headers = ["params", "total_ops", "mult", "dram_total"]
+    rows = []
+    for sp in schemes:
+        global arch_params
+        arch_params = sp.arch_param
+        args = [sp.fresh_ctxt] * fn.__code__.co_argcount
+        stats = fn(*args)
+        rows.append(
+            [
+                sp,
+                stats.sw.total_ops,
+                stats.sw.mult,
+                stats.arch.dram_total_rdwr_small,
+            ]
+        )
+    print(tabulate.tabulate(rows, headers=headers))
 )python";
 
 }  // namespace simfhe

--- a/lib/Target/SimFHE/SimFHETemplates.h
+++ b/lib/Target/SimFHE/SimFHETemplates.h
@@ -8,6 +8,7 @@ namespace heir {
 namespace simfhe {
 
 constexpr std::string_view kModulePrelude = R"python(
+import params
 import evaluator
 from perf_counter import PerfCounter
 )python";

--- a/tests/Dialect/SimFHE/Emitters/emit_simfhe.mlir
+++ b/tests/Dialect/SimFHE/Emitters/emit_simfhe.mlir
@@ -10,29 +10,29 @@
 
 // CHECK: def test_ops(
 // CHECK: stats = PerfCounter()
-// CHECK: stats += evaluator.negate([[ARG0:[A-Za-z0-9_]+]], arch_params)
-// CHECK-NEXT: [[RES0:[A-Za-z0-9_]+]] = [[ARG0]]
-// CHECK: stats += evaluator.add([[ARG1:[A-Za-z0-9_]+]], arch_params)
-// CHECK-NEXT: [[RES1:[A-Za-z0-9_]+]] = [[ARG1]]
-// CHECK: stats += evaluator.subtract([[ARG2:[A-Za-z0-9_]+]], arch_params)
-// CHECK-NEXT: [[RES2:[A-Za-z0-9_]+]] = [[ARG2]]
-// CHECK: stats += evaluator.multiply([[ARG3:[A-Za-z0-9_]+]], arch_params)
-// CHECK-NEXT: [[RES3:[A-Za-z0-9_]+]] = [[ARG3]]
-// CHECK: stats += evaluator.rotate([[ARG4:[A-Za-z0-9_]+]], arch_params)
-// CHECK-NEXT: [[RES4:[A-Za-z0-9_]+]] = [[ARG4]]
-// CHECK: stats += evaluator.add_plain([[ARG5:[A-Za-z0-9_]+]], arch_params)
-// CHECK-NEXT: [[RES5:[A-Za-z0-9_]+]] = [[ARG5]]
-// CHECK: stats += evaluator.subtract_plain([[ARG6:[A-Za-z0-9_]+]], arch_params)
-// CHECK-NEXT: [[RES6:[A-Za-z0-9_]+]] = [[ARG6]]
-// CHECK: stats += evaluator.multiply_plain([[ARG7:[A-Za-z0-9_]+]], arch_params)
-// CHECK-NEXT: [[RES7:[A-Za-z0-9_]+]] = [[ARG7]]
+// CHECK: stats += evaluator.negate([[ARG0:[A-Za-z0-9_]+]],
+// scheme_params.arch_param) CHECK-NEXT: [[RES0:[A-Za-z0-9_]+]] = [[ARG0]]
+// CHECK: stats += evaluator.add([[ARG1:[A-Za-z0-9_]+]],
+// scheme_params.arch_param) CHECK-NEXT: [[RES1:[A-Za-z0-9_]+]] = [[ARG1]]
+// CHECK: stats += evaluator.subtract([[ARG2:[A-Za-z0-9_]+]],
+// scheme_params.arch_param) CHECK-NEXT: [[RES2:[A-Za-z0-9_]+]] = [[ARG2]]
+// CHECK: stats += evaluator.multiply([[ARG3:[A-Za-z0-9_]+]],
+// scheme_params.arch_param) CHECK-NEXT: [[RES3:[A-Za-z0-9_]+]] = [[ARG3]]
+// CHECK: stats += evaluator.rotate([[ARG4:[A-Za-z0-9_]+]],
+// scheme_params.arch_param) CHECK-NEXT: [[RES4:[A-Za-z0-9_]+]] = [[ARG4]]
+// CHECK: stats += evaluator.add_plain([[ARG5:[A-Za-z0-9_]+]],
+// scheme_params.arch_param) CHECK-NEXT: [[RES5:[A-Za-z0-9_]+]] = [[ARG5]]
+// CHECK: stats += evaluator.subtract_plain([[ARG6:[A-Za-z0-9_]+]],
+// scheme_params.arch_param) CHECK-NEXT: [[RES6:[A-Za-z0-9_]+]] = [[ARG6]]
+// CHECK: stats += evaluator.multiply_plain([[ARG7:[A-Za-z0-9_]+]],
+// scheme_params.arch_param) CHECK-NEXT: [[RES7:[A-Za-z0-9_]+]] = [[ARG7]]
 // CHECK: return stats
 
 // CHECK: def test_relin(
 // CHECK: stats = PerfCounter()
-// CHECK: stats += evaluator.key_switch([[ARG:[A-Za-z0-9_]+]], [[ARG]], arch_params)
-// CHECK-NEXT: [[RES:[A-Za-z0-9_]+]] = [[ARG]]
-// CHECK: return stats
+// CHECK: stats += evaluator.key_switch([[ARG:[A-Za-z0-9_]+]], [[ARG]],
+// scheme_params.arch_param) CHECK-NEXT: [[RES:[A-Za-z0-9_]+]] = [[ARG]] CHECK:
+// return stats
 
 // CHECK: if __name__ == "__main__":
 // CHECK: run_workload(test_ops)

--- a/tests/Dialect/SimFHE/Emitters/emit_simfhe.mlir
+++ b/tests/Dialect/SimFHE/Emitters/emit_simfhe.mlir
@@ -22,7 +22,7 @@
 
 // CHECK: def test_relin(
 // CHECK: stats = PerfCounter()
-// CHECK: stats += evaluator.key_switch(
+// CHECK: stats += evaluator.key_switch({{.*}}, {{.*}}, arch_params)
 // CHECK: return stats
 
 // CHECK: if __name__ == "__main__":

--- a/tests/Dialect/SimFHE/Emitters/emit_simfhe.mlir
+++ b/tests/Dialect/SimFHE/Emitters/emit_simfhe.mlir
@@ -2,7 +2,8 @@
 // %S/../../CKKS/Conversions/ckks_to_openfhe/ckks_to_openfhe.mlir --emit-simfhe
 // | FileCheck %s
 
-// CHECK: import evaluator
+// CHECK: import params
+// CHECK-NEXT: import evaluator
 // CHECK-NEXT: from perf_counter import PerfCounter
 
 // CHECK: def test_ops(

--- a/tests/Dialect/SimFHE/Emitters/emit_simfhe.mlir
+++ b/tests/Dialect/SimFHE/Emitters/emit_simfhe.mlir
@@ -11,18 +11,27 @@
 // CHECK: def test_ops(
 // CHECK: stats = PerfCounter()
 // CHECK: stats += evaluator.negate(
+// CHECK-NEXT: v
 // CHECK: stats += evaluator.add(
+// CHECK-NEXT: v
 // CHECK: stats += evaluator.subtract(
+// CHECK-NEXT: v
 // CHECK: stats += evaluator.multiply(
+// CHECK-NEXT: v
 // CHECK: stats += evaluator.rotate(
+// CHECK-NEXT: v
 // CHECK: stats += evaluator.add_plain(
+// CHECK-NEXT: v
 // CHECK: stats += evaluator.subtract_plain(
+// CHECK-NEXT: v
 // CHECK: stats += evaluator.multiply_plain(
+// CHECK-NEXT: v
 // CHECK: return stats
 
 // CHECK: def test_relin(
 // CHECK: stats = PerfCounter()
 // CHECK: stats += evaluator.key_switch({{.*}}, {{.*}}, arch_params)
+// CHECK-NEXT: v
 // CHECK: return stats
 
 // CHECK: if __name__ == "__main__":

--- a/tests/Dialect/SimFHE/Emitters/emit_simfhe.mlir
+++ b/tests/Dialect/SimFHE/Emitters/emit_simfhe.mlir
@@ -10,28 +10,28 @@
 
 // CHECK: def test_ops(
 // CHECK: stats = PerfCounter()
-// CHECK: stats += evaluator.negate(
-// CHECK-NEXT: v
-// CHECK: stats += evaluator.add(
-// CHECK-NEXT: v
-// CHECK: stats += evaluator.subtract(
-// CHECK-NEXT: v
-// CHECK: stats += evaluator.multiply(
-// CHECK-NEXT: v
-// CHECK: stats += evaluator.rotate(
-// CHECK-NEXT: v
-// CHECK: stats += evaluator.add_plain(
-// CHECK-NEXT: v
-// CHECK: stats += evaluator.subtract_plain(
-// CHECK-NEXT: v
-// CHECK: stats += evaluator.multiply_plain(
-// CHECK-NEXT: v
+// CHECK: stats += evaluator.negate([[ARG0:[A-Za-z0-9_]+]], arch_params)
+// CHECK-NEXT: [[RES0:[A-Za-z0-9_]+]] = [[ARG0]]
+// CHECK: stats += evaluator.add([[ARG1:[A-Za-z0-9_]+]], arch_params)
+// CHECK-NEXT: [[RES1:[A-Za-z0-9_]+]] = [[ARG1]]
+// CHECK: stats += evaluator.subtract([[ARG2:[A-Za-z0-9_]+]], arch_params)
+// CHECK-NEXT: [[RES2:[A-Za-z0-9_]+]] = [[ARG2]]
+// CHECK: stats += evaluator.multiply([[ARG3:[A-Za-z0-9_]+]], arch_params)
+// CHECK-NEXT: [[RES3:[A-Za-z0-9_]+]] = [[ARG3]]
+// CHECK: stats += evaluator.rotate([[ARG4:[A-Za-z0-9_]+]], arch_params)
+// CHECK-NEXT: [[RES4:[A-Za-z0-9_]+]] = [[ARG4]]
+// CHECK: stats += evaluator.add_plain([[ARG5:[A-Za-z0-9_]+]], arch_params)
+// CHECK-NEXT: [[RES5:[A-Za-z0-9_]+]] = [[ARG5]]
+// CHECK: stats += evaluator.subtract_plain([[ARG6:[A-Za-z0-9_]+]], arch_params)
+// CHECK-NEXT: [[RES6:[A-Za-z0-9_]+]] = [[ARG6]]
+// CHECK: stats += evaluator.multiply_plain([[ARG7:[A-Za-z0-9_]+]], arch_params)
+// CHECK-NEXT: [[RES7:[A-Za-z0-9_]+]] = [[ARG7]]
 // CHECK: return stats
 
 // CHECK: def test_relin(
 // CHECK: stats = PerfCounter()
-// CHECK: stats += evaluator.key_switch({{.*}}, {{.*}}, arch_params)
-// CHECK-NEXT: v
+// CHECK: stats += evaluator.key_switch([[ARG:[A-Za-z0-9_]+]], [[ARG]], arch_params)
+// CHECK-NEXT: [[RES:[A-Za-z0-9_]+]] = [[ARG]]
 // CHECK: return stats
 
 // CHECK: if __name__ == "__main__":

--- a/tests/Dialect/SimFHE/Emitters/emit_simfhe.mlir
+++ b/tests/Dialect/SimFHE/Emitters/emit_simfhe.mlir
@@ -5,6 +5,8 @@
 // CHECK: import params
 // CHECK-NEXT: import evaluator
 // CHECK-NEXT: from perf_counter import PerfCounter
+// CHECK-NEXT: import tabulate
+// CHECK: def run_workload(
 
 // CHECK: def test_ops(
 // CHECK: stats = PerfCounter()
@@ -22,3 +24,7 @@
 // CHECK: stats = PerfCounter()
 // CHECK: stats += evaluator.key_switch(
 // CHECK: return stats
+
+// CHECK: if __name__ == "__main__":
+// CHECK: run_workload(test_ops)
+// CHECK: run_workload(test_relin)

--- a/tests/Dialect/SimFHE/Emitters/emit_simfhe.mlir
+++ b/tests/Dialect/SimFHE/Emitters/emit_simfhe.mlir
@@ -1,0 +1,23 @@
+// RUN: heir-translate
+// %S/../../CKKS/Conversions/ckks_to_openfhe/ckks_to_openfhe.mlir --emit-simfhe
+// | FileCheck %s
+
+// CHECK: import evaluator
+// CHECK-NEXT: from perf_counter import PerfCounter
+
+// CHECK: def test_ops(
+// CHECK: stats = PerfCounter()
+// CHECK: stats += evaluator.negate(
+// CHECK: stats += evaluator.add(
+// CHECK: stats += evaluator.subtract(
+// CHECK: stats += evaluator.multiply(
+// CHECK: stats += evaluator.rotate(
+// CHECK: stats += evaluator.add_plain(
+// CHECK: stats += evaluator.subtract_plain(
+// CHECK: stats += evaluator.multiply_plain(
+// CHECK: return stats
+
+// CHECK: def test_relin(
+// CHECK: stats = PerfCounter()
+// CHECK: stats += evaluator.key_switch(
+// CHECK: return stats

--- a/tools/BUILD
+++ b/tools/BUILD
@@ -204,6 +204,7 @@ cc_binary(
         "@heir//lib/Target/Lattigo:LattigoEmitter",
         "@heir//lib/Target/Metadata:MetadataEmitter",
         "@heir//lib/Target/OpenFhePke:OpenFheRegistration",
+        "@heir//lib/Target/SimFHE:SimFHEEmitter",
         "@heir//lib/Target/TfheRust:TfheRustEmitter",
         "@heir//lib/Target/TfheRustBool:TfheRustBoolEmitter",
         "@heir//lib/Target/TfheRustHL:TfheRustHLEmitter",

--- a/tools/heir-translate.cpp
+++ b/tools/heir-translate.cpp
@@ -4,6 +4,7 @@
 #include "lib/Target/Lattigo/LattigoEmitter.h"
 #include "lib/Target/Metadata/MetadataEmitter.h"
 #include "lib/Target/OpenFhePke/OpenFheTranslateRegistration.h"
+#include "lib/Target/SimFHE/SimFHEEmitter.h"
 // This comment includes internal emitters
 #include "lib/Target/TfheRust/TfheRustEmitter.h"
 #include "lib/Target/TfheRustBool/TfheRustBoolEmitter.h"
@@ -25,6 +26,7 @@ int main(int argc, char **argv) {
   // jaxite output
   mlir::heir::jaxite::registerToJaxiteTranslation();
   mlir::heir::jaxiteword::registerToJaxiteWordTranslation();
+  mlir::heir::simfhe::registerToSimFHETranslation();
 
   // OpenFHE
   mlir::heir::openfhe::registerTranslateOptions();


### PR DESCRIPTION
## Summary
- implement `SimFHEEmitter` and templates for generating python in SimFHE style
- register SimFHE translation in `heir-translate`
- hook emitter into build system (Bazel and CMake)

## Testing
- `pre-commit run --files lib/Target/CMakeLists.txt lib/Target/SimFHE/BUILD lib/Target/SimFHE/CMakeLists.txt lib/Target/SimFHE/SimFHEEmitter.cpp lib/Target/SimFHE/SimFHEEmitter.h lib/Target/SimFHE/SimFHETemplates.h tools/BUILD tools/heir-translate.cpp`
- `bazel test //...` *(fails: The current user is root, please run as non-root when using the hermetic Python interpreter)*

------
https://chatgpt.com/codex/tasks/task_e_684b43c3d8508328b01565c3d50517f1