### PR TITLE
Add openfhe->scheme pass

### DIFF
--- a/lib/Dialect/Openfhe/CMakeLists.txt
+++ b/lib/Dialect/Openfhe/CMakeLists.txt
@@ -1,2 +1,1 @@
-add_subdirectory(IR)
-add_subdirectory(Transforms)
+add_subdirectory(IR) add_subdirectory(Transforms) add_subdirectory(Conversions)

--- a/lib/Dialect/Openfhe/Conversions/BUILD
+++ b/lib/Dialect/Openfhe/Conversions/BUILD
@@ -1,0 +1,6 @@
+package(
+    default_applicable_licenses = ["@heir//:license"],
+    default_visibility = ["//visibility:public"],
+)
+
+exports_files(["BUILD"])

--- a/lib/Dialect/Openfhe/Conversions/CMakeLists.txt
+++ b/lib/Dialect/Openfhe/Conversions/CMakeLists.txt
@@ -1,0 +1,1 @@
+add_subdirectory(OpenfheToScheme)

--- a/lib/Dialect/Openfhe/Conversions/OpenfheToScheme/BUILD
+++ b/lib/Dialect/Openfhe/Conversions/OpenfheToScheme/BUILD
@@ -1,0 +1,31 @@
+load("@heir//lib/Transforms:transforms.bzl", "add_heir_transforms")
+
+package(
+    default_applicable_licenses = ["@heir//:license"],
+    default_visibility = ["//visibility:public"],
+)
+
+cc_library(
+    name = "OpenfheToScheme",
+    srcs = ["OpenfheToScheme.cpp"],
+    hdrs = ["OpenfheToScheme.h"],
+    deps = [
+        ":pass_inc_gen",
+        "@heir//lib/Dialect/Openfhe/IR:Dialect",
+        "@heir//lib/Dialect/BGV/IR:Dialect",
+        "@heir//lib/Dialect/CKKS/IR:Dialect",
+        "@heir//lib/Dialect/LWE/IR:Dialect",
+        "@heir//lib/Dialect:ModuleAttributes",
+        "@heir//lib/Utils/RewriteUtils",
+        "@llvm-project//mlir:IR",
+        "@llvm-project//mlir:Pass",
+        "@llvm-project//mlir:TransformUtils",
+    ],
+    alwayslink = 1,
+)
+
+add_heir_transforms(
+    header_filename = "OpenfheToScheme.h.inc",
+    pass_name = "OpenfheToScheme",
+    td_file = "OpenfheToScheme.td",
+)

--- a/lib/Dialect/Openfhe/Conversions/OpenfheToScheme/CMakeLists.txt
+++ b/lib/Dialect/Openfhe/Conversions/OpenfheToScheme/CMakeLists.txt
@@ -1,0 +1,10 @@
+add_heir_pass(OpenfheToScheme)
+
+    add_mlir_conversion_library(HEIROpenfheToScheme OpenfheToScheme.cpp
+
+                                    DEPENDS HEIROpenfheToSchemeIncGen
+
+                                        LINK_LIBS PUBLIC HEIRRewriteUtils
+                                            HEIRModuleAttributes HEIROpenfhe
+                                                HEIRBGV HEIRCKKS HEIRLWE MLIRIR
+                                                    MLIRPass MLIRTransformUtils)

--- a/lib/Dialect/Openfhe/Conversions/OpenfheToScheme/OpenfheToScheme.cpp
+++ b/lib/Dialect/Openfhe/Conversions/OpenfheToScheme/OpenfheToScheme.cpp
@@ -1,0 +1,200 @@
+#include "lib/Dialect/Openfhe/Conversions/OpenfheToScheme/OpenfheToScheme.h"
+
+#include "lib/Dialect/BGV/IR/BGVDialect.h"
+#include "lib/Dialect/BGV/IR/BGVOps.h"
+#include "lib/Dialect/CKKS/IR/CKKSDialect.h"
+#include "lib/Dialect/CKKS/IR/CKKSOps.h"
+#include "lib/Dialect/LWE/IR/LWEDialect.h"
+#include "lib/Dialect/LWE/IR/LWEOps.h"
+#include "lib/Dialect/ModuleAttributes.h"
+#include "lib/Dialect/Openfhe/IR/OpenfheDialect.h"
+#include "lib/Dialect/Openfhe/IR/OpenfheOps.h"
+#include "lib/Utils/RewriteUtils/RewriteUtils.h"
+#include "mlir/include/mlir/IR/PatternMatch.h"  // from @llvm-project
+#include "mlir/include/mlir/Transforms/WalkPatternRewriteDriver.h"  // from @llvm-project
+
+namespace mlir::heir::openfhe {
+
+#define GEN_PASS_DEF_OPENFHETOSCHEME
+#include "lib/Dialect/Openfhe/Conversions/OpenfheToScheme/OpenfheToScheme.h.inc"
+
+namespace {
+
+template <typename SrcOp, typename DstOp>
+struct ConvertSimpleOp : public OpRewritePattern<SrcOp> {
+  using OpRewritePattern<SrcOp>::OpRewritePattern;
+  LogicalResult matchAndRewrite(SrcOp op,
+                                PatternRewriter &rewriter) const override {
+    SmallVector<Value> operands(op->getOperands().begin() + 1,
+                                op->getOperands().end());
+    rewriter.replaceOpWithNewOp<DstOp>(op, op->getResultTypes(), operands,
+                                       op->getAttrs());
+    return success();
+  }
+};
+
+struct ConvertEncryptOp : public OpRewritePattern<openfhe::EncryptOp> {
+  using OpRewritePattern::OpRewritePattern;
+  LogicalResult matchAndRewrite(openfhe::EncryptOp op,
+                                PatternRewriter &rewriter) const override {
+    rewriter.replaceOpWithNewOp<lwe::RLWEEncryptOp>(
+        op, op.getCiphertext().getType(), op.getPlaintext(),
+        op.getEncryptionKey());
+    return success();
+  }
+};
+
+struct ConvertDecryptOp : public OpRewritePattern<openfhe::DecryptOp> {
+  using OpRewritePattern::OpRewritePattern;
+  LogicalResult matchAndRewrite(openfhe::DecryptOp op,
+                                PatternRewriter &rewriter) const override {
+    rewriter.replaceOpWithNewOp<lwe::RLWEDecryptOp>(
+        op, op.getPlaintext().getType(), op.getCiphertext(),
+        op.getPrivateKey());
+    return success();
+  }
+};
+
+struct ConvertMakePackedPlaintextOp
+    : public OpRewritePattern<openfhe::MakePackedPlaintextOp> {
+  using OpRewritePattern::OpRewritePattern;
+  LogicalResult matchAndRewrite(openfhe::MakePackedPlaintextOp op,
+                                PatternRewriter &rewriter) const override {
+    auto type = op.getPlaintext().getType().cast<lwe::NewLWEPlaintextType>();
+    rewriter.replaceOpWithNewOp<lwe::RLWEEncodeOp>(
+        op, op.getValue(), type.getEncoding(), type.getRing());
+    return success();
+  }
+};
+
+struct ConvertMakeCKKSPackedPlaintextOp
+    : public OpRewritePattern<openfhe::MakeCKKSPackedPlaintextOp> {
+  using OpRewritePattern::OpRewritePattern;
+  LogicalResult matchAndRewrite(openfhe::MakeCKKSPackedPlaintextOp op,
+                                PatternRewriter &rewriter) const override {
+    auto type = op.getPlaintext().getType().cast<lwe::NewLWEPlaintextType>();
+    rewriter.replaceOpWithNewOp<lwe::RLWEEncodeOp>(
+        op, op.getValue(), type.getEncoding(), type.getRing());
+    return success();
+  }
+};
+
+template <typename DstOp>
+struct ConvertRotOp : public OpRewritePattern<openfhe::RotOp> {
+  using OpRewritePattern::OpRewritePattern;
+  LogicalResult matchAndRewrite(openfhe::RotOp op,
+                                PatternRewriter &rewriter) const override {
+    auto indexAttr = op.getIndexAttr();
+    rewriter.replaceOpWithNewOp<DstOp>(op, op.getType(), op.getCiphertext(),
+                                       indexAttr);
+    return success();
+  }
+};
+
+template <typename DstOp>
+struct ConvertRelinOp : public OpRewritePattern<openfhe::RelinOp> {
+  using OpRewritePattern::OpRewritePattern;
+  LogicalResult matchAndRewrite(openfhe::RelinOp op,
+                                PatternRewriter &rewriter) const override {
+    auto ctType =
+        op.getCiphertext().getType().cast<lwe::NewLWECiphertextType>();
+    int dim = ctType.getCiphertextSpace().getSize();
+    SmallVector<int32_t> fromBasis;
+    for (int i = 0; i < dim; ++i) fromBasis.push_back(i);
+    SmallVector<int32_t> toBasis = {0, 1};
+    auto fromAttr = rewriter.getDenseI32ArrayAttr(fromBasis);
+    auto toAttr = rewriter.getDenseI32ArrayAttr(toBasis);
+    rewriter.replaceOpWithNewOp<DstOp>(op, op.getType(), op.getCiphertext(),
+                                       fromAttr, toAttr);
+    return success();
+  }
+};
+
+template <typename DstOp>
+struct ConvertModReduceOp : public OpRewritePattern<openfhe::ModReduceOp> {
+  using OpRewritePattern::OpRewritePattern;
+  LogicalResult matchAndRewrite(openfhe::ModReduceOp op,
+                                PatternRewriter &rewriter) const override {
+    auto toRing = op.getOutput()
+                      .getType()
+                      .cast<lwe::NewLWECiphertextType>()
+                      .getCiphertextSpace()
+                      .getRing();
+    rewriter.replaceOpWithNewOp<DstOp>(op, op.getType(), op.getCiphertext(),
+                                       toRing);
+    return success();
+  }
+};
+
+template <typename DstOp>
+struct ConvertLevelReduceOp : public OpRewritePattern<openfhe::LevelReduceOp> {
+  using OpRewritePattern::OpRewritePattern;
+  LogicalResult matchAndRewrite(openfhe::LevelReduceOp op,
+                                PatternRewriter &rewriter) const override {
+    rewriter.replaceOpWithNewOp<DstOp>(op, op.getType(), op.getCiphertext(),
+                                       op.getLevelToDropAttr());
+    return success();
+  }
+};
+
+struct ConvertBootstrapOp : public OpRewritePattern<openfhe::BootstrapOp> {
+  using OpRewritePattern::OpRewritePattern;
+  LogicalResult matchAndRewrite(openfhe::BootstrapOp op,
+                                PatternRewriter &rewriter) const override {
+    rewriter.replaceOpWithNewOp<ckks::BootstrapOp>(op, op.getType(),
+                                                   op.getCiphertext());
+    return success();
+  }
+};
+
+}  // namespace
+
+void OpenfheToScheme::runOnOperation() {
+  MLIRContext *context = &getContext();
+  auto module = getOperation();
+
+  std::string schemeName = scheme;
+  if (schemeName.empty()) {
+    if (moduleIsCKKS(module))
+      schemeName = "ckks";
+    else if (moduleIsBGV(module) || moduleIsBFV(module))
+      schemeName = "bgv";
+  }
+
+  RewritePatternSet patterns(context);
+
+  // Operations common to all schemes
+  patterns.add<ConvertEncryptOp, ConvertDecryptOp, ConvertMakePackedPlaintextOp,
+               ConvertMakeCKKSPackedPlaintextOp>(context);
+
+  if (schemeName == "ckks") {
+    patterns
+        .add<ConvertSimpleOp<openfhe::AddOp, ckks::AddOp>,
+             ConvertSimpleOp<openfhe::SubOp, ckks::SubOp>,
+             ConvertSimpleOp<openfhe::MulNoRelinOp, ckks::MulOp>,
+             ConvertSimpleOp<openfhe::NegateOp, ckks::NegateOp>,
+             ConvertSimpleOp<openfhe::AddPlainOp, ckks::AddPlainOp>,
+             ConvertSimpleOp<openfhe::SubPlainOp, ckks::SubPlainOp>,
+             ConvertSimpleOp<openfhe::MulPlainOp, ckks::MulPlainOp>,
+             ConvertRotOp<ckks::RotateOp>, ConvertRelinOp<ckks::RelinearizeOp>,
+             ConvertModReduceOp<ckks::RescaleOp>,
+             ConvertLevelReduceOp<ckks::LevelReduceOp>, ConvertBootstrapOp>(
+            context);
+  } else {
+    patterns.add<ConvertSimpleOp<openfhe::AddOp, bgv::AddOp>,
+                 ConvertSimpleOp<openfhe::SubOp, bgv::SubOp>,
+                 ConvertSimpleOp<openfhe::MulNoRelinOp, bgv::MulOp>,
+                 ConvertSimpleOp<openfhe::NegateOp, bgv::NegateOp>,
+                 ConvertSimpleOp<openfhe::AddPlainOp, bgv::AddPlainOp>,
+                 ConvertSimpleOp<openfhe::SubPlainOp, bgv::SubPlainOp>,
+                 ConvertSimpleOp<openfhe::MulPlainOp, bgv::MulPlainOp>,
+                 ConvertRotOp<bgv::RotateColumnsOp>,
+                 ConvertRelinOp<bgv::RelinearizeOp>,
+                 ConvertModReduceOp<bgv::ModulusSwitchOp>,
+                 ConvertLevelReduceOp<bgv::LevelReduceOp>>(context);
+  }
+
+  walkAndApplyPatterns(module, std::move(patterns));
+}
+
+}  // namespace mlir::heir::openfhe

--- a/lib/Dialect/Openfhe/Conversions/OpenfheToScheme/OpenfheToScheme.h
+++ b/lib/Dialect/Openfhe/Conversions/OpenfheToScheme/OpenfheToScheme.h
@@ -1,0 +1,17 @@
+#ifndef LIB_DIALECT_OPENFHE_CONVERSIONS_OPENFHETOSCHEME_OPENFHETOSCHEME_H_
+#define LIB_DIALECT_OPENFHE_CONVERSIONS_OPENFHETOSCHEME_OPENFHETOSCHEME_H_
+
+#include "mlir/include/mlir/Pass/Pass.h"  // from @llvm-project
+
+namespace mlir {
+namespace heir {
+namespace openfhe {
+
+#define GEN_PASS_DECL_OPENFHETOSCHEME
+#include "lib/Dialect/Openfhe/Conversions/OpenfheToScheme/OpenfheToScheme.h.inc"
+
+}  // namespace openfhe
+}  // namespace heir
+}  // namespace mlir
+
+#endif  // LIB_DIALECT_OPENFHE_CONVERSIONS_OPENFHETOSCHEME_OPENFHETOSCHEME_H_

--- a/lib/Dialect/Openfhe/Conversions/OpenfheToScheme/OpenfheToScheme.td
+++ b/lib/Dialect/Openfhe/Conversions/OpenfheToScheme/OpenfheToScheme.td
@@ -1,0 +1,27 @@
+#ifndef LIB_DIALECT_OPENFHE_CONVERSIONS_OPENFHETOSCHEME_OPENFHETOSCHEME_TD_
+#define LIB_DIALECT_OPENFHE_CONVERSIONS_OPENFHETOSCHEME_OPENFHETOSCHEME_TD_
+
+include "mlir/Pass/PassBase.td"
+
+def OpenfheToScheme : Pass<"openfhe-to-scheme"> {
+  let summary = "Convert the OpenFHE dialect to a scheme dialect";
+  let description = [{
+    Reverse the lowering performed by `--scheme-to-openfhe` by converting
+    operations from the `openfhe` dialect back to the target scheme dialect
+    (bgv, bfv or ckks). If the `scheme` option is not provided, the scheme
+    is inferred from the module attributes.
+  }];
+
+  let options = [
+    Option<"scheme", "scheme", "std::string", "", "Target scheme (bgv|bfv|ckks)">
+  ];
+
+  let dependentDialects = [
+    "mlir::heir::openfhe::OpenfheDialect",
+    "mlir::heir::bgv::BGVDialect",
+    "mlir::heir::ckks::CKKSDialect",
+    "mlir::heir::lwe::LWEDialect"
+  ];
+}
+
+#endif // LIB_DIALECT_OPENFHE_CONVERSIONS_OPENFHETOSCHEME_OPENFHETOSCHEME_TD_

--- a/lib/Pipelines/ArithmeticPipelineRegistration.cpp
+++ b/lib/Pipelines/ArithmeticPipelineRegistration.cpp
@@ -10,6 +10,7 @@
 #include "lib/Dialect/LWE/Transforms/AddDebugPort.h"
 #include "lib/Dialect/Lattigo/Transforms/AllocToInplace.h"
 #include "lib/Dialect/Lattigo/Transforms/ConfigureCryptoContext.h"
+#include "lib/Dialect/Openfhe/Conversions/OpenfheToScheme/OpenfheToScheme.h"
 #include "lib/Dialect/Openfhe/Transforms/ConfigureCryptoContext.h"
 #include "lib/Dialect/Openfhe/Transforms/CountAddAndKeySwitch.h"
 #include "lib/Dialect/Secret/Conversions/SecretToBGV/SecretToBGV.h"
@@ -386,6 +387,12 @@ BackendPipelineBuilder toOpenFhePipelineBuilder() {
     configureCryptoContextOptions.entryFunction = options.entryFunction;
     pm.addPass(
         openfhe::createConfigureCryptoContext(configureCryptoContextOptions));
+  };
+}
+
+BackendPipelineBuilder openfheToSchemePipelineBuilder() {
+  return [=](OpPassManager &pm, const BackendOptions &options) {
+    pm.addPass(openfhe::createOpenfheToScheme());
   };
 }
 

--- a/lib/Pipelines/ArithmeticPipelineRegistration.h
+++ b/lib/Pipelines/ArithmeticPipelineRegistration.h
@@ -136,6 +136,8 @@ RLWEPipelineBuilder mlirToRLWEPipelineBuilder(RLWEScheme scheme);
 
 BackendPipelineBuilder toOpenFhePipelineBuilder();
 
+BackendPipelineBuilder openfheToSchemePipelineBuilder();
+
 BackendPipelineBuilder toLattigoPipelineBuilder();
 
 }  // namespace mlir::heir

--- a/tools/heir-opt.cpp
+++ b/tools/heir-opt.cpp
@@ -419,6 +419,11 @@ int main(int argc, char **argv) {
       "Convert code expressed at FHE scheme level to OpenFHE C++ code.",
       toOpenFhePipelineBuilder());
 
+  PassPipelineRegistration<>(
+      "openfhe-to-scheme",
+      "Lift OpenFHE dialect operations back to the target scheme dialect.",
+      openfheToSchemePipelineBuilder());
+
   PassPipelineRegistration<mlir::heir::BackendOptions>(
       "scheme-to-lattigo",
       "Convert code expressed at FHE scheme level to Lattigo Go code.",


### PR DESCRIPTION
## Summary
- add OpenfheToScheme pass to lift OpenFHE ops back to a scheme dialect
- register new pipeline in heir-opt

## Testing
- `bazel test //...` *(fails: error while parsing .d file)*

------
https://chatgpt.com/codex/tasks/task_e_6855810807a88328a96a4247341ac1d2