### PR TITLE
Preserve color in compiler errors

### DIFF
--- a/frontend/heir/heir_cli/heir_cli.py
+++ b/frontend/heir/heir_cli/heir_cli.py
@@ -52,12 +52,18 @@ class CLIBackend:
     Returns:
         The stdout of the executed process.
     """
+    env = os.environ | {
+        "CLICOLOR_FORCE": "1",
+        "FORCE_COLOR": "1",
+        "PY_COLORS": "1",
+    }
     completed_process = subprocess.run(
         [os.path.abspath(self.binary_path)] + options,
         input=input,
         text=True,
         capture_output=True,
         check=False,
+        env=env,
     )
     if completed_process.returncode != 0:
       raise CLIError(
@@ -80,12 +86,18 @@ class CLIBackend:
     Returns:
         The stdout and stderr of the executed process.
     """
+    env = os.environ | {
+        "CLICOLOR_FORCE": "1",
+        "FORCE_COLOR": "1",
+        "PY_COLORS": "1",
+    }
     completed_process = subprocess.run(
         [os.path.abspath(self.binary_path)] + options,
         input=input,
         text=True,
         capture_output=True,
         check=False,
+        env=env,
     )
     if completed_process.returncode != 0:
       raise CLIError(

--- a/frontend/heir/interfaces.py
+++ b/frontend/heir/interfaces.py
@@ -127,8 +127,9 @@ class CompilerError(Exception):
     return (
         Fore.RED
         + Style.BRIGHT
-        + f"HEIR Error at {self.location}: {self.message}"
+        + f"HEIR Error at {self.location}: "
         + Style.RESET_ALL
+        + f"{self.message}"
     )
 
 


### PR DESCRIPTION
## Summary
- ensure color and style escape codes are preserved when invoking HEIR CLI tools

## Testing
- `pyink frontend/heir/heir_cli/heir_cli.py`
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'numba')*

------
https://chatgpt.com/codex/tasks/task_e_6851624fbd4c8328b5b9e35a5269fdba