### PR TITLE
Add MLIR string compilation API

### DIFF
--- a/frontend/compile_mlir_test.py
+++ b/frontend/compile_mlir_test.py
@@ -1,0 +1,20 @@
+from heir import compile_mlir
+from heir.backends.cleartext import CleartextBackend
+from absl.testing import absltest
+
+
+class CompileMlirTest(absltest.TestCase):
+
+  def test_compile_mlir(self):
+    mlir = (
+        "func.func @foo(%x: i16 {secret.secret}, %y: i16 {secret.secret}) -> (i16) {\n"
+        "  %0 = arith.addi %x, %y : i16\n"
+        "  func.return %0 : i16\n"
+        "}\n"
+    )
+    client = compile_mlir(mlir, backend=CleartextBackend())
+    self.assertIsNotNone(client)
+
+
+if __name__ == "__main__":
+  absltest.main()

--- a/frontend/heir/__init__.py
+++ b/frontend/heir/__init__.py
@@ -27,6 +27,6 @@ sys.meta_path.insert(0, NumbaBuiltinOverrideFinder())
 
 ## Normal __init__.py stuff below
 
-from .pipeline import compile
+from .pipeline import compile, compile_mlir
 
-__all__ = ["compile"]
+__all__ = ["compile", "compile_mlir"]


### PR DESCRIPTION
## Summary
- extend frontend pipeline with MLIR-based path
- provide `compile_mlir` function
- export new API
- add minimal compile_mlir test

## Testing
- `pytest -q` *(fails: ImportError while importing numba)*

------
https://chatgpt.com/codex/tasks/task_e_6851a9adeeac8328b2295e599e72e221