### PR TITLE
Support New LWE attributes in CGGI checks

### DIFF
--- a/lib/Dialect/CGGI/IR/CGGIOps.cpp
+++ b/lib/Dialect/CGGI/IR/CGGIOps.cpp
@@ -5,6 +5,7 @@
 
 #include "lib/Dialect/LWE/IR/LWEAttributes.h"
 #include "lib/Dialect/LWE/IR/LWETypes.h"
+#include "lib/Utils/ConversionUtils.h"
 #include "mlir/include/mlir/IR/Diagnostics.h"         // from @llvm-project
 #include "mlir/include/mlir/IR/PatternMatch.h"        // from @llvm-project
 #include "mlir/include/mlir/IR/TypeUtilities.h"       // from @llvm-project


### PR DESCRIPTION
## Summary
- allow `widthFromEncodingAttr` to read widths from new attribute types
- update CGGI verifiers to accept `NewLWECiphertextType`

## Testing
- `pre-commit run --files lib/Utils/ConversionUtils.cpp lib/Dialect/CGGI/IR/CGGIOps.cpp`

------
https://chatgpt.com/codex/tasks/task_e_685f3774ecb883288d9dc3da39e30fb4