### PR TITLE
cheddar: add destination-style bufferization support

### DIFF
--- a/lib/Dialect/Cheddar/IR/CheddarOps.td
+++ b/lib/Dialect/Cheddar/IR/CheddarOps.td
@@ -22,21 +22,24 @@ class Cheddar_Op<string mnemonic, list<Trait> traits = []> :
 // as a destination-passing-style (DPS) op on builtin tensors: a scalar payload
 // is a rank-0 `tensor<!cheddar.X>`, the trailing `$output` operand is the
 // destination (init), and the result is tied 1:1 to it. The op is valid both
-// in tensor form (one result, pre-bufferization) and in buffer form (operands
-// are `memref<!cheddar.X>`, zero results, post one-shot-bufferize). The shared
+// in tensor form (one or more results, pre-bufferization) and in buffer form
+// (operands are `memref<!cheddar.X>`, zero results, post one-shot-bufferize).
 // `getDpsInitsMutable` points at the init operand named by `initName` (the
 // `$output` of most ops; `decode` writes `$value`, `mad_unsafe` its
 // `$accumulator` for a true in-place update).
 class Cheddar_DpsOp<string mnemonic, list<Trait> traits = [],
-                    string initName = "Output"> :
+                    string initName = "Output", int initCount = 1,
+                    bit readsInit = 0> :
         Cheddar_Op<mnemonic, traits # [DestinationStyleOpInterface,
             DeclareOpInterfaceMethods<MemoryEffectsOpInterface>]> {
   let extraClassDeclaration = [{
-    // The single init operand as a (length-1) MutableOperandRange.
     ::mlir::MutableOperandRange getDpsInitsMutable() {
       return ::mlir::MutableOperandRange(
-          getOperation(), get}] # initName # [{Mutable().getOperandNumber(), 1);
+          getOperation(), get}] # initName # [{Mutable().getOperandNumber(),
+          }] # !cast<string>(initCount) # [{);
     }
+    static constexpr bool readsDpsInit() { return }] #
+        !if(readsInit, "true", "false") # [{; }
   }];
   // Operand-aware memory effects (linalg-style): only memref operands carry
   // effects, so the tensor form stays value-semantics/side-effect-free (and
@@ -52,16 +55,23 @@ class Cheddar_DpsOp<string mnemonic, list<Trait> traits = [],
       for (::mlir::OpOperand &operand : getOperation()->getOpOperands()) {
         if (!::llvm::isa<::mlir::MemRefType>(operand.get().getType()))
           continue;
-        if (isDpsInit(&operand))
-          effects.emplace_back(::mlir::MemoryEffects::Write::get(), &operand,
-                               ::mlir::SideEffects::DefaultResource::get());
-        else
+        bool isInit = isDpsInit(&operand);
+        if (!isInit || readsDpsInit())
           effects.emplace_back(::mlir::MemoryEffects::Read::get(), &operand,
+                               ::mlir::SideEffects::DefaultResource::get());
+        if (isInit)
+          effects.emplace_back(::mlir::MemoryEffects::Write::get(), &operand,
                                ::mlir::SideEffects::DefaultResource::get());
       }
     }
   }];
 }
+
+class Cheddar_ReadWriteDpsOp<string mnemonic, list<Trait> traits = [],
+                             string initName = "Output",
+                             int initCount = 1> :
+    Cheddar_DpsOp<mnemonic, traits, initName, initCount,
+                  /*readsInit=*/1>;
 
 // Payload operands and results are constrained by their cheddar element type.
 // `*Like` accepts a tensor or memref (valid pre- and post-bufferization);
@@ -80,8 +90,8 @@ def Cheddar_ConstResult : Variadic<RankedTensorOf<[Cheddar_Constant]>>;
 // destination-passing like the payload ops: in tensor form they produce an SSA
 // result (the owning context / user_interface, consumed downstream) and carry a
 // trailing `$output` init operand that is the bufferization destination hint.
-// After one-shot-bufferize + buffer-results-to-out-params the result becomes a
-// `memref<!cheddar.{context,user_interface}>` out-param, which
+// Cheddar bufferization exposes the result as a
+// `memref<!cheddar.{context,user_interface}>` out-param before One-Shot, which
 // `cheddar-emitc-boundary` re-types to the owning C++ smart-pointer references
 // (`std::shared_ptr<Context<word>>&` / `std::unique_ptr<UserInterface<word>>&`),
 // distinguishing them from the borrowed raw-pointer handles the
@@ -161,12 +171,14 @@ def Cheddar_CreateBootContextOp : Cheddar_DpsOp<"create_boot_context"> {
   let results = (outs Cheddar_BootContextResult:$result);
 }
 
-def Cheddar_PrepareBootstrapOp : Cheddar_DpsOp<"prepare_bootstrap", [], "Ui"> {
+def Cheddar_PrepareBootstrapOp : Cheddar_ReadWriteDpsOp<
+    "prepare_bootstrap", [SameVariadicResultSize], "Ctx", 2> {
   let summary = "Run the one-time bootstrap precompute and rotation-key setup";
   let description = [{
     Performs the one-time bootstrapping preparation on a `!cheddar.boot_context`
-    and threads the resulting rotation keys into the UserInterface (DPS on
-    `$ui`). Emits the canonical CHEDDAR sequence:
+    and threads the resulting rotation keys into the UserInterface. Both
+    `$ctx` and `$ui` are read-write DPS destinations. Emits the canonical
+    CHEDDAR sequence:
       ctx->PrepareEvalMod();
       ctx->PrepareEvalSpecialFFT(numSlots);
       EvkRequest req; ctx->AddRequiredRotations(req, numSlots);
@@ -181,7 +193,10 @@ def Cheddar_PrepareBootstrapOp : Cheddar_DpsOp<"prepare_bootstrap", [], "Ui"> {
     Cheddar_UserInterfaceLike:$ui,
     Builtin_IntegerAttr:$numSlots
   );
-  let results = (outs Cheddar_UserInterfaceResult:$result);
+  let results = (outs
+    Cheddar_BootContextResult:$ctxResult,
+    Cheddar_UserInterfaceResult:$uiResult
+  );
 }
 
 def Cheddar_GetEncoderOp : Cheddar_Op<"get_encoder", [Pure]> {
@@ -212,7 +227,8 @@ def Cheddar_GetMultKeyOp : Cheddar_Op<"get_mult_key", [Pure]> {
   let results = (outs Cheddar_EvalKey:$key);
 }
 
-def Cheddar_PrepareRotKeyOp : Cheddar_DpsOp<"prepare_rot_key", [], "Ui"> {
+def Cheddar_PrepareRotKeyOp : Cheddar_ReadWriteDpsOp<
+    "prepare_rot_key", [], "Ui"> {
   let summary = "Generate a rotation key for a given distance";
   let description = [{
     Calls `ui->PrepareRotationKey(distance, maxLevel)` to generate a rotation
@@ -270,15 +286,15 @@ def Cheddar_EncodeOp : Cheddar_DpsOp<"encode", [PlaintextEncodeOpInterface]> {
   let summary = "Encode a message vector into a CHEDDAR plaintext";
   let description = [{
     Calls encoder.Encode(pt, level, scale, message). The message is a vector
-    of complex numbers (or reals). `scale` is the C++ `double` value used by
-    CHEDDAR's Encoder. `$output` is the destination plaintext.
+    of complex numbers (or reals). `logScale` preserves HEIR's logarithmic
+    scale metadata for future use. `$output` is the destination plaintext.
   }];
   let arguments = (ins
     Cheddar_Encoder:$encoder,
     Cheddar_FloatLike:$message,
     Cheddar_PtLike:$output,
     Builtin_IntegerAttr:$level,
-    F64Attr:$scale
+    OptionalAttr<Builtin_IntegerAttr>:$logScale
   );
   let results = (outs Cheddar_PtResult:$result);
 }
@@ -286,17 +302,17 @@ def Cheddar_EncodeOp : Cheddar_DpsOp<"encode", [PlaintextEncodeOpInterface]> {
 def Cheddar_EncodeConstantOp : Cheddar_DpsOp<"encode_constant"> {
   let summary = "Encode a scalar double into a CHEDDAR constant";
   let description = [{
-    Calls encoder.EncodeConstant(constant, level, scale, number).
+    Calls encoder.EncodeConstant(constant, level, encoder.GetScale(level),
+    number).
     The result is in RNS form for efficient ciphertext-scalar ops.
-    `scale` is the C++ `double` value used by CHEDDAR's Encoder. `$output` is
-    the destination constant.
+    CHEDDAR derives the exact RNS scale from the target level. `$output` is the
+    destination constant.
   }];
   let arguments = (ins
     Cheddar_Encoder:$encoder,
     AnyFloat:$value,
     Cheddar_ConstLike:$output,
-    Builtin_IntegerAttr:$level,
-    F64Attr:$scale
+    Builtin_IntegerAttr:$level
   );
   let results = (outs Cheddar_ConstResult:$result);
 }
@@ -354,6 +370,21 @@ class Cheddar_BinaryCtCtOp<string mnemonic, list<Trait> traits = []>
     Cheddar_AnyContext:$ctx,
     Cheddar_CtLike:$lhs,
     Cheddar_CtLike:$rhs,
+    Cheddar_CtLike:$output
+  );
+  let results = (outs Cheddar_CtResult:$result);
+}
+
+def Cheddar_CopyOp : Cheddar_DpsOp<"copy"> {
+  let summary = "Deep-copy a ciphertext";
+  let description = [{
+    Calls context->Copy(res, input). This operation represents a genuine
+    semantic copy, primarily for copies that One-Shot Bufferize cannot remove
+    at function and region boundaries.
+  }];
+  let arguments = (ins
+    Cheddar_AnyContext:$ctx,
+    Cheddar_CtLike:$input,
     Cheddar_CtLike:$output
   );
   let results = (outs Cheddar_CtResult:$result);
@@ -604,7 +635,8 @@ def Cheddar_HConjAddOp : Cheddar_DpsOp<"hconj_add"> {
   let results = (outs Cheddar_CtResult:$result);
 }
 
-def Cheddar_MadUnsafeOp : Cheddar_DpsOp<"mad_unsafe", [], "Accumulator"> {
+def Cheddar_MadUnsafeOp : Cheddar_ReadWriteDpsOp<
+    "mad_unsafe", [], "Accumulator"> {
   let summary = "Fused multiply-accumulate with constant (no rescale)";
   let description = [{
     Computes res += a * constant (in-place accumulation).

--- a/lib/Dialect/Cheddar/Transforms/BUILD
+++ b/lib/Dialect/Cheddar/Transforms/BUILD
@@ -1,0 +1,57 @@
+load("@heir//lib/Transforms:transforms.bzl", "add_heir_transforms")
+load("@rules_cc//cc:cc_library.bzl", "cc_library")
+
+package(
+    default_applicable_licenses = ["@heir//:license"],
+    default_visibility = ["//visibility:public"],
+)
+
+cc_library(
+    name = "Transforms",
+    hdrs = ["Passes.h"],
+    deps = [
+        ":CheddarBufferize",
+        ":pass_inc_gen",
+    ],
+)
+
+cc_library(
+    name = "CheddarBufferize",
+    srcs = ["CheddarBufferize.cpp"],
+    hdrs = ["CheddarBufferize.h"],
+    deps = [
+        ":pass_inc_gen",
+        "@heir//lib/Dialect/Cheddar/IR:Dialect",
+        "@llvm-project//llvm:Support",
+        "@llvm-project//mlir:BufferizationDialect",
+        "@llvm-project//mlir:BufferizationTransforms",
+        "@llvm-project//mlir:FuncDialect",
+        "@llvm-project//mlir:IR",
+        "@llvm-project//mlir:MemRefDialect",
+        "@llvm-project//mlir:Pass",
+        "@llvm-project//mlir:SCFDialect",
+        "@llvm-project//mlir:Support",
+        "@llvm-project//mlir:TensorDialect",
+    ],
+)
+
+cc_library(
+    name = "BufferizableOpInterfaceImpl",
+    srcs = ["BufferizableOpInterfaceImpl.cpp"],
+    hdrs = ["BufferizableOpInterfaceImpl.h"],
+    deps = [
+        "@heir//lib/Dialect/Cheddar/IR:Dialect",
+        "@heir//lib/Dialect/Cheddar/IR:ops_inc_gen",
+        "@llvm-project//mlir:BufferizationDialect",
+        "@llvm-project//mlir:BufferizationInterfaces",
+        "@llvm-project//mlir:DestinationStyleOpInterface",
+        "@llvm-project//mlir:IR",
+        "@llvm-project//mlir:Support",
+    ],
+)
+
+add_heir_transforms(
+    header_filename = "Passes.h.inc",
+    pass_name = "Cheddar",
+    td_file = "Passes.td",
+)

--- a/lib/Dialect/Cheddar/Transforms/BufferizableOpInterfaceImpl.cpp
+++ b/lib/Dialect/Cheddar/Transforms/BufferizableOpInterfaceImpl.cpp
@@ -1,0 +1,138 @@
+#include "lib/Dialect/Cheddar/Transforms/BufferizableOpInterfaceImpl.h"
+
+#include <cassert>
+
+#include "lib/Dialect/Cheddar/IR/CheddarDialect.h"
+#include "lib/Dialect/Cheddar/IR/CheddarOps.h"
+#include "mlir/include/mlir/Dialect/Bufferization/IR/BufferizableOpInterface.h"  // from @llvm-project
+#include "mlir/include/mlir/Dialect/Bufferization/IR/DstBufferizableOpInterfaceImpl.h"  // from @llvm-project
+#include "mlir/include/mlir/IR/Block.h"         // from @llvm-project
+#include "mlir/include/mlir/IR/BuiltinTypes.h"  // from @llvm-project
+#include "mlir/include/mlir/IR/Operation.h"     // from @llvm-project
+#include "mlir/include/mlir/IR/PatternMatch.h"  // from @llvm-project
+#include "mlir/include/mlir/Interfaces/DestinationStyleOpInterface.h"  // from @llvm-project
+#include "mlir/include/mlir/Support/LLVM.h"  // from @llvm-project
+
+using namespace mlir;
+using namespace mlir::heir;
+using namespace mlir::heir::cheddar;
+
+namespace {
+
+// Generic bufferization model for the cheddar destination-passing-style ops.
+// The cheddar payload types are move-only and the C++ API writes into a
+// destination, so every payload-producing op is DPS on builtin tensors: tensor
+// operands (the ciphertext/plaintext/constant payloads and the float
+// message/diagonals buffers) bufferize to memrefs, the op loses its results,
+// and each result is replaced by the buffer of its tied DPS init operand.
+//
+// The stock DPS model supplies the init/result alias relation and write
+// semantics. Cheddar overrides its overly conservative "every init reads"
+// rule: ordinary results fully overwrite their destination, while the small
+// set of genuinely stateful/accumulating ops opt into a read-write init.
+template <typename OpTy>
+struct CheddarDpsModel
+    : public bufferization::DstBufferizableOpInterfaceExternalModel<
+          CheddarDpsModel<OpTy>, OpTy> {
+  bool bufferizesToMemoryRead(Operation* op, OpOperand& opOperand,
+                              const bufferization::AnalysisState& state) const {
+    auto dstOp = cast<DestinationStyleOpInterface>(op);
+    if (!dstOp.isDpsInit(&opOperand)) return true;
+    return OpTy::readsDpsInit();
+  }
+
+  bool isNotConflicting(Operation* op, OpOperand* read, OpOperand* write,
+                        const bufferization::AnalysisState& state) const {
+    auto dstOp = cast<DestinationStyleOpInterface>(op);
+    // Every scale-snu API represented by a Cheddar DPS op accepts an explicitly
+    // identical input and output object. Some kernels operate in place; others
+    // stage their input through an internal temporary before replacing the
+    // output. In either case, reusing the exact SSA value chosen as the DPS
+    // destination is semantically safe.
+    //
+    // Keep this deliberately narrower than an alias-set query: the lowering
+    // must explicitly opt into reuse by passing the same SSA value as an input
+    // and the tied init. We do not approve two different values merely because
+    // One-Shot believes their future buffers may alias.
+    return read->getOwner() == op && write->getOwner() == op &&
+           dstOp.isDpsInit(write) && read->get() == write->get();
+  }
+
+  LogicalResult verifyAnalysis(
+      Operation* op, const bufferization::AnalysisState& state) const {
+    if (!OpTy::readsDpsInit()) return success();
+    auto dstOp = cast<DestinationStyleOpInterface>(op);
+    for (OpOperand& init : op->getOpOperands()) {
+      if (!dstOp.isDpsInit(&init)) continue;
+      if (isa<TensorType>(init.get().getType()) && !state.isInPlace(init))
+        return op->emitOpError(
+            "move-only read-write destination must bufferize in-place");
+    }
+    return success();
+  }
+
+  LogicalResult bufferize(Operation* op, RewriterBase& rewriter,
+                          const bufferization::BufferizationOptions& options,
+                          bufferization::BufferizationState& state) const {
+    // Replace each tensor operand with its buffer; pass non-tensor operands
+    // (context/encoder/ui/eval-key/evk-map) through unchanged.
+    SmallVector<Value> newOperands;
+    newOperands.reserve(op->getNumOperands());
+    for (OpOperand& operand : op->getOpOperands()) {
+      Value v = operand.get();
+      if (isa<TensorType>(v.getType())) {
+        FailureOr<Value> buffer = getBuffer(rewriter, v, options, state);
+        if (failed(buffer)) return failure();
+        newOperands.push_back(*buffer);
+      } else {
+        newOperands.push_back(v);
+      }
+    }
+
+    // Rebuild the op on memrefs: same name/properties/attrs/operand order, no
+    // results (the DPS init buffers carry the values). All operations attached
+    // below are regionless and successorless.
+    rewriter.setInsertionPoint(op);
+    assert(op->getNumRegions() == 0 && op->getNumSuccessors() == 0);
+    rewriter.insert(Operation::create(
+        op->getLoc(), op->getName(), /*resultTypes=*/TypeRange{}, newOperands,
+        op->getAttrDictionary(), op->getPropertiesStorage(),
+        /*successors=*/BlockRange{}, /*numRegions=*/0));
+
+    // Each result is tied to a DPS init; its bufferized value is that init's
+    // buffer (already in newOperands at the init's operand index).
+    auto dstOp = cast<DestinationStyleOpInterface>(op);
+    SmallVector<Value> replacements;
+    replacements.reserve(op->getNumResults());
+    for (OpResult res : op->getResults()) {
+      OpOperand* init = dstOp.getTiedOpOperand(res);
+      replacements.push_back(newOperands[init->getOperandNumber()]);
+    }
+    bufferization::replaceOpWithBufferizedValues(rewriter, op, replacements);
+    return success();
+  }
+};
+
+template <typename OpTy>
+void attachIfDps(MLIRContext* ctx) {
+  if constexpr (OpTy::template hasTrait<DestinationStyleOpInterface::Trait>()) {
+    OpTy::template attachInterface<CheddarDpsModel<OpTy>>(*ctx);
+  }
+}
+
+template <typename... OpTys>
+void attachAllDpsOps(MLIRContext* ctx) {
+  (attachIfDps<OpTys>(ctx), ...);
+}
+
+}  // namespace
+
+void mlir::heir::cheddar::registerBufferizableOpInterfaceExternalModels(
+    DialectRegistry& registry) {
+  registry.addExtension(+[](MLIRContext* ctx, CheddarDialect* dialect) {
+    attachAllDpsOps<
+#define GET_OP_LIST
+#include "lib/Dialect/Cheddar/IR/CheddarOps.cpp.inc"
+        >(ctx);
+  });
+}

--- a/lib/Dialect/Cheddar/Transforms/BufferizableOpInterfaceImpl.h
+++ b/lib/Dialect/Cheddar/Transforms/BufferizableOpInterfaceImpl.h
@@ -1,0 +1,16 @@
+#ifndef LIB_DIALECT_CHEDDAR_TRANSFORMS_BUFFERIZABLEOPINTERFACEIMPL_H_
+#define LIB_DIALECT_CHEDDAR_TRANSFORMS_BUFFERIZABLEOPINTERFACEIMPL_H_
+
+#include "mlir/include/mlir/IR/DialectRegistry.h"  // from @llvm-project
+
+namespace mlir {
+namespace heir {
+namespace cheddar {
+
+void registerBufferizableOpInterfaceExternalModels(DialectRegistry& registry);
+
+}  // namespace cheddar
+}  // namespace heir
+}  // namespace mlir
+
+#endif  // LIB_DIALECT_CHEDDAR_TRANSFORMS_BUFFERIZABLEOPINTERFACEIMPL_H_

--- a/lib/Dialect/Cheddar/Transforms/CheddarBufferize.cpp
+++ b/lib/Dialect/Cheddar/Transforms/CheddarBufferize.cpp
@@ -1,0 +1,386 @@
+#include "lib/Dialect/Cheddar/Transforms/CheddarBufferize.h"
+
+#include <optional>
+#include <utility>
+
+#include "lib/Dialect/Cheddar/IR/CheddarDialect.h"
+#include "lib/Dialect/Cheddar/IR/CheddarOps.h"
+#include "lib/Dialect/Cheddar/IR/CheddarTypes.h"
+#include "llvm/include/llvm/ADT/BitVector.h"  // from @llvm-project
+#include "llvm/include/llvm/ADT/DenseMap.h"   // from @llvm-project
+#include "llvm/include/llvm/ADT/STLExtras.h"  // from @llvm-project
+#include "mlir/include/mlir/Dialect/Bufferization/IR/Bufferization.h"  // from @llvm-project
+#include "mlir/include/mlir/Dialect/Bufferization/Transforms/OneShotAnalysis.h"  // from @llvm-project
+#include "mlir/include/mlir/Dialect/Bufferization/Transforms/OneShotModuleBufferize.h"  // from @llvm-project
+#include "mlir/include/mlir/Dialect/Bufferization/Transforms/Transforms.h"  // from @llvm-project
+#include "mlir/include/mlir/Dialect/Func/IR/FuncOps.h"   // from @llvm-project
+#include "mlir/include/mlir/Dialect/MemRef/IR/MemRef.h"  // from @llvm-project
+#include "mlir/include/mlir/Dialect/SCF/IR/SCF.h"        // from @llvm-project
+#include "mlir/include/mlir/Dialect/Tensor/IR/Tensor.h"  // from @llvm-project
+#include "mlir/include/mlir/IR/Diagnostics.h"            // from @llvm-project
+#include "mlir/include/mlir/IR/PatternMatch.h"           // from @llvm-project
+#include "mlir/include/mlir/Support/LLVM.h"              // from @llvm-project
+
+namespace mlir {
+namespace heir {
+namespace cheddar {
+
+#define GEN_PASS_DEF_CHEDDARBUFFERIZE
+#include "lib/Dialect/Cheddar/Transforms/Passes.h.inc"
+
+namespace {
+
+bool isCheddarResultTensor(Type type) {
+  auto tensorType = dyn_cast<RankedTensorType>(type);
+  return tensorType &&
+         tensorType.getElementType().getDialect().getNamespace() ==
+             CheddarDialect::getDialectNamespace();
+}
+
+// Materialize packed Cheddar results element-by-element. A tensor.insert_slice
+// has value-copy semantics and therefore always asks One-Shot Bufferize for a
+// memcpy. At a function return the destination buffer is already explicit, so
+// decompose the packing chain into materializations of the inserted values
+// directly into rank-reduced subviews of that buffer. This preserves the
+// source tensor semantics while exposing the actual destination before
+// analysis.
+LogicalResult materializeResultInDestination(
+    OpBuilder& builder, Value value, Value destination,
+    SmallVectorImpl<Operation*>& deadPackingOps) {
+  auto insert = value.getDefiningOp<tensor::InsertSliceOp>();
+  if (insert && isCheddarResultTensor(insert.getSource().getType()) &&
+      insert.getResult().hasOneUse()) {
+    if (failed(materializeResultInDestination(builder, insert.getDest(),
+                                              destination, deadPackingOps)))
+      return failure();
+
+    auto destinationType = cast<MemRefType>(destination.getType());
+    auto sourceType = insert.getSourceType();
+    auto subviewType = memref::SubViewOp::inferRankReducedResultType(
+        sourceType.getShape(), destinationType, insert.getMixedOffsets(),
+        insert.getMixedSizes(), insert.getMixedStrides());
+    Value subview = memref::SubViewOp::create(
+                        builder, insert.getLoc(), subviewType, destination,
+                        insert.getMixedOffsets(), insert.getMixedSizes(),
+                        insert.getMixedStrides())
+                        .getResult();
+    if (failed(materializeResultInDestination(builder, insert.getSource(),
+                                              subview, deadPackingOps)))
+      return failure();
+    deadPackingOps.push_back(insert);
+    return success();
+  }
+
+  // A loop-carried tensor result can use the caller-provided buffer directly.
+  // Materialize the loop's initial value in that buffer, expose it as a
+  // writable tensor, and make it the corresponding iter_arg. Subset insertion
+  // inside the loop can then extract its DPS destination from the iter_arg;
+  // stock One-Shot Bufferize keeps the loop result equivalent to the caller's
+  // buffer without an aggregate copy.
+  if (auto result = dyn_cast<OpResult>(value)) {
+    if (auto forOp = dyn_cast<scf::ForOp>(result.getOwner())) {
+      unsigned resultNumber = result.getResultNumber();
+      if (resultNumber >= forOp.getInitArgs().size())
+        return forOp.emitOpError("result has no corresponding init argument");
+
+      OpBuilder::InsertionGuard guard(builder);
+      builder.setInsertionPoint(forOp);
+      Value init = forOp.getInitArgs()[resultNumber];
+      if (failed(materializeResultInDestination(builder, init, destination,
+                                                deadPackingOps)))
+        return failure();
+      auto tensor = bufferization::ToTensorOp::create(
+          builder, forOp.getLoc(), cast<RankedTensorType>(result.getType()),
+          destination, builder.getUnitAttr(), builder.getUnitAttr());
+      forOp.getInitArgsMutable()[resultNumber].set(tensor.getResult());
+      return success();
+    }
+  }
+
+  if (auto empty = value.getDefiningOp<tensor::EmptyOp>()) {
+    if (empty.getResult().hasOneUse()) deadPackingOps.push_back(empty);
+    return success();
+  }
+
+  bufferization::MaterializeInDestinationOp::create(
+      builder, value.getLoc(), TypeRange{}, value, destination,
+      builder.getUnitAttr(), builder.getUnitAttr());
+  return success();
+}
+
+std::optional<unsigned> findTiedFunctionArgument(func::FuncOp function,
+                                                 Value value) {
+  while (true) {
+    for (auto [index, argument] : llvm::enumerate(function.getArguments())) {
+      if (value == argument) return index;
+    }
+    auto result = dyn_cast<OpResult>(value);
+    if (!result) return std::nullopt;
+    auto dpsOp = dyn_cast<DestinationStyleOpInterface>(result.getOwner());
+    if (!dpsOp) return std::nullopt;
+    OpOperand* tiedInit = dpsOp.getTiedOpOperand(result);
+    if (!tiedInit) return std::nullopt;
+    value = tiedInit->get();
+  }
+}
+
+std::optional<unsigned> getEquivalentArgumentForResult(func::FuncOp function,
+                                                       unsigned resultIndex) {
+  std::optional<unsigned> equivalentArgument;
+  bool sawReturn = false;
+  WalkResult walkResult = function.walk([&](func::ReturnOp returnOp) {
+    sawReturn = true;
+    if (resultIndex >= returnOp.getNumOperands())
+      return WalkResult::interrupt();
+    std::optional<unsigned> argument =
+        findTiedFunctionArgument(function, returnOp.getOperand(resultIndex));
+    if (!argument || (equivalentArgument && equivalentArgument != argument))
+      return WalkResult::interrupt();
+    equivalentArgument = argument;
+    return WalkResult::advance();
+  });
+  if (!sawReturn || walkResult.wasInterrupted()) return std::nullopt;
+  return equivalentArgument;
+}
+
+// Make caller-provided tensor result storage visible while the program still
+// has tensor semantics. One-Shot can then propagate each destination backward
+// through DPS and subset-insertion chains instead of returning a memref (and,
+// after EmitC conversion, an unsupported C++ array value).
+LogicalResult materializeTensorResultsInDestinations(ModuleOp module) {
+  struct FunctionConversion {
+    func::FuncOp function;
+    SmallVector<unsigned> resultIndices;
+    SmallVector<RankedTensorType> resultTypes;
+    SmallVector<int64_t> equivalentArgumentByResult;
+  };
+
+  SmallVector<FunctionConversion> conversions;
+  DenseMap<StringAttr, unsigned> conversionByName;
+  module.walk([&](func::FuncOp function) {
+    if (function.isExternal()) return;
+    FunctionConversion conversion{
+        function,
+        {},
+        {},
+        SmallVector<int64_t>(function.getNumResults(), /*Value=*/-1)};
+    for (auto [index, type] : llvm::enumerate(function.getResultTypes())) {
+      if (!isa<RankedTensorType>(type)) continue;
+      if (std::optional<unsigned> argument =
+              getEquivalentArgumentForResult(function, index)) {
+        conversion.equivalentArgumentByResult[index] = *argument;
+        continue;
+      }
+      conversion.resultIndices.push_back(index);
+      conversion.resultTypes.push_back(cast<RankedTensorType>(type));
+    }
+    bool hasEquivalentResult =
+        llvm::any_of(conversion.equivalentArgumentByResult,
+                     [](int64_t argument) { return argument >= 0; });
+    if (conversion.resultIndices.empty() && !hasEquivalentResult) return;
+    conversionByName[function.getSymNameAttr()] = conversions.size();
+    conversions.push_back(std::move(conversion));
+  });
+
+  for (FunctionConversion& conversion : conversions) {
+    func::FuncOp function = conversion.function;
+    SmallVector<BlockArgument> outArgs;
+    outArgs.reserve(conversion.resultIndices.size());
+    for (auto [resultIndex, tensorType] :
+         llvm::zip(conversion.resultIndices, conversion.resultTypes)) {
+      NamedAttrList attrs(function.getResultAttrDict(resultIndex));
+      attrs.set("bufferize.result", UnitAttr::get(module.getContext()));
+      auto memrefType =
+          MemRefType::get(tensorType.getShape(), tensorType.getElementType());
+      if (failed(function.insertArgument(
+              function.getNumArguments(), memrefType,
+              attrs.getDictionary(function.getContext()), function.getLoc())))
+        return function.emitOpError("failed to append result destination");
+      outArgs.push_back(function.getArguments().back());
+    }
+
+    SmallVector<func::ReturnOp> returns;
+    function.walk(
+        [&](func::ReturnOp returnOp) { returns.push_back(returnOp); });
+    for (func::ReturnOp returnOp : returns) {
+      if (returnOp.getNumOperands() != function.getNumResults())
+        return returnOp.emitOpError(
+            "return operand count does not match function results");
+      OpBuilder builder(returnOp);
+      SmallVector<Value> keptOperands;
+      SmallVector<Operation*> deadPackingOps;
+      unsigned convertedIndex = 0;
+      for (auto [resultIndex, value] :
+           llvm::enumerate(returnOp.getOperands())) {
+        if (conversion.equivalentArgumentByResult[resultIndex] >= 0) continue;
+        if (convertedIndex < conversion.resultIndices.size() &&
+            conversion.resultIndices[convertedIndex] == resultIndex) {
+          if (failed(materializeResultInDestination(
+                  builder, value, outArgs[convertedIndex], deadPackingOps)))
+            return failure();
+          ++convertedIndex;
+        } else {
+          keptOperands.push_back(value);
+        }
+      }
+      returnOp.getOperandsMutable().assign(keptOperands);
+      for (Operation* op : llvm::reverse(deadPackingOps)) {
+        if (op->use_empty()) op->erase();
+      }
+    }
+
+    BitVector resultsToErase(function.getNumResults());
+    for (unsigned index : conversion.resultIndices) resultsToErase.set(index);
+    for (auto [index, argument] :
+         llvm::enumerate(conversion.equivalentArgumentByResult))
+      if (argument >= 0) resultsToErase.set(index);
+    if (failed(function.eraseResults(resultsToErase)))
+      return function.emitOpError("failed to erase materialized results");
+  }
+
+  SmallVector<func::CallOp> calls;
+  module.walk([&](func::CallOp call) {
+    if (conversionByName.contains(
+            StringAttr::get(module.getContext(), call.getCallee())))
+      calls.push_back(call);
+  });
+
+  for (func::CallOp call : calls) {
+    StringAttr calleeName =
+        StringAttr::get(module.getContext(), call.getCallee());
+    FunctionConversion& conversion =
+        conversions[conversionByName.lookup(calleeName)];
+    OpBuilder builder(call);
+    SmallVector<Value> newOperands(call.getOperands());
+    SmallVector<Type> keptResultTypes;
+    SmallVector<std::pair<Value, bufferization::MaterializeInDestinationOp>>
+        destinations;
+    destinations.reserve(conversion.resultIndices.size());
+
+    unsigned convertedIndex = 0;
+    for (auto [resultIndex, result] : llvm::enumerate(call.getResults())) {
+      if (conversion.equivalentArgumentByResult[resultIndex] >= 0) continue;
+      if (convertedIndex >= conversion.resultIndices.size() ||
+          conversion.resultIndices[convertedIndex] != resultIndex) {
+        keptResultTypes.push_back(result.getType());
+        continue;
+      }
+
+      bufferization::MaterializeInDestinationOp forwarding;
+      Value destination;
+      if (result.hasOneUse()) {
+        forwarding = dyn_cast<bufferization::MaterializeInDestinationOp>(
+            *result.getUsers().begin());
+        if (forwarding && forwarding.getSource() == result) {
+          destination = forwarding.getDest();
+          if (auto toTensor =
+                  destination.getDefiningOp<bufferization::ToTensorOp>())
+            destination = toTensor.getBuffer();
+          if (!isa<MemRefType>(destination.getType())) forwarding = nullptr;
+        } else {
+          forwarding = nullptr;
+        }
+      }
+      if (forwarding) {
+        // `destination` was recovered from the materialization above. In the
+        // usual function-result path it is the buffer wrapped by to_tensor.
+      } else {
+        RankedTensorType tensorType = conversion.resultTypes[convertedIndex];
+        if (!tensorType.hasStaticShape())
+          return call.emitOpError(
+              "dynamic Cheddar result destinations are not yet supported");
+        auto memrefType =
+            MemRefType::get(tensorType.getShape(), tensorType.getElementType());
+        destination =
+            memref::AllocOp::create(builder, call.getLoc(), memrefType)
+                .getResult();
+      }
+      newOperands.push_back(destination);
+      destinations.push_back({destination, forwarding});
+      ++convertedIndex;
+    }
+
+    auto newCall = func::CallOp::create(
+        builder, call.getLoc(), call.getCallee(), keptResultTypes, newOperands);
+    newCall->setAttrs(call->getAttrDictionary());
+
+    builder.setInsertionPointAfter(newCall);
+    convertedIndex = 0;
+    unsigned keptIndex = 0;
+    for (auto [resultIndex, result] : llvm::enumerate(call.getResults())) {
+      int64_t equivalentArgument =
+          conversion.equivalentArgumentByResult[resultIndex];
+      if (equivalentArgument >= 0) {
+        result.replaceAllUsesWith(call.getOperand(equivalentArgument));
+        continue;
+      }
+      if (convertedIndex < conversion.resultIndices.size() &&
+          conversion.resultIndices[convertedIndex] == resultIndex) {
+        auto [destination, forwarding] = destinations[convertedIndex];
+        if (forwarding) {
+          forwarding.erase();
+        } else {
+          auto tensor = bufferization::ToTensorOp::create(
+              builder, call.getLoc(), conversion.resultTypes[convertedIndex],
+              destination, builder.getUnitAttr(), builder.getUnitAttr());
+          result.replaceAllUsesWith(tensor.getResult());
+        }
+        ++convertedIndex;
+      } else {
+        result.replaceAllUsesWith(newCall.getResult(keptIndex++));
+      }
+    }
+    call.erase();
+  }
+
+  return success();
+}
+
+struct CheddarBufferize : public impl::CheddarBufferizeBase<CheddarBufferize> {
+  using Base::Base;
+
+  void getDependentDialects(DialectRegistry& registry) const override {
+    registry
+        .insert<bufferization::BufferizationDialect, memref::MemRefDialect>();
+  }
+
+  void runOnOperation() override {
+    ModuleOp module = getOperation();
+    if (failed(materializeTensorResultsInDestinations(module))) {
+      signalPassFailure();
+      return;
+    }
+
+    IRRewriter rewriter(&getContext());
+    if (failed(bufferization::eliminateEmptyTensors(rewriter, module))) {
+      signalPassFailure();
+      return;
+    }
+
+    bufferization::OneShotBufferizationOptions options;
+    options.allowReturnAllocsFromLoops = true;
+    options.bufferizeFunctionBoundaries = true;
+    options.setFunctionBoundaryTypeConversion(
+        bufferization::LayoutMapOption::IdentityLayoutMap);
+    options.memCpyFn = [](OpBuilder& builder, Location loc, Value source,
+                          Value target) -> LogicalResult {
+      if (source == target) return success();
+      auto sourceType = dyn_cast<BaseMemRefType>(source.getType());
+      if (sourceType && isa<UserInterfaceType>(sourceType.getElementType()))
+        return emitError(loc)
+               << "bufferization cannot copy a Cheddar user interface";
+      memref::CopyOp::create(builder, loc, source, target);
+      return success();
+    };
+    bufferization::BufferizationState state;
+    if (failed(
+            bufferization::runOneShotModuleBufferize(module, options, state))) {
+      signalPassFailure();
+    }
+  }
+};
+
+}  // namespace
+}  // namespace cheddar
+}  // namespace heir
+}  // namespace mlir

--- a/lib/Dialect/Cheddar/Transforms/CheddarBufferize.h
+++ b/lib/Dialect/Cheddar/Transforms/CheddarBufferize.h
@@ -1,0 +1,17 @@
+#ifndef LIB_DIALECT_CHEDDAR_TRANSFORMS_CHEDDARBUFFERIZE_H_
+#define LIB_DIALECT_CHEDDAR_TRANSFORMS_CHEDDARBUFFERIZE_H_
+
+#include "mlir/include/mlir/Pass/Pass.h"  // from @llvm-project
+
+namespace mlir {
+namespace heir {
+namespace cheddar {
+
+#define GEN_PASS_DECL_CHEDDARBUFFERIZE
+#include "lib/Dialect/Cheddar/Transforms/Passes.h.inc"
+
+}  // namespace cheddar
+}  // namespace heir
+}  // namespace mlir
+
+#endif  // LIB_DIALECT_CHEDDAR_TRANSFORMS_CHEDDARBUFFERIZE_H_

--- a/lib/Dialect/Cheddar/Transforms/Passes.h
+++ b/lib/Dialect/Cheddar/Transforms/Passes.h
@@ -1,0 +1,19 @@
+#ifndef LIB_DIALECT_CHEDDAR_TRANSFORMS_PASSES_H_
+#define LIB_DIALECT_CHEDDAR_TRANSFORMS_PASSES_H_
+
+// IWYU pragma: begin_keep
+#include "lib/Dialect/Cheddar/Transforms/CheddarBufferize.h"
+// IWYU pragma: end_keep
+
+namespace mlir {
+namespace heir {
+namespace cheddar {
+
+#define GEN_PASS_REGISTRATION
+#include "lib/Dialect/Cheddar/Transforms/Passes.h.inc"
+
+}  // namespace cheddar
+}  // namespace heir
+}  // namespace mlir
+
+#endif  // LIB_DIALECT_CHEDDAR_TRANSFORMS_PASSES_H_

--- a/lib/Dialect/Cheddar/Transforms/Passes.td
+++ b/lib/Dialect/Cheddar/Transforms/Passes.td
@@ -1,0 +1,19 @@
+#ifndef LIB_DIALECT_CHEDDAR_TRANSFORMS_PASSES_TD_
+#define LIB_DIALECT_CHEDDAR_TRANSFORMS_PASSES_TD_
+
+include "mlir/Pass/PassBase.td"
+
+def CheddarBufferize : Pass<"cheddar-bufferize", "ModuleOp"> {
+  let summary = "Run One-Shot Bufferize for Cheddar programs";
+  let description = [{
+    Converts Cheddar tensor function results to caller-provided destinations
+    before bufferization, runs the standard empty-tensor elimination, then runs
+    stock One-Shot Module Bufferization with function-boundary bufferization
+    and identity layout maps. This exposes the final destination early enough
+    for DPS producers to write into it directly. The bufferization memcpy hook
+    rejects every remaining copy of a move-only Cheddar value, regardless of
+    which participating dialect requested it.
+  }];
+}
+
+#endif  // LIB_DIALECT_CHEDDAR_TRANSFORMS_PASSES_TD_

--- a/tests/Dialect/Cheddar/IR/roundtrip.mlir
+++ b/tests/Dialect/Cheddar/IR/roundtrip.mlir
@@ -67,8 +67,7 @@ func.func @test_encode(
     %out: tensor<!cheddar.plaintext>) -> tensor<!cheddar.plaintext> {
   // CHECK: cheddar.encode
   // CHECK-SAME: level = 5
-  // CHECK-SAME: scale = 0x42C0000000000000
-  %pt = cheddar.encode %enc, %msg, %out {level = 5 : i64, scale = 35184372088832.0 : f64} : (!cheddar.encoder, tensor<4xf64>, tensor<!cheddar.plaintext>) -> tensor<!cheddar.plaintext>
+  %pt = cheddar.encode %enc, %msg, %out {level = 5 : i64, logScale = 37 : i64} : (!cheddar.encoder, tensor<4xf64>, tensor<!cheddar.plaintext>) -> tensor<!cheddar.plaintext>
   return %pt : tensor<!cheddar.plaintext>
 }
 
@@ -79,8 +78,7 @@ func.func @test_encode_constant(
     %out: tensor<!cheddar.constant>) -> tensor<!cheddar.constant> {
   // CHECK: cheddar.encode_constant
   // CHECK-SAME: level = 3
-  // CHECK-SAME: scale = 0x42C0000000000000
-  %c = cheddar.encode_constant %enc, %val, %out {level = 3 : i64, scale = 35184372088832.0 : f64} : (!cheddar.encoder, f64, tensor<!cheddar.constant>) -> tensor<!cheddar.constant>
+  %c = cheddar.encode_constant %enc, %val, %out {level = 3 : i64} : (!cheddar.encoder, f64, tensor<!cheddar.constant>) -> tensor<!cheddar.constant>
   return %c : tensor<!cheddar.constant>
 }
 
@@ -115,6 +113,16 @@ func.func @test_decrypt(
 }
 
 // --- Binary ct-ct operations ---
+
+// CHECK: @test_copy
+func.func @test_copy(
+    %ctx: !cheddar.context,
+    %input: tensor<!cheddar.ciphertext>,
+    %out: tensor<!cheddar.ciphertext>) -> tensor<!cheddar.ciphertext> {
+  // CHECK: cheddar.copy
+  %result = cheddar.copy %ctx, %input, %out : (!cheddar.context, tensor<!cheddar.ciphertext>, tensor<!cheddar.ciphertext>) -> tensor<!cheddar.ciphertext>
+  return %result : tensor<!cheddar.ciphertext>
+}
 
 // CHECK: @test_add
 func.func @test_add(

--- a/tests/Dialect/Cheddar/Transforms/BUILD
+++ b/tests/Dialect/Cheddar/Transforms/BUILD
@@ -1,0 +1,10 @@
+load("//bazel:lit.bzl", "glob_lit_tests")
+
+package(default_applicable_licenses = ["@heir//:license"])
+
+glob_lit_tests(
+    name = "all_tests",
+    data = ["@heir//tests:test_utilities"],
+    driver = "@heir//tests:run_lit.sh",
+    test_file_exts = ["mlir"],
+)

--- a/tests/Dialect/Cheddar/Transforms/bufferize.mlir
+++ b/tests/Dialect/Cheddar/Transforms/bufferize.mlir
@@ -1,0 +1,131 @@
+// RUN: heir-opt --cheddar-bufferize --fold-memref-alias-ops %s | FileCheck %s
+
+// The generic Cheddar DPS model must turn tensor payloads into buffers, erase
+// the tied SSA result, and replace uses with the destination buffer. Cover both
+// the usual trailing destination and the ops whose in-place destination is in a
+// nonstandard operand position.
+
+// CHECK: func.func @add
+// CHECK: cheddar.add {{.*}} : (!context, memref<!ciphertext>, memref<!ciphertext>, memref<!ciphertext>) -> ()
+// CHECK: return
+func.func @add(%ctx: !cheddar.context, %lhs: tensor<!cheddar.ciphertext>, %rhs: tensor<!cheddar.ciphertext>, %out: tensor<!cheddar.ciphertext>) -> tensor<!cheddar.ciphertext> {
+  %result = cheddar.add %ctx, %lhs, %rhs, %out : (!cheddar.context, tensor<!cheddar.ciphertext>, tensor<!cheddar.ciphertext>, tensor<!cheddar.ciphertext>) -> tensor<!cheddar.ciphertext>
+  return %result : tensor<!cheddar.ciphertext>
+}
+
+// CHECK: func.func @mad_unsafe
+// CHECK: cheddar.mad_unsafe {{.*}} : (!context, memref<!ciphertext>, memref<!ciphertext>, memref<!constant>) -> ()
+// CHECK: return
+func.func @mad_unsafe(%ctx: !cheddar.context, %acc: tensor<!cheddar.ciphertext>, %input: tensor<!cheddar.ciphertext>, %constant: tensor<!cheddar.constant>) -> tensor<!cheddar.ciphertext> {
+  %result = cheddar.mad_unsafe %ctx, %acc, %input, %constant : (!cheddar.context, tensor<!cheddar.ciphertext>, tensor<!cheddar.ciphertext>, tensor<!cheddar.constant>) -> tensor<!cheddar.ciphertext>
+  return %result : tensor<!cheddar.ciphertext>
+}
+
+// CHECK: func.func @prepare_rot_key
+// CHECK: cheddar.prepare_rot_key %{{.*}} {distance = 7 : i64, maxLevel = 13 : i64} : (memref<!user_interface>) -> ()
+// CHECK: return
+func.func @prepare_rot_key(%ui: tensor<!cheddar.user_interface>) -> tensor<!cheddar.user_interface> {
+  %result = cheddar.prepare_rot_key %ui {distance = 7 : i64, maxLevel = 13 : i64} : (tensor<!cheddar.user_interface>) -> tensor<!cheddar.user_interface>
+  return %result : tensor<!cheddar.user_interface>
+}
+
+// Both objects mutated by bootstrap setup are DPS destinations/results.
+// CHECK: func.func @prepare_bootstrap
+// CHECK: cheddar.prepare_bootstrap %{{.*}}, %{{.*}} {numSlots = 8 : i64} : (memref<!boot_context>, memref<!user_interface>) -> ()
+// CHECK: return
+func.func @prepare_bootstrap(%ctx: tensor<!cheddar.boot_context>, %ui: tensor<!cheddar.user_interface>) -> (tensor<!cheddar.boot_context>, tensor<!cheddar.user_interface>) {
+  %new_ctx, %new_ui = cheddar.prepare_bootstrap %ctx, %ui {numSlots = 8 : i64} : (tensor<!cheddar.boot_context>, tensor<!cheddar.user_interface>) -> (tensor<!cheddar.boot_context>, tensor<!cheddar.user_interface>)
+  return %new_ctx, %new_ui : tensor<!cheddar.boot_context>, tensor<!cheddar.user_interface>
+}
+
+// CHECK: func.func @decode
+// CHECK-SAME: %[[DECODED:[a-zA-Z0-9_]+]]: memref<4xf64>
+// CHECK: cheddar.decode %{{.*}}, %{{.*}}, %[[DECODED]] : (!encoder, memref<!plaintext>, memref<4xf64>) -> ()
+// CHECK: return{{$}}
+func.func @decode(%encoder: !cheddar.encoder, %plaintext: tensor<!cheddar.plaintext>, %value: tensor<4xf64>) -> tensor<4xf64> {
+  %decoded = cheddar.decode %encoder, %plaintext, %value : (!cheddar.encoder, tensor<!cheddar.plaintext>, tensor<4xf64>) -> tensor<4xf64>
+  return %decoded : tensor<4xf64>
+}
+
+// A chain of fully-overwriting arithmetic operations can keep using one
+// destination when the previous value dies. This is the normal DPS/One-Shot
+// path; no Cheddar-specific post-bufferization rewrite is involved.
+// CHECK: func.func @reuse_sequence
+// CHECK-SAME: %[[STORAGE:[a-zA-Z0-9_]+]]: memref<!ciphertext> {bufferize.result}
+// CHECK-NOT: memref.alloc
+// CHECK: cheddar.add %{{.*}}, %{{.*}}, %{{.*}}, %[[STORAGE]]
+// CHECK: cheddar.neg %{{.*}}, %[[STORAGE]], %[[STORAGE]]
+// CHECK-NOT: memref.copy
+func.func @reuse_sequence(%ctx: !cheddar.context, %lhs: tensor<!cheddar.ciphertext>, %rhs: tensor<!cheddar.ciphertext>) -> tensor<!cheddar.ciphertext> {
+  %empty = tensor.empty() : tensor<!cheddar.ciphertext>
+  %sum = cheddar.add %ctx, %lhs, %rhs, %empty : (!cheddar.context, tensor<!cheddar.ciphertext>, tensor<!cheddar.ciphertext>, tensor<!cheddar.ciphertext>) -> tensor<!cheddar.ciphertext>
+  %negated = cheddar.neg %ctx, %sum, %sum : (!cheddar.context, tensor<!cheddar.ciphertext>, tensor<!cheddar.ciphertext>) -> tensor<!cheddar.ciphertext>
+  return %negated : tensor<!cheddar.ciphertext>
+}
+
+// A shape-only tensor.empty still requests a distinct destination. Alias
+// support does not force reuse unless the lowering explicitly chooses it.
+// CHECK: func.func @rescale_fresh
+// CHECK-SAME: %[[OUTPUT:[a-zA-Z0-9_]+]]: memref<!ciphertext> {bufferize.result}
+// CHECK: %[[INPUT:[a-zA-Z0-9_]+]] = memref.alloc(){{.*}} : memref<!ciphertext>
+// CHECK: cheddar.add %{{.*}}, %{{.*}}, %{{.*}}, %[[INPUT]]
+// CHECK-NOT: memref.alloc
+// CHECK: cheddar.rescale %{{.*}}, %[[INPUT]], %[[OUTPUT]]
+func.func @rescale_fresh(%ctx: !cheddar.context, %lhs: tensor<!cheddar.ciphertext>, %rhs: tensor<!cheddar.ciphertext>) -> tensor<!cheddar.ciphertext> {
+  %inputEmpty = tensor.empty() : tensor<!cheddar.ciphertext>
+  %input = cheddar.add %ctx, %lhs, %rhs, %inputEmpty : (!cheddar.context, tensor<!cheddar.ciphertext>, tensor<!cheddar.ciphertext>, tensor<!cheddar.ciphertext>) -> tensor<!cheddar.ciphertext>
+  %outputEmpty = tensor.empty() : tensor<!cheddar.ciphertext>
+  %output = cheddar.rescale %ctx, %input, %outputEmpty : (!cheddar.context, tensor<!cheddar.ciphertext>, tensor<!cheddar.ciphertext>) -> tensor<!cheddar.ciphertext>
+  return %output : tensor<!cheddar.ciphertext>
+}
+
+// scale-snu implements an aliasing Rescale by staging through an internal
+// temporary and moving it back, so an explicitly reused destination remains
+// the same buffer from One-Shot's perspective.
+// CHECK: func.func @rescale_alias_hint
+// CHECK-SAME: %[[INPUT:[a-zA-Z0-9_]+]]: memref<!ciphertext> {bufferize.result}
+// CHECK-NOT: memref.alloc
+// CHECK: cheddar.add %{{.*}}, %{{.*}}, %{{.*}}, %[[INPUT]]
+// CHECK: cheddar.rescale %{{.*}}, %[[INPUT]], %[[INPUT]]
+// CHECK-NOT: memref.copy
+func.func @rescale_alias_hint(%ctx: !cheddar.context, %lhs: tensor<!cheddar.ciphertext>, %rhs: tensor<!cheddar.ciphertext>) -> tensor<!cheddar.ciphertext> {
+  %empty = tensor.empty() : tensor<!cheddar.ciphertext>
+  %input = cheddar.add %ctx, %lhs, %rhs, %empty : (!cheddar.context, tensor<!cheddar.ciphertext>, tensor<!cheddar.ciphertext>, tensor<!cheddar.ciphertext>) -> tensor<!cheddar.ciphertext>
+  %output = cheddar.rescale %ctx, %input, %input : (!cheddar.context, tensor<!cheddar.ciphertext>, tensor<!cheddar.ciphertext>) -> tensor<!cheddar.ciphertext>
+  return %output : tensor<!cheddar.ciphertext>
+}
+
+// scale-snu explicitly supports the fused rotation-add with all three
+// ciphertext references aliasing, so One-Shot can keep the same destination.
+// CHECK: func.func @hrot_add_in_place
+// CHECK-SAME: %[[STORAGE:[a-zA-Z0-9_]+]]: memref<!ciphertext> {bufferize.result}
+// CHECK-NOT: memref.alloc
+// CHECK: cheddar.add %{{.*}}, %{{.*}}, %{{.*}}, %[[STORAGE]]
+// CHECK: cheddar.hrot_add %{{.*}}, %{{.*}}, %[[STORAGE]], %[[STORAGE]], %[[STORAGE]]
+// CHECK-NOT: memref.copy
+func.func @hrot_add_in_place(%ctx: !cheddar.context, %ui: !cheddar.user_interface, %lhs: tensor<!cheddar.ciphertext>, %rhs: tensor<!cheddar.ciphertext>) -> tensor<!cheddar.ciphertext> {
+  %empty = tensor.empty() : tensor<!cheddar.ciphertext>
+  %input = cheddar.add %ctx, %lhs, %rhs, %empty : (!cheddar.context, tensor<!cheddar.ciphertext>, tensor<!cheddar.ciphertext>, tensor<!cheddar.ciphertext>) -> tensor<!cheddar.ciphertext>
+  %output = cheddar.hrot_add %ctx, %ui, %input, %input, %input {distance = 2 : i64} : (!cheddar.context, !cheddar.user_interface, tensor<!cheddar.ciphertext>, tensor<!cheddar.ciphertext>, tensor<!cheddar.ciphertext>) -> tensor<!cheddar.ciphertext>
+  return %output : tensor<!cheddar.ciphertext>
+}
+
+// Region-carried values stay equivalent to their iter_args. This exercises
+// the stock One-Shot loop analysis; Cheddar never rewrites the destination
+// after analysis.
+// CHECK: func.func @loop_in_place
+// The loop starts from a caller-owned input, not a shape-only tensor.empty, so
+// preserving functional input semantics requires one real boundary copy.
+// CHECK: memref.copy %{{.*}}, %{{.*}} : memref<!ciphertext> to memref<!ciphertext>
+// CHECK: scf.for {{.*}} iter_args(%[[ITER:[a-zA-Z0-9_]+]] = %{{.*}}) -> (memref<!ciphertext>) {
+// CHECK: cheddar.neg %{{.*}}, %[[ITER]], %[[ITER]]
+// CHECK: scf.yield %[[ITER]] : memref<!ciphertext>
+func.func @loop_in_place(%ctx: !cheddar.context, %init: tensor<!cheddar.ciphertext>, %upper: index) -> tensor<!cheddar.ciphertext> {
+  %c0 = arith.constant 0 : index
+  %c1 = arith.constant 1 : index
+  %result = scf.for %i = %c0 to %upper step %c1 iter_args(%iter = %init) -> tensor<!cheddar.ciphertext> {
+    %next = cheddar.neg %ctx, %iter, %iter : (!cheddar.context, tensor<!cheddar.ciphertext>, tensor<!cheddar.ciphertext>) -> tensor<!cheddar.ciphertext>
+    scf.yield %next : tensor<!cheddar.ciphertext>
+  }
+  return %result : tensor<!cheddar.ciphertext>
+}

--- a/tests/Dialect/Cheddar/Transforms/bufferize_invalid.mlir
+++ b/tests/Dialect/Cheddar/Transforms/bufferize_invalid.mlir
@@ -1,0 +1,26 @@
+// RUN: heir-opt --cheddar-bufferize --split-input-file --verify-diagnostics %s
+
+// Stateful destinations cannot be copied: copying a UserInterface and then
+// mutating the copy would violate its unique ownership contract. The precise
+// bufferization model therefore requires these destinations to be writable and
+// in-place.
+func.func @borrowed_ui(%ui: tensor<!cheddar.user_interface> {bufferization.writable = false}) -> tensor<!cheddar.user_interface> {
+  // expected-error@+1 {{move-only read-write destination must bufferize in-place}}
+  %updated = cheddar.prepare_rot_key %ui {distance = 7 : i64, maxLevel = 13 : i64} : (tensor<!cheddar.user_interface>) -> tensor<!cheddar.user_interface>
+  return %updated : tensor<!cheddar.user_interface>
+}
+
+// -----
+
+// A distinct UserInterface copy is always invalid: unlike payload
+// insert-slice copies, it cannot be an alias copy that a later fold removes.
+func.func @materialize_move_only(
+    %src: tensor<!cheddar.user_interface>,
+    %dest: tensor<!cheddar.user_interface>) -> tensor<!cheddar.user_interface> {
+  // expected-error @below {{bufferization cannot copy a Cheddar user interface}}
+  // expected-error @below {{failed to bufferize op}}
+  %result = bufferization.materialize_in_destination %src in %dest
+      : (tensor<!cheddar.user_interface>, tensor<!cheddar.user_interface>)
+          -> tensor<!cheddar.user_interface>
+  return %result : tensor<!cheddar.user_interface>
+}

--- a/tests/Dialect/Cheddar/Transforms/result_destination.mlir
+++ b/tests/Dialect/Cheddar/Transforms/result_destination.mlir
@@ -1,0 +1,59 @@
+// RUN: heir-opt --cheddar-bufferize --fold-memref-alias-ops --cse --canonicalize %s | FileCheck %s
+
+// Empty-tensor elimination propagates the caller-owned result destination
+// through the rank-reducing insertion before One-Shot Bufferize. The encrypt
+// operation therefore writes directly to the output element; neither the
+// insertion nor materialization requires a payload copy.
+// CHECK: func.func @packed_encrypt
+// CHECK-SAME: %[[OUT:[a-zA-Z0-9_]+]]: memref<1x!ciphertext> {bufferize.result}
+// CHECK-NOT: memref.alloc
+// CHECK: %[[SLOT:[a-zA-Z0-9_]+]] = memref.subview %[[OUT]][0] [1] [1]
+// CHECK: cheddar.encrypt %{{.*}}, %{{.*}}, %[[SLOT]]
+// CHECK-NOT: memref.copy
+// CHECK: return
+func.func @packed_encrypt(
+    %ui: !cheddar.user_interface,
+    %plaintext: tensor<!cheddar.plaintext>)
+    -> tensor<1x!cheddar.ciphertext> {
+  %scalarInit = tensor.empty() : tensor<!cheddar.ciphertext>
+  %encrypted = cheddar.encrypt %ui, %plaintext, %scalarInit
+      : (!cheddar.user_interface, tensor<!cheddar.plaintext>,
+         tensor<!cheddar.ciphertext>) -> tensor<!cheddar.ciphertext>
+  %packedInit = tensor.empty() : tensor<1x!cheddar.ciphertext>
+  %packed = tensor.insert_slice %encrypted into %packedInit[0] [1] [1]
+      : tensor<!cheddar.ciphertext> into tensor<1x!cheddar.ciphertext>
+  return %packed : tensor<1x!cheddar.ciphertext>
+}
+
+// A caller-provided aggregate result is threaded into the loop body. The
+// scalar producer writes through a subview of it, so neither the loop boundary
+// nor tensor.insert_slice needs a ciphertext copy.
+// CHECK: func.func @loop_packed
+// CHECK-SAME: %[[OUT:[a-zA-Z0-9_]+]]: memref<8x!ciphertext> {bufferize.result}
+// CHECK-NOT: memref.alloc
+// CHECK: scf.for
+// CHECK: %[[SLOT:[a-zA-Z0-9_]+]] = memref.subview %[[OUT]][%{{.*}}] [1] [1]
+// CHECK: cheddar.add %{{.*}}, %{{.*}}, %{{.*}}, %[[SLOT]]
+// CHECK-NOT: cheddar.copy
+// CHECK-NOT: memref.copy
+// CHECK: return
+func.func @loop_packed(%ctx: !cheddar.context,
+                       %input: tensor<!cheddar.ciphertext>)
+    -> tensor<8x!cheddar.ciphertext> {
+  %output = tensor.empty() : tensor<8x!cheddar.ciphertext>
+  %c0 = arith.constant 0 : index
+  %c1 = arith.constant 1 : index
+  %c8 = arith.constant 8 : index
+  %result = scf.for %i = %c0 to %c8 step %c1
+      iter_args(%iter = %output) -> tensor<8x!cheddar.ciphertext> {
+    %empty = tensor.empty() : tensor<!cheddar.ciphertext>
+    %value = cheddar.add %ctx, %input, %input, %empty
+        : (!cheddar.context, tensor<!cheddar.ciphertext>,
+           tensor<!cheddar.ciphertext>, tensor<!cheddar.ciphertext>)
+            -> tensor<!cheddar.ciphertext>
+    %inserted = tensor.insert_slice %value into %iter[%i] [1] [1]
+        : tensor<!cheddar.ciphertext> into tensor<8x!cheddar.ciphertext>
+    scf.yield %inserted : tensor<8x!cheddar.ciphertext>
+  }
+  return %result : tensor<8x!cheddar.ciphertext>
+}

--- a/tools/BUILD
+++ b/tools/BUILD
@@ -50,6 +50,8 @@ cc_binary(
         "@heir//lib/Dialect/CKKS/IR:Dialect",
         "@heir//lib/Dialect/CKKS/Transforms",
         "@heir//lib/Dialect/Cheddar/IR:Dialect",
+        "@heir//lib/Dialect/Cheddar/Transforms",
+        "@heir//lib/Dialect/Cheddar/Transforms:BufferizableOpInterfaceImpl",
         "@heir//lib/Dialect/Comb/IR:Dialect",
         "@heir//lib/Dialect/Debug/IR:Dialect",
         "@heir//lib/Dialect/Debug/Transforms",

--- a/tools/heir-opt.cpp
+++ b/tools/heir-opt.cpp
@@ -19,6 +19,8 @@
 #include "lib/Dialect/CKKS/IR/CKKSDialect.h"
 #include "lib/Dialect/CKKS/Transforms/Passes.h"
 #include "lib/Dialect/Cheddar/IR/CheddarDialect.h"
+#include "lib/Dialect/Cheddar/Transforms/BufferizableOpInterfaceImpl.h"
+#include "lib/Dialect/Cheddar/Transforms/Passes.h"
 #include "lib/Dialect/Comb/IR/CombDialect.h"
 #include "lib/Dialect/Debug/IR/DebugDialect.h"
 #include "lib/Dialect/Debug/Transforms/Passes.h"
@@ -188,6 +190,7 @@
 #include "mlir/include/mlir/Dialect/Math/IR/Math.h"      // from @llvm-project
 #include "mlir/include/mlir/Dialect/MemRef/IR/MemRef.h"  // from @llvm-project
 #include "mlir/include/mlir/Dialect/MemRef/IR/ValueBoundsOpInterfaceImpl.h"  // from @llvm-project
+#include "mlir/include/mlir/Dialect/MemRef/Transforms/AllocationOpInterfaceImpl.h"  // from @llvm-project
 #include "mlir/include/mlir/Dialect/MemRef/Transforms/Passes.h"  // from @llvm-project
 #include "mlir/include/mlir/Dialect/SCF/IR/SCF.h"  // from @llvm-project
 #include "mlir/include/mlir/Dialect/SCF/IR/ValueBoundsOpInterfaceImpl.h"  // from @llvm-project
@@ -326,6 +329,7 @@ int main(int argc, char** argv) {
   registerTransformsPasses();      // canonicalize, cse, etc.
   affine::registerAffinePasses();  // loop unrolling
   registerLinalgPasses();          // linalg to loops
+  memref::registerMemRefPasses();  // fold-memref-alias-ops, etc.
 
   // These are only needed by two tests that build a pass pipeline
   // from the CLI. Those tests can probably eventually be removed.
@@ -363,6 +367,7 @@ int main(int argc, char** argv) {
       registry);
   cf::registerBufferizableOpInterfaceExternalModels(registry);
   mlir::linalg::registerBufferizableOpInterfaceExternalModels(registry);
+  mlir::memref::registerAllocationOpInterfaceExternalModels(registry);
   scf::registerBufferizableOpInterfaceExternalModels(registry);
   tensor::registerBufferizableOpInterfaceExternalModels(registry);
   registry.addExtension(+[](MLIRContext* ctx, LLVM::LLVMDialect* dialect) {
@@ -383,6 +388,7 @@ int main(int argc, char** argv) {
   debug::registerDebugPasses();
   ckks::registerCKKSPasses();
   kernel::registerKernelPasses();
+  cheddar::registerCheddarPasses();
   lattigo::registerLattigoPasses();
   lwe::registerLWEPasses();
   mgmt::registerMgmtPasses();
@@ -516,6 +522,7 @@ int main(int argc, char** argv) {
   // Interfaces in HEIR
   secret::registerBufferizableOpInterfaceExternalModels(registry);
   lattigo::registerBufferizableOpInterfaceExternalModels(registry);
+  cheddar::registerBufferizableOpInterfaceExternalModels(registry);
   preprocessing::registerBufferizableOpInterfaceExternalModels(registry);
   registerIncreasesMulDepthOpInterface(registry);
   registerLayoutConversionHoistableInterface(registry);


### PR DESCRIPTION
Adds a Bufferization interface implementation for the Cheddar dialect. Because much of the Cheddar API uses move-only semantics, the lowering handles ownership explicitly and avoids introducing the `memref.copy` operations that generic bufferization would otherwise produce.