### PR TITLE
cheddar: lower operations to EmitC

### DIFF
--- a/bazel/extensions.bzl
+++ b/bazel/extensions.bzl
@@ -22,6 +22,9 @@ def _llvm_deps_impl(_):
             # through the automated integration process). The patch file is
             # automatically generated, and should not be removed even if empty.
             "@heir//patches:llvm.patch",
+            # Hand-maintained (NOT auto-generated): lets `emitc.subscript` take
+            # an `!emitc.lvalue` base, needed by the cheddar EmitC emitter.
+            "@heir//patches:emitc_subscript_lvalue.patch",
         ],
         patch_args = ["-p1"],
     )

--- a/lib/Conversions/CheddarToEmitC/BUILD
+++ b/lib/Conversions/CheddarToEmitC/BUILD
@@ -1,0 +1,39 @@
+load("@heir//lib/Transforms:transforms.bzl", "add_heir_transforms")
+load("@rules_cc//cc:cc_library.bzl", "cc_library")
+
+package(
+    default_applicable_licenses = ["@heir//:license"],
+    default_visibility = ["//visibility:public"],
+)
+
+cc_library(
+    name = "CheddarToEmitC",
+    srcs = ["CheddarToEmitC.cpp"],
+    hdrs = ["CheddarToEmitC.h"],
+    deps = [
+        ":pass_inc_gen",
+        "@heir//lib/Dialect/Cheddar/IR:Dialect",
+        "@heir//lib/Utils:TargetUtils",
+        "@llvm-project//llvm:Support",
+        "@llvm-project//mlir:ArithDialect",
+        "@llvm-project//mlir:ConvertToEmitCInterface",
+        "@llvm-project//mlir:DestinationStyleOpInterface",
+        "@llvm-project//mlir:EmitCDialect",
+        "@llvm-project//mlir:FuncDialect",
+        "@llvm-project//mlir:FuncTransforms",
+        "@llvm-project//mlir:IR",
+        "@llvm-project//mlir:MemRefDialect",
+        "@llvm-project//mlir:MemRefToEmitC",
+        "@llvm-project//mlir:MemRefUtils",
+        "@llvm-project//mlir:Pass",
+        "@llvm-project//mlir:SCFDialect",
+        "@llvm-project//mlir:Support",
+        "@llvm-project//mlir:TransformUtils",
+    ],
+)
+
+add_heir_transforms(
+    header_filename = "CheddarToEmitC.h.inc",
+    pass_name = "CheddarToEmitC",
+    td_file = "CheddarToEmitC.td",
+)

--- a/lib/Conversions/CheddarToEmitC/CheddarToEmitC.cpp
+++ b/lib/Conversions/CheddarToEmitC/CheddarToEmitC.cpp
@@ -1,0 +1,1074 @@
+#include "lib/Conversions/CheddarToEmitC/CheddarToEmitC.h"
+
+#include <optional>
+#include <string>
+
+#include "lib/Dialect/Cheddar/IR/CheddarDialect.h"
+#include "lib/Dialect/Cheddar/IR/CheddarOps.h"
+#include "lib/Dialect/Cheddar/IR/CheddarTypes.h"
+#include "lib/Utils/TargetUtils.h"
+#include "llvm/include/llvm/ADT/DenseSet.h"         // from @llvm-project
+#include "llvm/include/llvm/ADT/STLExtras.h"        // from @llvm-project
+#include "llvm/include/llvm/ADT/SmallVector.h"      // from @llvm-project
+#include "llvm/include/llvm/ADT/StringMap.h"        // from @llvm-project
+#include "llvm/include/llvm/ADT/StringSet.h"        // from @llvm-project
+#include "llvm/include/llvm/Support/raw_ostream.h"  // from @llvm-project
+#include "mlir/include/mlir/Conversion/ConvertToEmitC/ToEmitCInterface.h"  // from @llvm-project
+#include "mlir/include/mlir/Conversion/MemRefToEmitC/MemRefToEmitC.h"  // from @llvm-project
+#include "mlir/include/mlir/Dialect/Arith/IR/Arith.h"   // from @llvm-project
+#include "mlir/include/mlir/Dialect/EmitC/IR/EmitC.h"   // from @llvm-project
+#include "mlir/include/mlir/Dialect/Func/IR/FuncOps.h"  // from @llvm-project
+#include "mlir/include/mlir/Dialect/Func/Transforms/FuncConversions.h"  // from @llvm-project
+#include "mlir/include/mlir/Dialect/MemRef/IR/MemRef.h"  // from @llvm-project
+#include "mlir/include/mlir/Dialect/MemRef/Utils/MemRefUtils.h"  // from @llvm-project
+#include "mlir/include/mlir/Dialect/SCF/IR/SCF.h"     // from @llvm-project
+#include "mlir/include/mlir/IR/BuiltinAttributes.h"   // from @llvm-project
+#include "mlir/include/mlir/IR/BuiltinOps.h"          // from @llvm-project
+#include "mlir/include/mlir/IR/BuiltinTypes.h"        // from @llvm-project
+#include "mlir/include/mlir/IR/PatternMatch.h"        // from @llvm-project
+#include "mlir/include/mlir/IR/SymbolTable.h"         // from @llvm-project
+#include "mlir/include/mlir/IR/Value.h"               // from @llvm-project
+#include "mlir/include/mlir/Support/LLVM.h"           // from @llvm-project
+#include "mlir/include/mlir/Support/LogicalResult.h"  // from @llvm-project
+#include "mlir/include/mlir/Transforms/DialectConversion.h"  // from @llvm-project
+
+namespace mlir::heir {
+
+#define GEN_PASS_DEF_CHEDDARTOEMITC
+#include "lib/Conversions/CheddarToEmitC/CheddarToEmitC.h.inc"
+
+namespace {
+
+using ::mlir::emitc::CallOpaqueOp;
+using ::mlir::emitc::LValueType;
+using ::mlir::emitc::MemberCallOpaqueOp;
+using ::mlir::emitc::OpaqueAttr;
+using ::mlir::emitc::OpaqueType;
+using ::mlir::emitc::PointerType;
+using ::mlir::emitc::VariableOp;
+using ::mlir::emitc::VerbatimOp;
+
+//===----------------------------------------------------------------------===//
+// Helpers
+//===----------------------------------------------------------------------===//
+
+constexpr StringLiteral kDestinationOperandAttr = "cheddar.destination_operand";
+
+template <typename OpTy>
+OpTy markDestination(OpTy op, unsigned operandNumber) {
+  op->setAttr(
+      kDestinationOperandAttr,
+      IntegerAttr::get(IntegerType::get(op.getContext(), 64), operandNumber));
+  return op;
+}
+
+std::optional<unsigned> getDestinationOperand(Operation* op) {
+  auto attr = op->getAttrOfType<IntegerAttr>(kDestinationOperandAttr);
+  if (!attr) return std::nullopt;
+  return static_cast<unsigned>(attr.getInt());
+}
+
+// The CHEDDAR payload C++ type name for a cheddar element type, or "" if `t`
+// isn't a (move-only) cheddar payload type.
+std::string payloadTypeName(Type t) {
+  if (isa<cheddar::CiphertextType>(t)) return "Ciphertext<word>";
+  if (isa<cheddar::PlaintextType>(t)) return "Plaintext<word>";
+  if (isa<cheddar::ConstantType>(t)) return "Constant<word>";
+  if (isa<cheddar::EvalKeyType>(t)) return "EvaluationKey<word>";
+  return "";
+}
+
+// The scalar C++ element type name for a memref element: a cheddar payload, or
+// a plain float. "" if `t` is neither (the buffer is left to upstream / fails).
+std::string scalarCppName(Type t) {
+  std::string p = payloadTypeName(t);
+  if (!p.empty()) return p;
+  if (auto f = dyn_cast<FloatType>(t)) {
+    if (f.getWidth() == 32) return "float";
+    if (f.getWidth() == 64) return "double";
+  }
+  return "";
+}
+
+// Build the (nested) `std::array` C++ type for a buffer shape + element name.
+// shape [1, 1024], elt "float" -> "std::array<std::array<float, 1024>, 1>".
+std::string stdArrayName(ArrayRef<int64_t> shape, StringRef elt) {
+  std::string s = elt.str();
+  for (int64_t d : llvm::reverse(shape))
+    s = "std::array<" + s + ", " + std::to_string(d) + ">";
+  return s;
+}
+
+// The owning C++ smart-pointer type name for a cheddar setup-handle element
+// (context / user_interface), or "" otherwise. A `memref<!cheddar.X>` of one of
+// these is an OWNING destination (written by
+// create_context/create_user_interface and handed back through a `__configure`
+// out-param), as opposed to the bare borrowed handle the compute funcs take
+// (`Context<word>*` / `UserInterface<word>*`).
+std::string owningHandleTypeName(Type t) {
+  if (isa<cheddar::ContextType>(t)) return "std::shared_ptr<Context<word>>";
+  if (isa<cheddar::BootContextType>(t))
+    return "std::shared_ptr<BootContext<word>>";
+  if (isa<cheddar::UserInterfaceType>(t))
+    return "std::unique_ptr<UserInterface<word>>";
+  return "";
+}
+
+int64_t numElements(ArrayRef<int64_t> shape) {
+  int64_t result = 1;
+  for (int64_t dim : shape) result *= dim;
+  return result;
+}
+
+// Flat `<elt>*` to a buffer's first element: the value itself if it is already
+// a pointer (e.g. a subview slice), else `&array[0]..[0]`. Emitting this as SSA
+// `address_of(subscript(buf, 0..0))` -- not a baked `&buf[0]..[0]` string --
+// lets cheddar-emitc-boundary recognize and flatten a result out-param.
+Value addressOfFirstElement(OpBuilder& b, Location loc, Value array) {
+  if (isa<emitc::PointerType>(array.getType())) return array;
+  auto arrayTy = cast<emitc::ArrayType>(array.getType());
+  auto sizeT = emitc::SizeTType::get(b.getContext());
+  SmallVector<Value> zeroIdxs;
+  for (size_t i = 0; i < arrayTy.getShape().size(); ++i)
+    zeroIdxs.push_back(emitc::LiteralOp::create(b, loc, sizeT, "0"));
+  auto lvalueTy = emitc::LValueType::get(arrayTy.getElementType());
+  Value firstElement =
+      emitc::SubscriptOp::create(b, loc, lvalueTy, array, zeroIdxs);
+  return emitc::AddressOfOp::create(
+      b, loc, emitc::PointerType::get(arrayTy.getElementType()), firstElement);
+}
+
+//===----------------------------------------------------------------------===//
+// Type conversions
+//===----------------------------------------------------------------------===//
+
+// Add the cheddar-specific conversions to the shared EmitC type converter:
+// cheddar handle/payload types and payload buffers. A move-only payload buffer
+// (`memref<!cheddar.X>`) maps to an `emitc.lvalue` of the payload type for a
+// scalar (rank-0) buffer, or to an `emitc.array` for a rank-1 buffer (looped
+// kernels). Function-boundary buffers are re-typed to C++ references by the
+// `cheddar-emitc-boundary` pass (a func cannot carry lvalue args).
+void addCheddarEmitCTypeConversions(TypeConverter& tc, MLIRContext* ctx) {
+  // Identity for the emitc types we produce, so they are recognised as already
+  // legal (the shared EmitCTypeConverter's generic rule rejects e.g. lvalue,
+  // leaving a converted func signature perpetually "illegal").
+  tc.addConversion([](emitc::LValueType t) -> Type { return t; });
+  tc.addConversion([ctx](cheddar::ParameterType) -> Type {
+    return OpaqueType::get(ctx, "Parameter<word>");
+  });
+  tc.addConversion([ctx](cheddar::ContextType) -> Type {
+    return PointerType::get(ctx, OpaqueType::get(ctx, "Context<word>"));
+  });
+  tc.addConversion([ctx](cheddar::BootContextType) -> Type {
+    return PointerType::get(ctx, OpaqueType::get(ctx, "BootContext<word>"));
+  });
+  tc.addConversion([ctx](cheddar::UserInterfaceType) -> Type {
+    return PointerType::get(ctx, OpaqueType::get(ctx, "UserInterface<word>"));
+  });
+  tc.addConversion([ctx](cheddar::EncoderType) -> Type {
+    return OpaqueType::get(ctx, "Encoder<word>");
+  });
+  tc.addConversion([ctx](cheddar::EvkMapType) -> Type {
+    return OpaqueType::get(ctx, "EvkMap<word>");
+  });
+  tc.addConversion([ctx](cheddar::EvalKeyType) -> Type {
+    return OpaqueType::get(ctx, "EvaluationKey<word>");
+  });
+  tc.addConversion([ctx](cheddar::CiphertextType) -> Type {
+    return OpaqueType::get(ctx, "Ciphertext<word>");
+  });
+  tc.addConversion([ctx](cheddar::PlaintextType) -> Type {
+    return OpaqueType::get(ctx, "Plaintext<word>");
+  });
+  tc.addConversion([ctx](cheddar::ConstantType) -> Type {
+    return OpaqueType::get(ctx, "Constant<word>");
+  });
+  tc.addConversion(
+      [ctx](IndexType) -> Type { return emitc::SizeTType::get(ctx); });
+  // Bufferized buffers split by element kind:
+  //  * move-only cheddar PAYLOAD (ciphertext/plaintext/constant/key): a place
+  //    carried as `lvalue<opaque>` -- rank-0 -> `T name;`; rank>=1 -> a
+  //    (nested) `std::array` (`std::array<T,N> name;`). std::array (not a C
+  //    array) so it binds to the `std::array<T,N>&` function-boundary refs and
+  //    the harness; subscripting works via the patched emitc.subscript
+  //    (lvalue<opaque> base).
+  //  * FLOAT message/weight buffers: a C array (`emitc.array`). emitc.global
+  //    (weight constants) requires an emitc.array type and emitc subscripts C
+  //    arrays natively, so floats stay C arrays; a strided subview slice
+  //    feeding cheddar.encode becomes a raw pointer.
+  // Layout is otherwise ignored (a payload subview slice is contiguous, so its
+  // shape alone names the std::array). Other memrefs are left to upstream.
+  tc.addConversion([ctx](MemRefType type) -> std::optional<Type> {
+    Type eltType = type.getElementType();
+    // Owning setup-handle destination (rank-0 context/user_interface buffer):
+    // an `lvalue` of the owning smart-pointer type, re-typed to `T&` at the
+    // function boundary so `__configure` writes the handle back to the caller.
+    if (type.getRank() == 0) {
+      std::string owning = owningHandleTypeName(eltType);
+      if (!owning.empty())
+        return Type(LValueType::get(OpaqueType::get(ctx, owning)));
+    }
+    std::string elt = scalarCppName(eltType);
+    if (elt.empty()) return std::nullopt;
+    bool payload = !payloadTypeName(eltType).empty();
+    if (type.getRank() == 0) {
+      if (payload) return Type(LValueType::get(OpaqueType::get(ctx, elt)));
+      return Type(emitc::PointerType::get(eltType));
+    }
+    if (payload) {
+      if (!type.hasStaticShape() || llvm::is_contained(type.getShape(), 0))
+        return Type();
+      if (!memref::isStaticShapeAndContiguousRowMajor(type)) return Type();
+      return Type(LValueType::get(
+          OpaqueType::get(ctx, stdArrayName(type.getShape(), elt))));
+    }
+    // A proven-contiguous float subview lowers to a raw pointer. Reject other
+    // strided layouts rather than silently discarding their stride semantics.
+    if (isa<StridedLayoutAttr>(type.getLayout())) {
+      if (!memref::isStaticShapeAndContiguousRowMajor(type)) return Type();
+      return Type(emitc::PointerType::get(eltType));
+    }
+    if (!type.hasStaticShape() || llvm::is_contained(type.getShape(), 0))
+      return Type();
+    return Type(emitc::ArrayType::get(type.getShape(), eltType));
+  });
+}
+
+// emitc::OpaqueType doesn't implement MemRefElementTypeInterface upstream;
+// needed if `memref<Nx!emitc.opaque<...>>` is ever formed. Marker-only.
+struct EmitCOpaqueAsMemRefElement
+    : public mlir::MemRefElementTypeInterface::ExternalModel<
+          EmitCOpaqueAsMemRefElement, mlir::emitc::OpaqueType> {};
+
+// The getter-style setup ops hand back a const& to a move-only / non-assignable
+// value; a value-materialising lowering can't compile them. Reject up front.
+bool diagnoseUnsupportedGetters(Operation* root) {
+  bool found = false;
+  root->walk([&](Operation* op) {
+    if (isa<cheddar::GetEvkMapOp, cheddar::GetMultKeyOp, cheddar::GetEncoderOp>(
+            op)) {
+      op->emitError()
+          << "cheddar-to-emitc: lowering of '" << op->getName().getStringRef()
+          << "' is not supported: it returns a const reference to a "
+             "move-only/non-assignable value. Pass the "
+             "key/map/encoder as a function argument, or look it up "
+             "inline at the use site.";
+      found = true;
+    }
+  });
+  return found;
+}
+
+//===----------------------------------------------------------------------===//
+// Conversion patterns
+//===----------------------------------------------------------------------===//
+
+// A `__heir_debug_*` call (from --lwe-add-debug-port, re-shaped by LWEToCheddar
+// to (Encoder, UserInterface, Ciphertext)) -> a free C++ call to an
+// externally-defined `__heir_debug(encoder, ui, ct, "name", "metadata")`. The
+// debug name/metadata travel as `debug.name`/`debug.metadata` dialect attrs;
+// they are baked into the call as trailing string-literal args. Medusa's C++
+// prelude defines `__heir_debug` (decrypt + decode + print); the external
+// `func.func` declaration is erased by the cheddar-emitc-boundary pass (the
+// upstream Cpp emitter cannot print an external func.func declaration).
+struct ConvertDebugCall : public OpConversionPattern<func::CallOp> {
+  using OpConversionPattern::OpConversionPattern;
+  LogicalResult matchAndRewrite(
+      func::CallOp op, OpAdaptor adaptor,
+      ConversionPatternRewriter& rewriter) const override {
+    if (!isDebugPort(op.getCallee())) return failure();
+    auto* ctx = rewriter.getContext();
+    auto escape = [](StringRef s) {
+      std::string out = "\"";
+      for (char c : s) {
+        if (c == '"' || c == '\\') out += '\\';
+        out += c;
+      }
+      out += '"';
+      return out;
+    };
+    std::string name;
+    if (auto n = op->getAttrOfType<StringAttr>("debug.name"))
+      name = escape(n.getValue());
+    else
+      name = "\"\"";
+    std::string metadata;
+    if (auto m = op->getAttrOfType<StringAttr>("debug.metadata"))
+      metadata = escape(m.getValue());
+    else
+      metadata = "\"\"";
+    SmallVector<Value> operands(adaptor.getOperands().begin(),
+                                adaptor.getOperands().end());
+    SmallVector<Attribute> args;
+    for (size_t i = 0; i < operands.size(); ++i)
+      args.push_back(rewriter.getIndexAttr(i));
+    args.push_back(emitc::OpaqueAttr::get(ctx, name));
+    args.push_back(emitc::OpaqueAttr::get(ctx, metadata));
+    CallOpaqueOp::create(rewriter, op.getLoc(), TypeRange{},
+                         rewriter.getStringAttr("__heir_debug"), operands,
+                         rewriter.getArrayAttr(args),
+                         /*template_args=*/ArrayAttr{});
+    rewriter.eraseOp(op);
+    return success();
+  }
+};
+
+//===----------------------------------------------------------------------===//
+// memref op patterns (payload + float)
+//===----------------------------------------------------------------------===//
+
+// memref.alloc of a cheddar buffer (payload or float, scalar or std::array) ->
+// a stack `emitc.variable` of the converted lvalue<opaque> type, i.e.
+// `T name;` / `std::array<T,N> name;`. We own this (rather than upstream
+// MemRefToEmitC, which heap-allocs a pointer) so the buffer is a value that
+// binds to the `std::array<T,N>&` boundaries and is subscriptable.
+struct ConvertAllocLocal : public OpConversionPattern<mlir::memref::AllocOp> {
+  using OpConversionPattern::OpConversionPattern;
+  LogicalResult matchAndRewrite(
+      mlir::memref::AllocOp op, OpAdaptor /*adaptor*/,
+      ConversionPatternRewriter& rewriter) const override {
+    Type converted = getTypeConverter()->convertType(op.getType());
+    // payload buffer (lvalue<opaque>) or float C array (emitc.array): both are
+    // valid emitc.variable result types -> a stack local. (We own this so float
+    // allocs become stack arrays, not upstream's heap malloc/aligned_alloc.)
+    if (!isa_and_present<emitc::LValueType>(converted) &&
+        !isa_and_present<emitc::ArrayType>(converted))
+      return failure();
+    auto variable = emitc::VariableOp::create(
+        rewriter, op.getLoc(), converted,
+        emitc::OpaqueAttr::get(rewriter.getContext(), ""));
+    rewriter.replaceOp(op, variable);
+    return success();
+  }
+};
+
+// memref.dealloc of a cheddar payload buffer (lvalue<opaque>, a move-only
+// Ciphertext/Plaintext<word> that owns GPU memory) -> free the device buffer
+// *now* by move-assigning an empty handle (`v = {};`), which runs the payload's
+// destructor at last use. Without this, every intermediate stays live until the
+// enclosing C++ function returns (scope-bound RAII), so peak GPU memory is the
+// sum of ALL intermediates and large models OOM. The ownership-based buffer
+// deallocation pass inserts these deallocs at last use; here we lower them.
+struct EraseDealloc : public OpConversionPattern<mlir::memref::DeallocOp> {
+  using OpConversionPattern::OpConversionPattern;
+  LogicalResult matchAndRewrite(
+      mlir::memref::DeallocOp op, OpAdaptor adaptor,
+      ConversionPatternRewriter& rewriter) const override {
+    Type memTy = adaptor.getMemref().getType();
+    if (auto l = dyn_cast<emitc::LValueType>(memTy)) {
+      if (auto opaque = dyn_cast<emitc::OpaqueType>(l.getValueType())) {
+        // Move-only payload (Ciphertext/Plaintext<word>): free the GPU buffer
+        // at last use by move-assigning a fresh default-constructed temporary,
+        // e.g. `v = Ciphertext<word>();`. NB `v = {}` does NOT compile -- these
+        // types are `explicit`-constructed (all-default-args ctor) and not
+        // brace-assignable. The opaque type string IS the C++ type name.
+        std::string reset = "{} = " + opaque.getValue().str() + "();";
+        VerbatimOp::create(rewriter, op.getLoc(), reset,
+                           ValueRange{adaptor.getMemref()});
+      }
+      // Non-payload lvalues (e.g. plain float scalars) are scope-bound stack
+      // values with nothing to free -- just drop the dealloc.
+      rewriter.eraseOp(op);
+      return success();
+    }
+    // Plain float buffers lower to scope-bound stack arrays (emitc.array); the
+    // ownership-based dealloc still inserts a memref.dealloc for them, which
+    // has nothing to free -- drop it.
+    if (isa<emitc::ArrayType>(memTy)) {
+      rewriter.eraseOp(op);
+      return success();
+    }
+    return failure();
+  }
+};
+
+// memref.load on a std::array buffer (lvalue<opaque>) -> `base[i...]` via
+// emitc.subscript. For a payload element the subscript (an lvalue) is fed to
+// member_call operands directly; for a float element a memref.load yields a
+// value, so add an emitc.load.
+struct ConvertLoadArray : public OpConversionPattern<mlir::memref::LoadOp> {
+  using OpConversionPattern::OpConversionPattern;
+  LogicalResult matchAndRewrite(
+      mlir::memref::LoadOp op, OpAdaptor adaptor,
+      ConversionPatternRewriter& rewriter) const override {
+    Type baseTy = adaptor.getMemref().getType();
+    bool isPayloadBuf = isa<emitc::LValueType>(baseTy);
+    if (!isPayloadBuf && !isa<emitc::ArrayType>(baseTy)) return failure();
+    Type elt =
+        getTypeConverter()->convertType(op.getMemRefType().getElementType());
+    if (!elt) return failure();
+    // Rank-0 payload memref: a rank-0 `memref<!cheddar.X>` converts to the
+    // element lvalue itself (lvalue<opaque>), so a no-index load IS that lvalue
+    // -- no subscript. Mirrors the indexed payload case which yields an lvalue
+    // (used by preprocessing storage of a single plaintext slot). Non-payload
+    // rank-0 loads fall through to the stock memref->emitc patterns.
+    if (adaptor.getIndices().empty()) {
+      if (isPayloadBuf && isa<emitc::OpaqueType>(elt)) {
+        rewriter.replaceOp(op, adaptor.getMemref());
+        return success();
+      }
+      return failure();
+    }
+    auto sub = emitc::SubscriptOp::create(
+        rewriter, op.getLoc(), emitc::LValueType::get(elt), adaptor.getMemref(),
+        adaptor.getIndices());
+    if (isa<emitc::OpaqueType>(elt)) {
+      rewriter.replaceOp(op, sub.getResult());  // payload: lvalue, no copy
+      return success();
+    }
+    auto loaded =
+        emitc::LoadOp::create(rewriter, op.getLoc(), elt, sub.getResult());
+    rewriter.replaceOp(op, loaded);
+    return success();
+  }
+};
+
+// The dialect-conversion materialization for an opaque memref.store's value
+// operand may turn an `lvalue<opaque<T>>` producer into the `opaque<T>` value
+// form via an unrealized_conversion_cast. Look through that cast so the
+// assignment uses the lvalue directly.
+static Value unwrapSingleUnrealizedCast(Value v) {
+  if (auto cast = v.getDefiningOp<mlir::UnrealizedConversionCastOp>();
+      cast && cast.getInputs().size() == 1 &&
+      isa<emitc::LValueType>(cast.getInputs()[0].getType()))
+    return cast.getInputs()[0];
+  return v;
+}
+
+// Diagnose move-only copies before dialect conversion tries to materialize
+// converted operands. An OpConversionPattern may never reach matchAndRewrite
+// when such a materialization is impossible, which would hide the ownership
+// error behind a generic "failed to legalize" diagnostic.
+struct RejectMoveOnlyStore : public OpRewritePattern<mlir::memref::StoreOp> {
+  using OpRewritePattern::OpRewritePattern;
+  LogicalResult matchAndRewrite(mlir::memref::StoreOp op,
+                                PatternRewriter& /*rewriter*/) const override {
+    Type elementType = op.getMemRefType().getElementType();
+    if (payloadTypeName(elementType).empty() &&
+        !isa<cheddar::UserInterfaceType>(elementType))
+      return failure();
+    return op.emitOpError(
+        "copying a move-only Cheddar value with memref.store is invalid");
+  }
+};
+
+struct HandleMoveOnlyCopy : public OpRewritePattern<mlir::memref::CopyOp> {
+  using OpRewritePattern::OpRewritePattern;
+  LogicalResult matchAndRewrite(mlir::memref::CopyOp op,
+                                PatternRewriter& rewriter) const override {
+    auto sourceType = cast<MemRefType>(op.getSource().getType());
+    Type elementType = sourceType.getElementType();
+    if (payloadTypeName(elementType).empty() &&
+        !isa<cheddar::UserInterfaceType>(elementType))
+      return failure();
+    if (op.getSource() == op.getTarget()) {
+      rewriter.eraseOp(op);
+      return success();
+    }
+    return op.emitOpError(
+        "copying a move-only Cheddar value with memref.copy is invalid");
+  }
+};
+
+// memref.store retains value-copy semantics. CHEDDAR's move-only payloads must
+// therefore never reach this conversion; their producers must write directly
+// into destination buffers during bufferization.
+struct ConvertStoreArray : public OpConversionPattern<mlir::memref::StoreOp> {
+  using OpConversionPattern::OpConversionPattern;
+  LogicalResult matchAndRewrite(
+      mlir::memref::StoreOp op, OpAdaptor adaptor,
+      ConversionPatternRewriter& rewriter) const override {
+    Type baseTy = adaptor.getMemref().getType();
+    if (!isa<emitc::LValueType>(baseTy) && !isa<emitc::ArrayType>(baseTy))
+      return failure();
+    Type elt =
+        getTypeConverter()->convertType(op.getMemRefType().getElementType());
+    if (!elt) return failure();
+    // Rank-0 memref: store directly into the element lvalue (no subscript).
+    if (adaptor.getIndices().empty()) {
+      if (isa<emitc::LValueType>(baseTy) && isa<emitc::OpaqueType>(elt)) {
+        markDestination(
+            VerbatimOp::create(
+                rewriter, op.getLoc(), "{} = {};",
+                ValueRange{adaptor.getMemref(),
+                           unwrapSingleUnrealizedCast(adaptor.getValue())}),
+            0);
+        rewriter.eraseOp(op);
+        return success();
+      }
+      return failure();
+    }
+    auto sub = emitc::SubscriptOp::create(
+        rewriter, op.getLoc(), emitc::LValueType::get(elt), adaptor.getMemref(),
+        adaptor.getIndices());
+    if (isa<emitc::OpaqueType>(elt)) {
+      markDestination(
+          VerbatimOp::create(
+              rewriter, op.getLoc(), "{} = {};",
+              ValueRange{sub.getResult(),
+                         unwrapSingleUnrealizedCast(adaptor.getValue())}),
+          0);
+    } else {
+      emitc::AssignOp::create(rewriter, op.getLoc(), sub.getResult(),
+                              adaptor.getValue());
+    }
+    rewriter.eraseOp(op);
+    return success();
+  }
+};
+
+// memref.copy also retains value-copy semantics. It cannot be reinterpreted as
+// an ownership transfer merely because a source happens to be dead.
+struct ConvertCopy : public OpConversionPattern<mlir::memref::CopyOp> {
+  using OpConversionPattern::OpConversionPattern;
+  LogicalResult matchAndRewrite(
+      mlir::memref::CopyOp op, OpAdaptor adaptor,
+      ConversionPatternRewriter& rewriter) const override {
+    Value src = adaptor.getSource();
+    Value tgt = adaptor.getTarget();
+    auto opaqueOf = [](Value v) -> emitc::OpaqueType {
+      auto l = dyn_cast<emitc::LValueType>(v.getType());
+      return l ? dyn_cast<emitc::OpaqueType>(l.getValueType())
+               : emitc::OpaqueType();
+    };
+    emitc::OpaqueType so = opaqueOf(src), to = opaqueOf(tgt);
+    if (!so || !to) return failure();
+    markDestination(VerbatimOp::create(rewriter, op.getLoc(), "{} = {};",
+                                       ValueRange{tgt, src}),
+                    0);
+    rewriter.eraseOp(op);
+    return success();
+  }
+};
+
+// memref.subview slicing a std::array buffer (lvalue<opaque>) -> `base[o...]`,
+// an lvalue subscript. The rank-reducing extract/insert slices used to pull a
+// single ciphertext out of a `tensor<1x!cheddar.X>` packing container, or a row
+// out of a `<1x1024xf32>` buffer, drop leading (size-1) dims: emit a subscript
+// indexing those dimensions by their offsets, yielding the converted inner
+// buffer or scalar. A nested C++ array cannot represent rank reduction of a
+// non-leading dimension, so reject that layout explicitly.
+struct ConvertSubViewSubscript
+    : public OpConversionPattern<mlir::memref::SubViewOp> {
+  using OpConversionPattern::OpConversionPattern;
+  LogicalResult matchAndRewrite(
+      mlir::memref::SubViewOp op, OpAdaptor adaptor,
+      ConversionPatternRewriter& rewriter) const override {
+    Value base = adaptor.getSource();
+    if (!isa<emitc::LValueType>(base.getType())) return failure();
+    Type resultTy = getTypeConverter()->convertType(op.getType());
+    if (!isa_and_present<emitc::LValueType>(resultTy)) return failure();
+    int64_t srcRank = op.getSourceType().getRank();
+    int64_t resRank = cast<MemRefType>(op.getType()).getRank();
+    int64_t dropped = srcRank - resRank;
+    if (dropped <= 0) return failure();
+    llvm::SmallBitVector droppedDims = op.getDroppedDims();
+    for (int64_t i = 0; i < srcRank; ++i)
+      if (droppedDims.test(i) != (i < dropped))
+        return rewriter.notifyMatchFailure(
+            op, "payload subview may drop only leading dimensions");
+    // Subscript the dropped (leading) dims by their offsets. Offsets may be
+    // static (a literal index) or dynamic (a loop induction variable, e.g. from
+    // a `tensor.insert_slice` in an scf.for) -- emitc.subscript accepts dynamic
+    // index operands, so thread the converted dynamic offset value through.
+    auto mixedOffsets = op.getMixedOffsets();
+    if (static_cast<int64_t>(mixedOffsets.size()) != srcRank) return failure();
+    auto staticSizes = op.getStaticSizes();
+    auto staticStrides = op.getStaticStrides();
+    ArrayRef<int64_t> sourceShape = op.getSourceType().getShape();
+    for (int64_t i = dropped; i < srcRank; ++i) {
+      if (ShapedType::isDynamic(staticSizes[i]) ||
+          staticSizes[i] != sourceShape[i] || staticStrides[i] != 1)
+        return rewriter.notifyMatchFailure(
+            op, "payload subview must retain a full contiguous suffix");
+      auto offset = mixedOffsets[i];
+      auto attr = dyn_cast<Attribute>(offset);
+      if (!attr || cast<IntegerAttr>(attr).getInt() != 0)
+        return rewriter.notifyMatchFailure(
+            op, "payload subview must have zero retained-dimension offsets");
+    }
+    ValueRange dynOffsets = adaptor.getOffsets();
+    auto sizeT = emitc::SizeTType::get(getContext());
+    SmallVector<Value> idx;
+    unsigned dynCursor = 0;
+    for (int64_t i = 0; i < srcRank; ++i) {
+      bool isDyn = isa<Value>(mixedOffsets[i]);
+      if (i < dropped) {
+        if (isDyn) {
+          idx.push_back(dynOffsets[dynCursor]);
+        } else {
+          int64_t o =
+              cast<IntegerAttr>(cast<Attribute>(mixedOffsets[i])).getInt();
+          idx.push_back(emitc::LiteralOp::create(rewriter, op.getLoc(), sizeT,
+                                                 std::to_string(o)));
+        }
+      }
+      if (isDyn) ++dynCursor;
+    }
+    auto subscript =
+        emitc::SubscriptOp::create(rewriter, op.getLoc(), resultTy, base, idx);
+    rewriter.replaceOp(op, subscript);
+    return success();
+  }
+};
+
+// memref.cast of a payload buffer -> forward the converted source. The
+// rank-reducing extract_slice that pulls a single ciphertext out of a
+// `tensor<1x!cheddar.X>` packing container produces a `strided<[]>` rank-0
+// memref; when that feeds an extern call (the __heir_debug read) whose decl arg
+// is the plain unstrided memref, a `memref.cast` strided<[]> -> plain is
+// inserted. Both sides are the same Ciphertext/Plaintext lvalue at the C++
+// level, so the cast is a no-op: replace it with its (already converted)
+// source.
+struct ConvertPayloadCast : public OpConversionPattern<mlir::memref::CastOp> {
+  using OpConversionPattern::OpConversionPattern;
+  LogicalResult matchAndRewrite(
+      mlir::memref::CastOp op, OpAdaptor adaptor,
+      ConversionPatternRewriter& rewriter) const override {
+    auto resTy = dyn_cast<MemRefType>(op.getType());
+    if (!resTy || !isa<cheddar::CiphertextType, cheddar::PlaintextType,
+                       cheddar::ConstantType>(resTy.getElementType()))
+      return failure();
+    rewriter.replaceOp(op, adaptor.getSource());
+    return success();
+  }
+};
+
+// memref.subview producing a strided slice of a float C-array buffer ->
+// `&base[o...]`, a raw pointer (the message slice fed to cheddar.encode).
+struct ConvertSubViewToPointer
+    : public OpConversionPattern<mlir::memref::SubViewOp> {
+  using OpConversionPattern::OpConversionPattern;
+  LogicalResult matchAndRewrite(
+      mlir::memref::SubViewOp op, OpAdaptor adaptor,
+      ConversionPatternRewriter& rewriter) const override {
+    Value base = adaptor.getSource();
+    auto arrayTy = dyn_cast<emitc::ArrayType>(base.getType());
+    if (!arrayTy || !isa<FloatType>(arrayTy.getElementType())) return failure();
+    auto resultType = cast<MemRefType>(op.getType());
+    if (!memref::isStaticShapeAndContiguousRowMajor(resultType))
+      return rewriter.notifyMatchFailure(op,
+                                         "float subview must be contiguous");
+    auto offsets = op.getStaticOffsets();
+    if (static_cast<int64_t>(offsets.size()) != arrayTy.getShape().size())
+      return failure();
+    for (int64_t o : offsets)
+      if (ShapedType::isDynamic(o)) return failure();
+    auto sizeT = emitc::SizeTType::get(getContext());
+    SmallVector<Value> idx;
+    for (int64_t o : offsets)
+      idx.push_back(emitc::LiteralOp::create(rewriter, op.getLoc(), sizeT,
+                                             std::to_string(o)));
+    auto lvalT = emitc::LValueType::get(arrayTy.getElementType());
+    auto sub =
+        emitc::SubscriptOp::create(rewriter, op.getLoc(), lvalT, base, idx);
+    auto address = emitc::AddressOfOp::create(
+        rewriter, op.getLoc(),
+        emitc::PointerType::get(arrayTy.getElementType()), sub.getResult());
+    rewriter.replaceOp(op, address);
+    return success();
+  }
+};
+
+// memref.copy between float buffers (C arrays / pointers) -> an element-wise
+// loop (the move-only payload copy is handled by ConvertCopy).
+struct ConvertMemRefCopyFloat
+    : public OpConversionPattern<mlir::memref::CopyOp> {
+  using OpConversionPattern::OpConversionPattern;
+  LogicalResult matchAndRewrite(
+      mlir::memref::CopyOp op, OpAdaptor adaptor,
+      ConversionPatternRewriter& rewriter) const override {
+    Value src = adaptor.getSource();
+    Value tgt = adaptor.getTarget();
+    auto floatOperand = [](Value v) -> bool {
+      if (auto p = dyn_cast<emitc::PointerType>(v.getType()))
+        return isa<FloatType>(p.getPointee());
+      if (auto a = dyn_cast<emitc::ArrayType>(v.getType()))
+        return isa<FloatType>(a.getElementType());
+      return false;
+    };
+    if (!floatOperand(src) || !floatOperand(tgt)) return failure();
+    auto sourceType = cast<MemRefType>(op.getSource().getType());
+    if (!sourceType.hasStaticShape())
+      return rewriter.notifyMatchFailure(op,
+                                         "float copy requires static shape");
+    int64_t n = numElements(sourceType.getShape());
+    // Index both buffers through flat `<elt>*` SSA pointers so a result
+    // out-param target (later flattened to `float*` at the boundary) stays
+    // valid; the printed C++ is unchanged for ordinary C-array copies.
+    Value tgtPtr = addressOfFirstElement(rewriter, op.getLoc(), tgt);
+    Value srcPtr = addressOfFirstElement(rewriter, op.getLoc(), src);
+    std::string fmt = "for (size_t _i = 0; _i < " + std::to_string(n) +
+                      "; ++_i) ({})[_i] = ({})[_i];";
+    markDestination(VerbatimOp::create(rewriter, op.getLoc(), fmt,
+                                       ValueRange{tgtPtr, srcPtr}),
+                    0);
+    rewriter.eraseOp(op);
+    return success();
+  }
+};
+
+// Like upstream ConvertGlobal but tolerates an alignment attribute (bufferized
+// constant float globals carry `alignment = 64`; emitc.global has no alignas).
+// Float globals convert to emitc.array (a C array), which emitc.global accepts
+// and emitc subscripts/get_globals natively.
+struct ConvertGlobalDropAlign
+    : public OpConversionPattern<mlir::memref::GlobalOp> {
+  using OpConversionPattern::OpConversionPattern;
+  LogicalResult matchAndRewrite(
+      mlir::memref::GlobalOp op, OpAdaptor adaptor,
+      ConversionPatternRewriter& rewriter) const override {
+    if (!op.getType().hasStaticShape()) return failure();
+    Type resultTy = getTypeConverter()->convertType(op.getType());
+    if (!isa_and_present<emitc::ArrayType>(resultTy)) return failure();
+    auto vis = SymbolTable::getSymbolVisibility(op);
+    if (vis != SymbolTable::Visibility::Public &&
+        vis != SymbolTable::Visibility::Private)
+      return failure();
+    bool staticSpecifier = vis == SymbolTable::Visibility::Private;
+    Attribute initialValue = adaptor.getInitialValueAttr();
+    if (isa_and_present<UnitAttr>(initialValue)) initialValue = {};
+    // Emit the global non-const even when the source memref is `constant`.
+    // A read-only float buffer arg (e.g. `_assign_layout`'s input) prints as a
+    // plain `float v[1][512]` param -- func.func args carry no const qualifier
+    // in this emitter -- so a `static const float[...]` global cannot bind to
+    // it (`no matching function`). The globals are machine-generated and never
+    // mutated, so dropping `const` is safe and keeps them callable everywhere.
+    auto global = emitc::GlobalOp::create(
+        rewriter, op.getLoc(), adaptor.getSymName(), resultTy, initialValue,
+        /*externSpecifier=*/!staticSpecifier, staticSpecifier,
+        /*constSpecifier=*/false);
+    rewriter.replaceOp(op, global);
+    return success();
+  }
+};
+
+//===----------------------------------------------------------------------===//
+// ConvertToEmitC dialect interface
+//===----------------------------------------------------------------------===//
+
+// Populate target legality, type conversions, and patterns for lowering cheddar
+// (plus the func-boundary structural conversion that keeps `func.func`) to
+// EmitC. Driven by `--convert-to-emitc` (which also pulls in arith/scf/memref
+// via their own interfaces).
+struct CheddarToEmitCDialectInterface : public ConvertToEmitCPatternInterface {
+  CheddarToEmitCDialectInterface(Dialect* dialect)
+      : ConvertToEmitCPatternInterface(dialect) {}
+
+  void populateConvertToEmitCConversionPatterns(
+      ConversionTarget& target, TypeConverter& typeConverter,
+      RewritePatternSet& patterns,
+      std::optional<bool> /*lowerToCpp*/) const final {
+    MLIRContext* ctx = patterns.getContext();
+    addCheddarEmitCTypeConversions(typeConverter, ctx);
+
+    // Keep func.func/return/call (structural type conversion only). The SCF
+    // interface sets markUnknownOpDynamicallyLegal(true), so set the legality
+    // we depend on explicitly rather than relying on defaults.
+    populateFunctionOpInterfaceTypeConversionPattern<func::FuncOp>(
+        patterns, typeConverter);
+    // Gate on signature legality only: requiring the body to also be legal
+    // creates a circular dependency (the driver re-checks the func before
+    // descending into the body), leaving the func "updated in place but still
+    // illegal". Body ops are converted independently by their own patterns.
+    target.addDynamicallyLegalOp<func::FuncOp>(
+        [&typeConverter](func::FuncOp op) {
+          return typeConverter.isSignatureLegal(op.getFunctionType());
+        });
+    populateReturnOpTypeConversionPattern(patterns, typeConverter);
+    target.addDynamicallyLegalOp<func::ReturnOp>(
+        [&typeConverter](func::ReturnOp op) {
+          return typeConverter.isLegal(op);
+        });
+    populateCallOpTypeConversionPattern(patterns, typeConverter);
+    target.addDynamicallyLegalOp<func::CallOp>(
+        [&typeConverter](func::CallOp op) {
+          // A __heir_debug_* call is rewritten to an emitc.call_opaque
+          // "__heir_debug" by ConvertDebugCall; never treat it as legal.
+          return !isDebugPort(op.getCallee()) && typeConverter.isLegal(op);
+        });
+    patterns.add<ConvertDebugCall>(typeConverter, ctx, /*benefit=*/2);
+
+    target.addIllegalDialect<cheddar::CheddarDialect>();
+    target.addIllegalDialect<arith::ArithDialect>();
+    target.addDynamicallyLegalDialect<mlir::memref::MemRefDialect>(
+        [&typeConverter](Operation* op) { return typeConverter.isLegal(op); });
+    // memref.global has no typed operand/result, so the dialect-level isLegal
+    // check above always considers it legal and never converts it -- leaving
+    // the converted emitc.get_global referencing a missing emitc.global. Force
+    // it illegal so ConvertGlobalDropAlign lowers it.
+    target.addIllegalOp<mlir::memref::GlobalOp>();
+
+    // Pull in the stock MemRefToEmitC patterns for the plain float ops
+    // (alloc/load/store/global) at default benefit; the custom payload/float
+    // patterns below at benefit 2 win where they apply. (This helper does not
+    // touch the type converter -- the memref type conversions live in
+    // addCheddarEmitCTypeConversions.)
+    mlir::populateMemRefToEmitCConversionPatterns(patterns, typeConverter);
+
+    // Payload memref ops + float-buffer ops (benefit 2 to win over the stock
+    // MemRefToEmitC patterns added just above).
+    patterns.add<ConvertAllocLocal, EraseDealloc, ConvertLoadArray,
+                 ConvertStoreArray, ConvertCopy, ConvertMemRefCopyFloat,
+                 ConvertSubViewSubscript, ConvertSubViewToPointer,
+                 ConvertPayloadCast, ConvertGlobalDropAlign>(typeConverter,
+                                                              ctx,
+                                                              /*benefit=*/2);
+    patterns.add<RejectMoveOnlyStore, HandleMoveOnlyCopy>(ctx,
+                                                          /*benefit=*/3);
+  }
+};
+
+//===----------------------------------------------------------------------===//
+// cheddar-emitc-boundary pass
+//===----------------------------------------------------------------------===//
+
+// Build the C++ reference type for a converted buffer arg. Every cheddar buffer
+// converts to `lvalue<opaque T>` (T a scalar payload or a `std::array<...>`):
+//   lvalue<opaque T> -> `T&` (written) / `const T&` (read-only).
+// A func/emitc.func cannot carry an lvalue arg, so this is applied to the
+// boundary by the cheddar-emitc-boundary pass.
+Type referenceArgType(MLIRContext* ctx, Type converted, bool written) {
+  // Payload buffer args: lvalue<opaque> -> `T&` / `const T&` (T is a scalar
+  // payload or a std::array of payloads).
+  if (auto l = dyn_cast<emitc::LValueType>(converted)) {
+    auto o = dyn_cast<emitc::OpaqueType>(l.getValueType());
+    if (!o) return {};
+    std::string base = o.getValue().str();
+    return OpaqueType::get(ctx,
+                           written ? (base + "&") : ("const " + base + "&"));
+  }
+  // Non-copyable handle args passed by value would force a move/copy at the
+  // call boundary (Encoder is a reference-holding view; EvkMap and
+  // EvaluationKey are move-only) and mismatch the C++ harness's `const T&`
+  // declarations. They only ever appear as read-only inputs, so tighten to
+  // `const T&`.
+  if (auto o = dyn_cast<emitc::OpaqueType>(converted)) {
+    StringRef n = o.getValue();
+    if (n == "Encoder<word>" || n == "EvkMap<word>" ||
+        n == "EvaluationKey<word>")
+      return OpaqueType::get(ctx, ("const " + n + "&").str());
+  }
+  return {};
+}
+
+// A float-element *result* out-param (carries `bufferize.result`) must match
+// the C++ harness's flat `float*` convention -- the pre-DPS emitter lifted
+// float-array results to `float*`. buffer-results-to-out-params instead hands
+// us a multi-dim C array (`float v[1][10]`), whose param type decays to
+// `float(*)[10]` != `float*` and fails to link. Retype such args to `<elt>*`
+// and rewrite the body's `&arg[0]..[0]` (addressOfFirstElement -- the only way
+// the decode copy touches the buffer) to `arg`. Float *inputs* (images,
+// weights; no `bufferize.result`) keep their multi-dim shape. Returns the
+// pointer type, or {} if the arg isn't a flat-able float-array result.
+Type flattenFloatResultArg(BlockArgument arg) {
+  auto arr = dyn_cast<emitc::ArrayType>(arg.getType());
+  if (!arr || !isa<FloatType>(arr.getElementType())) return {};
+  // Every use must be `address_of(subscript(arg, 0..0))`, so flattening to a
+  // pointer is sound (a residual multi-index subscript on a pointer would be
+  // invalid C++); otherwise bail and leave the arg as a C array.
+  SmallVector<std::pair<emitc::AddressOfOp, emitc::SubscriptOp>> toRewrite;
+  for (OpOperand& use : arg.getUses()) {
+    auto sub = dyn_cast<emitc::SubscriptOp>(use.getOwner());
+    if (!sub || sub.getValue() != arg || !sub.getResult().hasOneUse())
+      return {};
+    auto addr =
+        dyn_cast<emitc::AddressOfOp>(*sub.getResult().getUsers().begin());
+    if (!addr) return {};
+    toRewrite.push_back({addr, sub});
+  }
+  auto ptrTy = emitc::PointerType::get(arr.getElementType());
+  arg.setType(ptrTy);
+  for (auto& [addr, sub] : toRewrite) {
+    addr.getResult().replaceAllUsesWith(arg);
+    addr.erase();
+    sub.erase();
+  }
+  return ptrTy;
+}
+
+// Determine whether an emitted operation writes this value. Conversion
+// patterns mark their exact destination operand; call sites inherit the
+// corresponding callee-argument classification. Subscripts and casts preserve
+// the underlying storage identity for this purpose.
+bool valueWrittenAsDest(
+    Value root,
+    const llvm::StringMap<SmallVector<bool>>& writtenFunctionArguments) {
+  SmallVector<Value> worklist{root};
+  llvm::DenseSet<Value> visited;
+  while (!worklist.empty()) {
+    Value value = worklist.pop_back_val();
+    if (!visited.insert(value).second) continue;
+    for (OpOperand& use : value.getUses()) {
+      Operation* owner = use.getOwner();
+      unsigned operandNumber = use.getOperandNumber();
+      if (getDestinationOperand(owner) == operandNumber) return true;
+      if (auto call = dyn_cast<func::CallOp>(owner)) {
+        auto it = writtenFunctionArguments.find(call.getCallee());
+        if (it != writtenFunctionArguments.end() &&
+            operandNumber < it->second.size() && it->second[operandNumber])
+          return true;
+      }
+      if (auto subscript = dyn_cast<emitc::SubscriptOp>(owner);
+          subscript && operandNumber == 0)
+        worklist.push_back(subscript.getResult());
+      if (auto cast = dyn_cast<UnrealizedConversionCastOp>(owner);
+          cast && cast->getNumResults() == 1)
+        worklist.push_back(cast->getResult(0));
+    }
+  }
+  return false;
+}
+
+struct CheddarToEmitCPass
+    : public impl::CheddarToEmitCBase<CheddarToEmitCPass> {
+  using CheddarToEmitCBase::CheddarToEmitCBase;
+
+  void runOnOperation() override {
+    auto* ctx = &getContext();
+    if (diagnoseUnsupportedGetters(getOperation())) {
+      signalPassFailure();
+      return;
+    }
+
+    // Erase the external `__heir_debug_*` declarations: ConvertDebugCall
+    // already rewrote their call sites to emitc.call_opaque "__heir_debug", and
+    // the upstream Cpp emitter cannot print an external (bodyless) func.func
+    // (it mis-emits it as an empty zero-arg definition). Medusa's C++ prelude
+    // declares + defines `__heir_debug`.
+    SmallVector<func::FuncOp> debugDecls;
+    getOperation()->walk([&](func::FuncOp fn) {
+      if (fn.isExternal() && isDebugPort(fn.getName()))
+        debugDecls.push_back(fn);
+    });
+    for (func::FuncOp fn : debugDecls) fn.erase();
+
+    // Compute mutable arguments to a fixed point over structured func.call
+    // edges. This preserves const-correctness through helper functions without
+    // trying to recover write intent from emitted C++ text.
+    llvm::StringMap<SmallVector<bool>> writtenFunctionArguments;
+    getOperation()->walk([&](func::FuncOp fn) {
+      if (fn.isExternal()) return;
+      SmallVector<bool> written(fn.getNumArguments(), false);
+      for (unsigned i = 0; i < fn.getNumArguments(); ++i)
+        written[i] = static_cast<bool>(fn.getArgAttr(i, "bufferize.result"));
+      writtenFunctionArguments[fn.getName()] = std::move(written);
+    });
+    bool changedWritten;
+    do {
+      changedWritten = false;
+      getOperation()->walk([&](func::FuncOp fn) {
+        if (fn.isExternal()) return;
+        SmallVector<bool>& written = writtenFunctionArguments[fn.getName()];
+        for (unsigned i = 0; i < fn.getNumArguments(); ++i) {
+          if (written[i]) continue;
+          if (valueWrittenAsDest(fn.getArgument(i), writtenFunctionArguments)) {
+            written[i] = true;
+            changedWritten = true;
+          }
+        }
+      });
+    } while (changedWritten);
+
+    // Re-type payload-buffer args (lvalue/array, which a func cannot carry) to
+    // C++ references, mutable iff written.
+    llvm::StringSet<> refified;
+    getOperation()->walk([&](func::FuncOp fn) {
+      if (fn.isExternal()) return;
+      Block& entry = fn.getBody().front();
+      SmallVector<Type> inputs(fn.getFunctionType().getInputs().begin(),
+                               fn.getFunctionType().getInputs().end());
+      // Only the client-decrypt boundary func (whose float result the
+      // hand-written harness declares as `float*`) gets its float-array result
+      // flattened. Internal helpers (e.g. `_assign_layout`) also have
+      // `bufferize.result` float outputs, but their callers are generated code
+      // that passes multi-dim C arrays -- flattening those to `float*` would
+      // break the in-module call (`no matching function`).
+      bool clientDecrypt = fn->hasAttr("client.dec_func");
+      bool changed = false;
+      for (unsigned i = 0; i < inputs.size(); ++i) {
+        bool written = writtenFunctionArguments[fn.getName()][i];
+        Type ref = referenceArgType(ctx, inputs[i], written);
+        if (!ref) {
+          // Not a payload/handle arg. The client-decrypt float-array result
+          // out-param is flattened to a `<elt>*` to match the harness.
+          if (clientDecrypt && fn.getArgAttr(i, "bufferize.result")) {
+            if (Type ptr = flattenFloatResultArg(entry.getArgument(i))) {
+              inputs[i] = ptr;
+              changed = true;
+            }
+          }
+          continue;
+        }
+        inputs[i] = ref;
+        entry.getArgument(i).setType(ref);
+        changed = true;
+      }
+      if (changed) {
+        fn.setType(
+            FunctionType::get(ctx, inputs, fn.getFunctionType().getResults()));
+        refified.insert(fn.getName());
+      }
+    });
+
+    // Cross-function calls to ref-ified callees no longer type-check as
+    // func.call. Keep their operands structured in emitc.call_opaque instead
+    // of formatting the entire call as untyped verbatim text.
+    SmallVector<func::CallOp> callsToRewrite;
+    getOperation()->walk([&](func::CallOp call) {
+      if (refified.contains(call.getCallee())) callsToRewrite.push_back(call);
+    });
+    for (func::CallOp call : callsToRewrite) {
+      OpBuilder b(call);
+      auto rewritten = CallOpaqueOp::create(
+          b, call.getLoc(), call.getResultTypes(),
+          b.getStringAttr(call.getCallee()), /*args=*/ArrayAttr{},
+          /*templateArgs=*/ArrayAttr{}, call.getOperands());
+      call.replaceAllUsesWith(rewritten.getResults());
+      call.erase();
+    }
+
+    // Destination markers are compiler-internal ABI metadata. The C++
+    // translation no longer needs them after argument mutability is fixed.
+    getOperation()->walk(
+        [](Operation* op) { op->removeAttr(kDestinationOperandAttr); });
+
+    // Strip leftover tensor_ext.* boundary metadata (references the
+    // unregistered tensor_ext dialect, which mlir-to-cpp can't parse).
+    getOperation()->walk([](func::FuncOp fn) {
+      auto stripTensorExt =
+          [](DictionaryAttr d) -> std::optional<SmallVector<NamedAttribute>> {
+        if (!d) return std::nullopt;
+        SmallVector<NamedAttribute> kept;
+        for (NamedAttribute a : d)
+          if (!a.getName().strref().starts_with("tensor_ext."))
+            kept.push_back(a);
+        if (kept.size() == d.size()) return std::nullopt;
+        return kept;
+      };
+      for (unsigned i = 0, e = fn.getNumArguments(); i < e; ++i)
+        if (auto kept = stripTensorExt(fn.getArgAttrDict(i)))
+          fn.setArgAttrs(i, *kept);
+      for (unsigned i = 0, e = fn.getNumResults(); i < e; ++i)
+        if (auto kept = stripTensorExt(fn.getResultAttrDict(i)))
+          fn.setResultAttrs(i, *kept);
+    });
+  }
+};
+
+}  // namespace
+
+void registerCheddarConvertToEmitCInterface(DialectRegistry& registry) {
+  registry.addExtension(
+      +[](MLIRContext* ctx, cheddar::CheddarDialect* dialect) {
+        dialect->addInterfaces<CheddarToEmitCDialectInterface>();
+      });
+}
+
+void registerCheddarToEmitCExternalModels(DialectRegistry& registry) {
+  registry.addExtension(+[](MLIRContext* ctx, mlir::emitc::EmitCDialect*) {
+    mlir::emitc::OpaqueType::attachInterface<EmitCOpaqueAsMemRefElement>(*ctx);
+  });
+}
+
+}  // namespace mlir::heir

--- a/lib/Conversions/CheddarToEmitC/CheddarToEmitC.cpp
+++ b/lib/Conversions/CheddarToEmitC/CheddarToEmitC.cpp
@@ -1,5 +1,7 @@
 #include "lib/Conversions/CheddarToEmitC/CheddarToEmitC.h"
 
+#include <cstdio>
+#include <functional>
 #include <optional>
 #include <string>
 
@@ -21,13 +23,14 @@
 #include "mlir/include/mlir/Dialect/Func/Transforms/FuncConversions.h"  // from @llvm-project
 #include "mlir/include/mlir/Dialect/MemRef/IR/MemRef.h"  // from @llvm-project
 #include "mlir/include/mlir/Dialect/MemRef/Utils/MemRefUtils.h"  // from @llvm-project
-#include "mlir/include/mlir/Dialect/SCF/IR/SCF.h"     // from @llvm-project
-#include "mlir/include/mlir/IR/BuiltinAttributes.h"   // from @llvm-project
-#include "mlir/include/mlir/IR/BuiltinOps.h"          // from @llvm-project
-#include "mlir/include/mlir/IR/BuiltinTypes.h"        // from @llvm-project
-#include "mlir/include/mlir/IR/PatternMatch.h"        // from @llvm-project
-#include "mlir/include/mlir/IR/SymbolTable.h"         // from @llvm-project
-#include "mlir/include/mlir/IR/Value.h"               // from @llvm-project
+#include "mlir/include/mlir/Dialect/SCF/IR/SCF.h"    // from @llvm-project
+#include "mlir/include/mlir/IR/BuiltinAttributes.h"  // from @llvm-project
+#include "mlir/include/mlir/IR/BuiltinOps.h"         // from @llvm-project
+#include "mlir/include/mlir/IR/BuiltinTypes.h"       // from @llvm-project
+#include "mlir/include/mlir/IR/PatternMatch.h"       // from @llvm-project
+#include "mlir/include/mlir/IR/SymbolTable.h"        // from @llvm-project
+#include "mlir/include/mlir/IR/Value.h"              // from @llvm-project
+#include "mlir/include/mlir/Interfaces/DestinationStyleOpInterface.h"  // from @llvm-project
 #include "mlir/include/mlir/Support/LLVM.h"           // from @llvm-project
 #include "mlir/include/mlir/Support/LogicalResult.h"  // from @llvm-project
 #include "mlir/include/mlir/Transforms/DialectConversion.h"  // from @llvm-project
@@ -114,6 +117,25 @@ std::string owningHandleTypeName(Type t) {
   return "";
 }
 
+std::string intLit(IntegerAttr a) { return std::to_string(a.getInt()); }
+
+std::string floatLit(FloatAttr a) {
+  // Full double precision (%.17g round-trips exactly); the default formatv
+  // precision silently corrupts literal scales.
+  char buf[40];
+  std::snprintf(buf, sizeof(buf), "%.17g", a.getValueAsDouble());
+  return std::string(buf);
+}
+
+std::string floatArrayLit(ArrayAttr a) {
+  std::string s = "{";
+  for (size_t i = 0; i < a.size(); ++i) {
+    if (i > 0) s += ", ";
+    s += floatLit(cast<FloatAttr>(a[i]));
+  }
+  return s + "}";
+}
+
 int64_t numElements(ArrayRef<int64_t> shape) {
   int64_t result = 1;
   for (int64_t dim : shape) result *= dim;
@@ -136,6 +158,29 @@ Value addressOfFirstElement(OpBuilder& b, Location loc, Value array) {
       emitc::SubscriptOp::create(b, loc, lvalueTy, array, zeroIdxs);
   return emitc::AddressOfOp::create(
       b, loc, emitc::PointerType::get(arrayTy.getElementType()), firstElement);
+}
+
+// Emit `receiver.method(out, args..., extra)` (or `receiver->method(...)` for a
+// pointer receiver). Trailing literal text (`extra`) is appended as one opaque
+// constant arg.
+void emitOutParamCall(OpBuilder& b, Location loc, Value receiver,
+                      StringRef method, Value out, ValueRange args,
+                      StringRef extra = "") {
+  SmallVector<Value> argOperands{out};
+  argOperands.append(args.begin(), args.end());
+  ArrayAttr argsAttr;
+  if (!extra.empty()) {
+    SmallVector<Attribute> a;
+    for (size_t i = 0; i < argOperands.size(); ++i)
+      a.push_back(b.getIndexAttr(i));
+    a.push_back(emitc::OpaqueAttr::get(b.getContext(), extra));
+    argsAttr = b.getArrayAttr(a);
+  }
+  markDestination(
+      MemberCallOpaqueOp::create(b, loc, /*resultTypes=*/TypeRange{}, receiver,
+                                 b.getStringAttr(method), argsAttr,
+                                 /*template_args=*/ArrayAttr{}, argOperands),
+      1);
 }
 
 //===----------------------------------------------------------------------===//
@@ -262,6 +307,314 @@ bool diagnoseUnsupportedGetters(Operation* root) {
 //===----------------------------------------------------------------------===//
 // Conversion patterns
 //===----------------------------------------------------------------------===//
+
+// Generic destination-passing op -> a single out-parameter method call:
+//   receiver->Method(dest, inputs..., extra)
+template <typename Op>
+struct OutParamDpsPattern : public OpConversionPattern<Op> {
+  OutParamDpsPattern(const TypeConverter& tc, MLIRContext* ctx,
+                     StringRef method,
+                     std::function<std::string(Op)> extra = nullptr)
+      : OpConversionPattern<Op>(tc, ctx),
+        method(method.str()),
+        extra(std::move(extra)) {}
+
+  LogicalResult matchAndRewrite(
+      Op op, typename Op::Adaptor adaptor,
+      ConversionPatternRewriter& rewriter) const override {
+    auto dpsOp = cast<DestinationStyleOpInterface>(op.getOperation());
+    unsigned initIdx = dpsOp.getDpsInitOperand(0)->getOperandNumber();
+    auto operands = adaptor.getOperands();
+    Value receiver = operands[0];
+    Value dest = operands[initIdx];
+    SmallVector<Value> inputs;
+    for (unsigned i = 1; i < operands.size(); ++i)
+      if (i != initIdx) inputs.push_back(operands[i]);
+    std::string extraStr = extra ? extra(op) : "";
+    emitOutParamCall(rewriter, op.getLoc(), receiver, method, dest, inputs,
+                     extraStr);
+    rewriter.eraseOp(op);
+    return success();
+  }
+
+  std::string method;
+  std::function<std::string(Op)> extra;
+};
+
+// cheddar.encode: fill a std::vector<Complex> from the float message buffer,
+// then encode at the requested logarithmic scale, or CHEDDAR's canonical scale
+// for the level when no explicit scale is present.
+struct ConvertEncode : public OpConversionPattern<cheddar::EncodeOp> {
+  using OpConversionPattern::OpConversionPattern;
+  LogicalResult matchAndRewrite(
+      cheddar::EncodeOp op, OpAdaptor adaptor,
+      ConversionPatternRewriter& rewriter) const override {
+    Value out = adaptor.getOutput();
+    std::string lvl = std::to_string(op.getLevelAttr().getInt());
+    Value msg = adaptor.getMessage();
+    auto messageType = dyn_cast<ShapedType>(op.getMessage().getType());
+    if (!messageType || !messageType.hasStaticShape())
+      return rewriter.notifyMatchFailure(
+          op, "encode requires a static message shape");
+    int64_t n = numElements(messageType.getShape());
+    // Flatten both a whole (possibly multidimensional) C array and a subview
+    // pointer to the first scalar element before constructing the vector.
+    Value begin = addressOfFirstElement(rewriter, op.getLoc(), msg);
+    Value vec =
+        VariableOp::create(rewriter, op.getLoc(),
+                           LValueType::get(OpaqueType::get(
+                               rewriter.getContext(), "std::vector<Complex>")),
+                           OpaqueAttr::get(rewriter.getContext(), ""));
+    VerbatimOp::create(
+        rewriter, op.getLoc(),
+        "{} = std::vector<Complex>({}, {} + " + std::to_string(n) + ");",
+        ValueRange{vec, begin, begin});
+    // TODO(#2364): Use scale from op once HEIR can do precise scale tracking.
+    std::string scale = "{}.GetScale(" + lvl + ")";
+    SmallVector<Value> operands{adaptor.getEncoder(), out,
+                                adaptor.getEncoder()};
+    operands.push_back(vec);
+    markDestination(
+        VerbatimOp::create(rewriter, op.getLoc(),
+                           "{}.Encode({}, " + lvl + ", " + scale + ", {});",
+                           operands),
+        1);
+    rewriter.eraseOp(op);
+    return success();
+  }
+};
+
+// cheddar.encode_constant: encode at the same canonical per-level scale.
+struct ConvertEncodeConstant
+    : public OpConversionPattern<cheddar::EncodeConstantOp> {
+  using OpConversionPattern::OpConversionPattern;
+  LogicalResult matchAndRewrite(
+      cheddar::EncodeConstantOp op, OpAdaptor adaptor,
+      ConversionPatternRewriter& rewriter) const override {
+    std::string lvl = intLit(op.getLevelAttr());
+    std::string fmt =
+        "{}.EncodeConstant({}, " + lvl + ", {}.GetScale(" + lvl + "), {});";
+    markDestination(VerbatimOp::create(
+                        rewriter, op.getLoc(), fmt,
+                        ValueRange{adaptor.getEncoder(), adaptor.getOutput(),
+                                   adaptor.getEncoder(), adaptor.getValue()}),
+                    1);
+    rewriter.eraseOp(op);
+    return success();
+  }
+};
+
+// cheddar.decode: decode into a temporary complex vector, copy real parts into
+// the float destination buffer.
+struct ConvertDecode : public OpConversionPattern<cheddar::DecodeOp> {
+  using OpConversionPattern::OpConversionPattern;
+  LogicalResult matchAndRewrite(
+      cheddar::DecodeOp op, OpAdaptor adaptor,
+      ConversionPatternRewriter& rewriter) const override {
+    Value dst = adaptor.getValue();
+    if (!isa<emitc::ArrayType, emitc::LValueType>(dst.getType()))
+      return failure();
+    auto memTy = dyn_cast<MemRefType>(op.getValue().getType());
+    if (!memTy || !memTy.hasStaticShape() ||
+        !isa<FloatType>(memTy.getElementType()))
+      return failure();
+    auto shape = memTy.getShape();
+    std::string idxPrefix;
+    for (size_t i = 0; i + 1 < shape.size(); ++i) {
+      if (shape[i] != 1) return failure();
+      idxPrefix += "[0]";
+    }
+    auto* ctx = rewriter.getContext();
+    Value vec = VariableOp::create(
+        rewriter, op.getLoc(),
+        LValueType::get(OpaqueType::get(ctx, "std::vector<Complex>")),
+        OpaqueAttr::get(ctx, ""));
+    markDestination(
+        VerbatimOp::create(
+            rewriter, op.getLoc(), "{}.Decode({}, {});",
+            ValueRange{adaptor.getEncoder(), vec, adaptor.getPlaintext()}),
+        1);
+    markDestination(
+        VerbatimOp::create(rewriter, op.getLoc(),
+                           "for (size_t _i = 0; _i < " +
+                               std::to_string(shape.back()) + "; ++_i) {}" +
+                               idxPrefix + "[_i] = {}.at(_i).real();",
+                           ValueRange{dst, vec}),
+        0);
+    rewriter.eraseOp(op);
+    return success();
+  }
+};
+
+// HRot/HRotAdd/HConj/HConjAdd: look up the rotation/conjugation key inline.
+struct ConvertHRot : public OpConversionPattern<cheddar::HRotOp> {
+  using OpConversionPattern::OpConversionPattern;
+  LogicalResult matchAndRewrite(
+      cheddar::HRotOp op, OpAdaptor adaptor,
+      ConversionPatternRewriter& rewriter) const override {
+    Value ui = adaptor.getUi();
+    Value out = adaptor.getOutput();
+    if (auto sd = op.getStaticDistanceAttr()) {
+      std::string d = intLit(sd);
+      markDestination(
+          VerbatimOp::create(
+              rewriter, op.getLoc(),
+              "{}->HRot({}, {}, {}->GetRotationKey(" + d + "), " + d + ");",
+              ValueRange{adaptor.getCtx(), out, adaptor.getInput(), ui}),
+          1);
+    } else {
+      Value dyn = adaptor.getDynamicDistance();
+      markDestination(
+          VerbatimOp::create(rewriter, op.getLoc(),
+                             "{}->HRot({}, {}, {}->GetRotationKey({}), {});",
+                             ValueRange{adaptor.getCtx(), out,
+                                        adaptor.getInput(), ui, dyn, dyn}),
+          1);
+    }
+    rewriter.eraseOp(op);
+    return success();
+  }
+};
+
+struct ConvertHRotAdd : public OpConversionPattern<cheddar::HRotAddOp> {
+  using OpConversionPattern::OpConversionPattern;
+  LogicalResult matchAndRewrite(
+      cheddar::HRotAddOp op, OpAdaptor adaptor,
+      ConversionPatternRewriter& rewriter) const override {
+    Value ui = adaptor.getUi();
+    std::string d = intLit(op.getDistanceAttr());
+    markDestination(
+        VerbatimOp::create(
+            rewriter, op.getLoc(),
+            "{}->HRotAdd({}, {}, {}, {}->GetRotationKey(" + d + "), " + d +
+                ");",
+            ValueRange{adaptor.getCtx(), adaptor.getOutput(),
+                       adaptor.getInput(), adaptor.getAddend(), ui}),
+        1);
+    rewriter.eraseOp(op);
+    return success();
+  }
+};
+
+struct ConvertHConj : public OpConversionPattern<cheddar::HConjOp> {
+  using OpConversionPattern::OpConversionPattern;
+  LogicalResult matchAndRewrite(
+      cheddar::HConjOp op, OpAdaptor adaptor,
+      ConversionPatternRewriter& rewriter) const override {
+    Value ui = adaptor.getUi();
+    markDestination(
+        VerbatimOp::create(rewriter, op.getLoc(),
+                           "{}->HConj({}, {}, {}->GetConjugationKey());",
+                           ValueRange{adaptor.getCtx(), adaptor.getOutput(),
+                                      adaptor.getInput(), ui}),
+        1);
+    rewriter.eraseOp(op);
+    return success();
+  }
+};
+
+struct ConvertHConjAdd : public OpConversionPattern<cheddar::HConjAddOp> {
+  using OpConversionPattern::OpConversionPattern;
+  LogicalResult matchAndRewrite(
+      cheddar::HConjAddOp op, OpAdaptor adaptor,
+      ConversionPatternRewriter& rewriter) const override {
+    Value ui = adaptor.getUi();
+    markDestination(
+        VerbatimOp::create(
+            rewriter, op.getLoc(),
+            "{}->HConjAdd({}, {}, {}, {}->GetConjugationKey());",
+            ValueRange{adaptor.getCtx(), adaptor.getOutput(),
+                       adaptor.getInput(), adaptor.getAddend(), ui}),
+        1);
+    rewriter.eraseOp(op);
+    return success();
+  }
+};
+
+// cheddar.eval_poly -> the real cheddar::EvalPoly<word> class (no free
+// `RunEvalPoly` exists). It is a stateful object: construct, Compile, then
+// Evaluate. Critically, EvalPoly's Chebyshev basis recurrence (T_{2n}=2T_n^2-1)
+// propagates scale as `x_scale*y_scale/param_.GetRescalePrimeProd(level)`, and
+// the constructor's `input_scale`/`target_scale`/`input_level` SEED that
+// recurrence -- cheddar's asserts only check self-consistency with these args,
+// not against the real q-products, so a wrong seed silently squares into a
+// catastrophic blow-up (e.g. a degree-15 sign poly returning ~1e105) while the
+// scale *label* stays canonical. So we must mirror exactly how cheddar's own
+// EvalMod seeds EvalPoly: take the level/scale from the *actual* input
+// ciphertext and derive target_scale by the same square/divide recurrence.
+//
+//   {
+//     ConstContextPtr<word> cp(ConstContextPtr<word>(), ctx);
+//     int lvl = ctx->param_.NPToLevel(in.GetNP());
+//     double is = in.GetScale();
+//     double ts = is;
+//     ts = ts*ts / ctx->param_.GetRescalePrimeProd(lvl - 0);   // x
+//     level_consumption
+//     ...
+//     cheddar::EvalPoly<word> ep({coeffs}, lvl, is, ts, /*chebyshev=*/true);
+//     ep.Compile(cp);
+//     ep.Evaluate(cp, out, in, evk.GetMultiplicationKey());
+//   }
+//
+// This needs `in.GetScale()`/`in.GetNP()` (whose receiver is a move-only lvalue
+// ciphertext that emitc.member_call_opaque rejects), `ctx->param_` (a nested
+// member access), and a per-level recurrence -- so it is emitted as verbatim
+// statements. These are all real cheddar public API (the inline equivalent of
+// EvalMod), not a shim. A `{ }` block scope destroys the EvalPoly (which holds
+// the GPU power basis) right after Evaluate; its locals stay block-local so
+// repeated eval_poly ops in one function do not collide.
+struct ConvertEvalPoly : public OpConversionPattern<cheddar::EvalPolyOp> {
+  using OpConversionPattern::OpConversionPattern;
+  LogicalResult matchAndRewrite(
+      cheddar::EvalPolyOp op, OpAdaptor adaptor,
+      ConversionPatternRewriter& rewriter) const override {
+    Location loc = op.getLoc();
+    Value ctxV = adaptor.getCtx();
+    Value in = adaptor.getInput();
+    Value out = adaptor.getOutput();
+    Value evk = adaptor.getEvkMap();
+    int64_t levelConsumption = op.getLevelConsumptionAttr().getInt();
+
+    auto emit = [&](const Twine& fmt, ValueRange operands) {
+      VerbatimOp::create(rewriter, loc, rewriter.getStringAttr(fmt.str()),
+                         operands);
+    };
+
+    emit("{", {});
+    // Compile/Evaluate take a ConstContextPtr (shared_ptr<const Context>); wrap
+    // the raw Context* in a non-owning alias (it does not own the context).
+    emit("ConstContextPtr<word> _ep_cp(ConstContextPtr<word>(), {});", {ctxV});
+    // level + input scale taken from the actual input ciphertext.
+    emit("int _ep_lvl = {}->param_.NPToLevel({}.GetNP());", {ctxV, in});
+    emit("double _ep_is = {}.GetScale();", {in});
+    // target_scale recurrence: ts <- ts*ts / GetRescalePrimeProd(lvl - i).
+    emit("double _ep_ts = _ep_is;", {});
+    for (int64_t i = 0; i < levelConsumption; ++i)
+      emit(
+          "_ep_ts = _ep_ts * _ep_ts / {}->param_.GetRescalePrimeProd(_ep_lvl "
+          "- " +
+              Twine(i) + ");",
+          {ctxV});
+    // Construct (no operands -> the coefficient brace-list is emitted
+    // verbatim).
+    emit("cheddar::EvalPoly<word> _ep(" +
+             floatArrayLit(op.getCoefficientsAttr()) +
+             ", _ep_lvl, _ep_is, _ep_ts, true);",
+         {});
+    emit("_ep.Compile(_ep_cp);", {});
+    markDestination(
+        VerbatimOp::create(
+            rewriter, loc,
+            rewriter.getStringAttr(
+                "_ep.Evaluate(_ep_cp, {}, {}, {}.GetMultiplicationKey());"),
+            ValueRange{out, in, evk}),
+        0);
+    emit("}", {});
+
+    rewriter.eraseOp(op);
+    return success();
+  }
+};
 
 // A `__heir_debug_*` call (from --lwe-add-debug-port, re-shaped by LWEToCheddar
 // to (Encoder, UserInterface, Ciphertext)) -> a free C++ call to an
@@ -448,7 +801,7 @@ struct RejectMoveOnlyStore : public OpRewritePattern<mlir::memref::StoreOp> {
         !isa<cheddar::UserInterfaceType>(elementType))
       return failure();
     return op.emitOpError(
-        "copying a move-only Cheddar value with memref.store is invalid");
+        "copying a move-only Cheddar payload with memref.store is invalid");
   }
 };
 
@@ -458,15 +811,58 @@ struct HandleMoveOnlyCopy : public OpRewritePattern<mlir::memref::CopyOp> {
                                 PatternRewriter& rewriter) const override {
     auto sourceType = cast<MemRefType>(op.getSource().getType());
     Type elementType = sourceType.getElementType();
+    if (op.getSource() == op.getTarget()) {
+      rewriter.eraseOp(op);
+      return success();
+    }
+    if (isa<cheddar::CiphertextType>(elementType)) return failure();
     if (payloadTypeName(elementType).empty() &&
         !isa<cheddar::UserInterfaceType>(elementType))
+      return failure();
+    return op.emitOpError(
+        "copying a move-only Cheddar value with memref.copy is invalid");
+  }
+};
+
+// Copies that survive bufferization's standard alias folding have true copy
+// semantics. Lower ciphertext copies through CHEDDAR's deep-copy API instead
+// of reinterpreting them as C++ assignment or ownership transfer.
+struct ConvertCiphertextCopy
+    : public OpConversionPattern<mlir::memref::CopyOp> {
+  using OpConversionPattern::OpConversionPattern;
+  LogicalResult matchAndRewrite(
+      mlir::memref::CopyOp op, OpAdaptor adaptor,
+      ConversionPatternRewriter& rewriter) const override {
+    auto sourceType = cast<MemRefType>(op.getSource().getType());
+    if (!isa<cheddar::CiphertextType>(sourceType.getElementType()))
       return failure();
     if (op.getSource() == op.getTarget()) {
       rewriter.eraseOp(op);
       return success();
     }
-    return op.emitOpError(
-        "copying a move-only Cheddar value with memref.copy is invalid");
+
+    Value context;
+    if (auto function = op->getParentOfType<func::FuncOp>()) {
+      for (BlockArgument argument : function.getArguments()) {
+        auto pointer = dyn_cast<emitc::PointerType>(argument.getType());
+        auto opaque = pointer
+                          ? dyn_cast<emitc::OpaqueType>(pointer.getPointee())
+                          : emitc::OpaqueType();
+        if (opaque && (opaque.getValue() == "Context<word>" ||
+                       opaque.getValue() == "BootContext<word>")) {
+          context = argument;
+          break;
+        }
+      }
+    }
+    if (!context)
+      return op.emitOpError(
+          "cannot deep-copy a Cheddar ciphertext without a context argument");
+
+    emitOutParamCall(rewriter, op.getLoc(), context, "Copy",
+                     adaptor.getTarget(), ValueRange{adaptor.getSource()});
+    rewriter.eraseOp(op);
+    return success();
   }
 };
 
@@ -816,6 +1212,42 @@ struct CheddarToEmitCDialectInterface : public ConvertToEmitCPatternInterface {
                                                               /*benefit=*/2);
     patterns.add<RejectMoveOnlyStore, HandleMoveOnlyCopy>(ctx,
                                                           /*benefit=*/3);
+    patterns.add<ConvertCiphertextCopy>(typeConverter, ctx, /*benefit=*/3);
+
+    patterns
+        .add<ConvertEncode, ConvertEncodeConstant, ConvertDecode, ConvertHRot,
+             ConvertHRotAdd, ConvertHConj, ConvertHConjAdd, ConvertEvalPoly>(
+            typeConverter, ctx);
+
+    auto addDps = [&](StringRef name, auto opTag,
+                      std::function<std::string(decltype(opTag))> extra =
+                          nullptr) {
+      using Op = decltype(opTag);
+      patterns.add<OutParamDpsPattern<Op>>(typeConverter, ctx, name, extra);
+    };
+    addDps("Copy", cheddar::CopyOp{});
+    addDps("Add", cheddar::AddOp{});
+    addDps("Sub", cheddar::SubOp{});
+    addDps("Mult", cheddar::MultOp{});
+    addDps("Add", cheddar::AddPlainOp{});
+    addDps("Sub", cheddar::SubPlainOp{});
+    addDps("Mult", cheddar::MultPlainOp{});
+    addDps("Add", cheddar::AddConstOp{});
+    addDps("Mult", cheddar::MultConstOp{});
+    addDps("Neg", cheddar::NegOp{});
+    addDps("Rescale", cheddar::RescaleOp{});
+    addDps("Relinearize", cheddar::RelinearizeOp{});
+    addDps("RelinearizeRescale", cheddar::RelinearizeRescaleOp{});
+    addDps("Encrypt", cheddar::EncryptOp{});
+    addDps("Decrypt", cheddar::DecryptOp{});
+    addDps("MadUnsafe", cheddar::MadUnsafeOp{});
+    addDps("Boot", cheddar::BootOp{});
+    addDps("LevelDown", cheddar::LevelDownOp{}, [](cheddar::LevelDownOp op) {
+      return intLit(op.getTargetLevelAttr());
+    });
+    addDps("HMult", cheddar::HMultOp{}, [](cheddar::HMultOp op) {
+      return op.getRescale() ? std::string("true") : std::string("false");
+    });
   }
 };
 

--- a/lib/Conversions/CheddarToEmitC/CheddarToEmitC.h
+++ b/lib/Conversions/CheddarToEmitC/CheddarToEmitC.h
@@ -1,0 +1,30 @@
+#ifndef LIB_CONVERSIONS_CHEDDARTOEMITC_CHEDDARTOEMITC_H_
+#define LIB_CONVERSIONS_CHEDDARTOEMITC_CHEDDARTOEMITC_H_
+
+#include "mlir/include/mlir/IR/DialectRegistry.h"  // from @llvm-project
+#include "mlir/include/mlir/Pass/Pass.h"           // from @llvm-project
+
+namespace mlir::heir {
+
+// Attaches MemRefElementTypeInterface as an external (marker-only) model to
+// emitc::OpaqueType. Needed so that the cheddar-to-emitc type converter can
+// form `memref<Nx!emitc.opaque<...>>` as the converted form of
+// `memref<Nx!cheddar.*>` after bufferization. Call once at tool startup.
+void registerCheddarToEmitCExternalModels(DialectRegistry& registry);
+
+// Attaches the cheddar `ConvertToEmitCPatternInterface` so that
+// `--convert-to-emitc` lowers cheddar ops (and keeps `func.func` boundaries via
+// a structural type conversion) to EmitC. Call once at tool startup. Run
+// `--convert-to-emitc=filter-dialects=cheddar,arith,scf` followed by the
+// `cheddar-emitc-boundary` pass.
+void registerCheddarConvertToEmitCInterface(DialectRegistry& registry);
+
+#define GEN_PASS_DECL
+#include "lib/Conversions/CheddarToEmitC/CheddarToEmitC.h.inc"
+
+#define GEN_PASS_REGISTRATION
+#include "lib/Conversions/CheddarToEmitC/CheddarToEmitC.h.inc"
+
+}  // namespace mlir::heir
+
+#endif  // LIB_CONVERSIONS_CHEDDARTOEMITC_CHEDDARTOEMITC_H_

--- a/lib/Conversions/CheddarToEmitC/CheddarToEmitC.td
+++ b/lib/Conversions/CheddarToEmitC/CheddarToEmitC.td
@@ -1,0 +1,39 @@
+#ifndef LIB_CONVERSIONS_CHEDDARTOEMITC_CHEDDARTOEMITC_TD_
+#define LIB_CONVERSIONS_CHEDDARTOEMITC_CHEDDARTOEMITC_TD_
+
+include "mlir/Pass/PassBase.td"
+
+def CheddarToEmitC : Pass<"cheddar-emitc-boundary"> {
+  let summary = "Fix up EmitC function boundaries for the CHEDDAR move-only ABI.";
+
+  let description = [{
+    Runs after `--convert-to-emitc` (which lowers the cheddar/arith/scf/memref
+    ops via their `ConvertToEmitCPatternInterface` implementations). The cheddar
+    payload types are move-only and live in `emitc.lvalue`/`emitc.array` local
+    buffers, but a function cannot carry an `lvalue`/array argument. This pass
+    re-types each payload-buffer function argument to a C++ reference
+    (`const T&` for a read-only input, `T&`/`std::array<T,N>&` for a written
+    out-param/in-place buffer), re-emits cross-function calls to such functions
+    as structured `emitc.call_opaque` operations (their operand types no longer
+    match the reference-typed parameters), and strips HEIR-internal `tensor_ext.*`
+    boundary metadata that `mlir-translate --mlir-to-cpp` cannot parse.
+
+    (* example filepath=tests/Conversions/CheddarToEmitC/doctest.mlir *)
+  }];
+
+  // Also list the dialects that the preceding `--convert-to-emitc` restricts to
+  // via `filter-dialects=cheddar,arith,scf`: that pass errors if a
+  // filtered dialect is not *loaded*, and a program without loops/allocs would
+  // not otherwise load scf/memref. Declaring them here (this pass always runs
+  // right after convert-to-emitc) forces them loaded at pass-manager init.
+  let dependentDialects = [
+    "::mlir::emitc::EmitCDialect",
+    "::mlir::func::FuncDialect",
+    "::mlir::arith::ArithDialect",
+    "::mlir::scf::SCFDialect",
+    "::mlir::memref::MemRefDialect",
+    "::mlir::heir::cheddar::CheddarDialect",
+  ];
+}
+
+#endif  // LIB_CONVERSIONS_CHEDDARTOEMITC_CHEDDARTOEMITC_TD_

--- a/lib/Dialect/Cheddar/IR/BUILD
+++ b/lib/Dialect/Cheddar/IR/BUILD
@@ -27,6 +27,7 @@ cc_library(
         ":types_inc_gen",
         "@heir//lib/Dialect:HEIRInterfaces",
         "@llvm-project//llvm:Support",
+        "@llvm-project//mlir:ConvertToEmitCInterface",
         "@llvm-project//mlir:DestinationStyleOpInterface",
         "@llvm-project//mlir:IR",
         "@llvm-project//mlir:InferTypeOpInterface",

--- a/lib/Dialect/Cheddar/IR/CheddarDialect.cpp
+++ b/lib/Dialect/Cheddar/IR/CheddarDialect.cpp
@@ -1,6 +1,7 @@
 #include "lib/Dialect/Cheddar/IR/CheddarDialect.h"
 
-#include "llvm/include/llvm/ADT/TypeSwitch.h"            // from @llvm-project
+#include "llvm/include/llvm/ADT/TypeSwitch.h"  // from @llvm-project
+#include "mlir/include/mlir/Conversion/ConvertToEmitC/ToEmitCInterface.h"  // from @llvm-project
 #include "mlir/include/mlir/IR/Builders.h"               // from @llvm-project
 #include "mlir/include/mlir/IR/DialectImplementation.h"  // from @llvm-project
 
@@ -32,6 +33,12 @@ void CheddarDialect::initialize() {
 #define GET_OP_LIST
 #include "lib/Dialect/Cheddar/IR/CheddarOps.cpp.inc"
       >();
+
+  // The actual interface implementation is attached as an external model by
+  // `registerCheddarConvertToEmitCInterface` (see CheddarToEmitC), so that the
+  // dialect library doesn't depend on the conversion library.
+  declarePromisedInterface<mlir::ConvertToEmitCPatternInterface,
+                           CheddarDialect>();
 }
 
 }  // namespace cheddar

--- a/lib/Dialect/Cheddar/IR/CheddarOps.cpp
+++ b/lib/Dialect/Cheddar/IR/CheddarOps.cpp
@@ -54,7 +54,11 @@ LogicalResult LinearTransformOp::verify() {
   return success();
 }
 
-LogicalResult EvalPolyOp::verify() { return success(); }
+LogicalResult EvalPolyOp::verify() {
+  if (getLevelConsumption().getInt() < 2)
+    return emitOpError("level consumption must be at least two");
+  return success();
+}
 
 }  // namespace cheddar
 }  // namespace heir

--- a/lib/Dialect/Cheddar/IR/CheddarOps.td
+++ b/lib/Dialect/Cheddar/IR/CheddarOps.td
@@ -85,6 +85,10 @@ def Cheddar_FloatLike : TensorOrMemRef<[AnyFloat, AnyComplex]>;
 def Cheddar_CtResult : Variadic<RankedTensorOf<[Cheddar_Ciphertext]>>;
 def Cheddar_PtResult : Variadic<RankedTensorOf<[Cheddar_Plaintext]>>;
 def Cheddar_ConstResult : Variadic<RankedTensorOf<[Cheddar_Constant]>>;
+def Cheddar_LinearTransformLike :
+    TensorOrMemRef<[Cheddar_LinearTransform]>;
+def Cheddar_LinearTransformResult :
+    Variadic<RankedTensorOf<[Cheddar_LinearTransform]>>;
 
 // Owning setup-handle destinations. The `create_*` setup ops are
 // destination-passing like the payload ops: in tensor form they produce an SSA
@@ -251,12 +255,12 @@ def Cheddar_MakeParameterOp : Cheddar_Op<"make_parameter", [Pure]> {
   let description = [{
     Builds a `cheddar::Parameter<word>` from the CKKS modulus chain. The main
     primes are the CKKS `Q` limbs and the aux primes are the `P` limbs; the
-    canonical level config is one-main-prime-per-level (`{{1, 0}, {2, 0}, ...}`)
-    and the default encryption level is `#mainPrimes - 1`, both derived from
-    `mainPrimes` by the emitter. `logScale` is the log2 of the default CKKS
-    scale. This is the single setup op that produces the `!cheddar.parameter`
-    consumed by `cheddar.create_context`, so a generated `__configure` is
-    self-contained.
+    canonical level config is one-main-prime-per-level (`{{1, 0}, {2, 0}, ...}`).
+    The default encryption level is `#mainPrimes - 1` for an ordinary context;
+    a boot context instead uses CHEDDAR's required SlotToCoeff start level.
+    `logScale` is the log2 of the default CKKS scale. This is the single setup
+    op that produces the `!cheddar.parameter` consumed by
+    `cheddar.create_context`, so a generated `__configure` is self-contained.
 
     Bootstrapping programs override the defaults: `defaultEncryptionLevel`
     pins the encryption level below the chain top (the boot-circuit primes sit
@@ -285,17 +289,16 @@ def Cheddar_MakeParameterOp : Cheddar_Op<"make_parameter", [Pure]> {
 def Cheddar_EncodeOp : Cheddar_DpsOp<"encode", [PlaintextEncodeOpInterface]> {
   let summary = "Encode a message vector into a CHEDDAR plaintext";
   let description = [{
-    Calls encoder.Encode(pt, level, encoder.GetScale(level), message). The
-    message is a vector of complex numbers (or reals). CHEDDAR derives the
-    exact RNS scale from the target level; HEIR's logarithmic scale metadata
-    is resolved by scale management before lowering to this operation.
-    `$output` is the destination plaintext.
+    Calls encoder.Encode(pt, level, scale, message). The message is a vector
+    of complex numbers (or reals). `logScale` preserves HEIR's logarithmic
+    scale metadata for future use. `$output` is the destination plaintext.
   }];
   let arguments = (ins
     Cheddar_Encoder:$encoder,
     Cheddar_FloatLike:$message,
     Cheddar_PtLike:$output,
-    Builtin_IntegerAttr:$level
+    Builtin_IntegerAttr:$level,
+    OptionalAttr<Builtin_IntegerAttr>:$logScale
   );
   let results = (outs Cheddar_PtResult:$result);
 }
@@ -691,6 +694,8 @@ def Cheddar_LinearTransformOp : Cheddar_DpsOp<"linear_transform", [
     The `diagonals` input is a 2D tensor where each row is a non-zero diagonal.
     The `diagonal_indices` attribute specifies which diagonal each row represents.
     The `level` attribute specifies the modulus level for the operation.
+    `min_ks` selects scale-snu's minimum-key-switch evaluation when the baby-
+    and giant-step rotations are complete arithmetic progressions.
   }];
   let arguments = (ins
     Cheddar_AnyContext:$ctx,
@@ -701,10 +706,57 @@ def Cheddar_LinearTransformOp : Cheddar_DpsOp<"linear_transform", [
     DenseI32ArrayAttr:$diagonal_indices,
     Builtin_IntegerAttr:$level,
     Builtin_IntegerAttr:$bs,
-    Builtin_IntegerAttr:$gs
+    Builtin_IntegerAttr:$gs,
+    DefaultValuedAttr<BoolAttr, "false">:$min_ks
   );
   let results = (outs Cheddar_CtResult:$result);
   let hasVerifier = 1;
+}
+
+def Cheddar_PrepareLinearTransformOp :
+    Cheddar_DpsOp<"prepare_linear_transform", [
+      DeclareOpInterfaceMethods<RotationOpInterface>
+    ]> {
+  let summary = "Compile and encode a reusable linear transform";
+  let description = [{
+    Packs cleartext diagonals into a StripedMatrix and constructs the scale-snu
+    LinearTransform object. This data-independent work belongs in split
+    preprocessing and is reused by encrypted evaluation.
+    `min_ks` records the key-switch strategy chosen by the source lowering.
+  }];
+  let arguments = (ins
+    Cheddar_AnyContext:$ctx,
+    TensorOrMemRef<[AnyFloat]>:$diagonals,
+    Cheddar_LinearTransformLike:$output,
+    DenseI32ArrayAttr:$diagonal_indices,
+    Builtin_IntegerAttr:$width,
+    Builtin_IntegerAttr:$level,
+    Builtin_IntegerAttr:$bs,
+    Builtin_IntegerAttr:$gs,
+    DefaultValuedAttr<BoolAttr, "false">:$min_ks
+  );
+  let results = (outs Cheddar_LinearTransformResult:$result);
+  let hasVerifier = 1;
+}
+
+def Cheddar_ApplyPreparedLinearTransformOp :
+    Cheddar_DpsOp<"apply_prepared_linear_transform"> {
+  let summary = "Evaluate a precompiled linear transform";
+  let description = [{
+    Applies a LinearTransform prepared by `cheddar.prepare_linear_transform`.
+    No diagonal packing or encoding is performed by this operation.
+    `min_ks` must match the strategy used to plan keys for the prepared
+    transform.
+  }];
+  let arguments = (ins
+    Cheddar_AnyContext:$ctx,
+    Cheddar_CtLike:$input,
+    Cheddar_EvkMap:$evkMap,
+    Cheddar_LinearTransformLike:$transform,
+    Cheddar_CtLike:$output,
+    DefaultValuedAttr<BoolAttr, "false">:$min_ks
+  );
+  let results = (outs Cheddar_CtResult:$result);
 }
 
 def Cheddar_EvalPolyOp : Cheddar_DpsOp<"eval_poly"> {
@@ -712,8 +764,9 @@ def Cheddar_EvalPolyOp : Cheddar_DpsOp<"eval_poly"> {
   let description = [{
     Evaluates a polynomial (e.g., Chebyshev approximation) on an encrypted
     input using CHEDDAR's EvalPoly extension.
-    `level` is the level the input ciphertext enters at; `outputLevel` is the
-    level the result lands at after the polynomial's multiplicative depth.
+    `levelConsumption` is copied from the upstream
+    `kernel.eval_chebyshev` level interface and drives CHEDDAR's target-scale
+    recurrence.
   }];
   let arguments = (ins
     Cheddar_AnyContext:$ctx,
@@ -721,8 +774,7 @@ def Cheddar_EvalPolyOp : Cheddar_DpsOp<"eval_poly"> {
     Cheddar_EvkMap:$evkMap,
     Cheddar_CtLike:$output,
     F64ArrayAttr:$coefficients,
-    Builtin_IntegerAttr:$level,
-    Builtin_IntegerAttr:$outputLevel
+    Builtin_IntegerAttr:$levelConsumption
   );
   let results = (outs Cheddar_CtResult:$result);
   let hasVerifier = 1;

--- a/patches/emitc_subscript_lvalue.patch
+++ b/patches/emitc_subscript_lvalue.patch
@@ -1,0 +1,36 @@
+# HEIR-maintained LLVM patch (NOT auto-generated): support move-only buffers
+# carried as `lvalue<opaque "std::array<...>">`. Allow `emitc.subscript` to
+# take an `!emitc.lvalue` base, and make the stock MemRefToEmitC copy pattern
+# decline non-array operands instead of asserting after a custom pattern does.
+# Upstream candidates; drop these once both changes land in the pinned LLVM.
+diff -ruN --strip-trailing-cr a/mlir/include/mlir/Dialect/EmitC/IR/EmitC.td b/mlir/include/mlir/Dialect/EmitC/IR/EmitC.td
+--- a/mlir/include/mlir/Dialect/EmitC/IR/EmitC.td
++++ b/mlir/include/mlir/Dialect/EmitC/IR/EmitC.td
+@@ -1623,7 +1623,8 @@
+   let arguments = (ins Arg<AnyTypeOf<[
+       EmitC_ArrayType,
+       EmitC_OpaqueType,
+-      EmitC_PointerType]>,
++      EmitC_PointerType,
++      EmitC_LValueType]>,
+     "the value to subscript">:$value,
+     Variadic<EmitCType>:$indices);
+   let results = (outs EmitC_LValueType:$result);
+diff -ruN --strip-trailing-cr a/mlir/lib/Conversion/MemRefToEmitC/MemRefToEmitC.cpp b/mlir/lib/Conversion/MemRefToEmitC/MemRefToEmitC.cpp
+--- a/mlir/lib/Conversion/MemRefToEmitC/MemRefToEmitC.cpp
++++ b/mlir/lib/Conversion/MemRefToEmitC/MemRefToEmitC.cpp
+@@ -315,9 +315,10 @@
+     auto srcArrayValue =
+-        cast<TypedValue<emitc::ArrayType>>(operands.getSource());
++        dyn_cast<TypedValue<emitc::ArrayType>>(operands.getSource());
++    auto targetArrayValue =
++        dyn_cast<TypedValue<emitc::ArrayType>>(operands.getTarget());
++    if (!srcArrayValue || !targetArrayValue)
++      return rewriter.notifyMatchFailure(loc, "expected array operands");
+     emitc::AddressOfOp srcPtr =
+         createPointerFromEmitcArray(loc, rewriter, srcArrayValue);
+-
+-    auto targetArrayValue =
+-        cast<TypedValue<emitc::ArrayType>>(operands.getTarget());
+     emitc::AddressOfOp targetPtr =
+         createPointerFromEmitcArray(loc, rewriter, targetArrayValue);

--- a/sky/cheddar_add_e2e.yaml
+++ b/sky/cheddar_add_e2e.yaml
@@ -1,0 +1,47 @@
+# SkyPilot config for running ONLY the cheddar add_e2e end-to-end test in
+# default (debug) compilation mode on a GPU instance. Mirrors
+# sky/cheddar_test_dbg.yaml but targets a single test target, so it doesn't
+# trip over the other cheddar e2e examples that are not yet migrated to the
+# destination-passing-style cheddar dialect.
+#
+# Usage: sky launch -c heir-cheddar-dbg -i 10 sky/cheddar_add_e2e.yaml
+#
+# Uses nvidia/cuda Ubuntu 24.04 base image for clang + CUDA compatibility.
+
+name: heir-cheddar-dbg
+
+# assumes we'll call this from the repo root
+workdir: .
+
+resources:
+  accelerators: A10G:1
+  cpus: 64+
+  memory: 128+
+  disk_size: 200
+  cloud: aws
+  image_id: docker:nvidia/cuda:12.9.1-cudnn-devel-ubuntu24.04
+  autostop:
+    idle_minutes: 10
+
+setup: |
+  set -ex
+
+  apt-get update -qq
+  apt-get install -y -qq \
+    clang cmake g++ lld libomp-dev llvm ninja-build pkg-config \
+    zlib1g-dev \
+    libtommath-dev libjsoncpp-dev \
+    libcusparselt0 \
+    git wget pip
+
+  if ! command -v bazel &> /dev/null; then
+    wget -q https://github.com/bazelbuild/bazelisk/releases/latest/download/bazelisk-linux-amd64 -O /usr/local/bin/bazel
+    chmod +x /usr/local/bin/bazel
+  fi
+
+run: |
+  set -ex
+  bazel fetch //tests/Examples/cheddar/add_e2e:add_e2e_test --config=cheddar
+  bazel test //tests/Examples/cheddar/add_e2e:add_e2e_test \
+    --config=cheddar --test_output=all --test_timeout=1800
+  echo "## DONE ##"

--- a/tests/Conversions/CheddarToEmitC/BUILD
+++ b/tests/Conversions/CheddarToEmitC/BUILD
@@ -1,0 +1,10 @@
+load("//bazel:lit.bzl", "glob_lit_tests")
+
+package(default_applicable_licenses = ["@heir//:license"])
+
+glob_lit_tests(
+    name = "all_tests",
+    data = ["@heir//tests:test_utilities"],
+    driver = "@heir//tests:run_lit.sh",
+    test_file_exts = ["mlir"],
+)

--- a/tests/Conversions/CheddarToEmitC/abi.mlir
+++ b/tests/Conversions/CheddarToEmitC/abi.mlir
@@ -1,0 +1,58 @@
+// RUN: heir-opt --convert-to-emitc=filter-dialects=cheddar --cheddar-emitc-boundary --reconcile-unrealized-casts %s | FileCheck %s
+
+// The ABI substrate is independently useful without lowering a CHEDDAR
+// runtime operation: move-only payload buffers become C++ references, and
+// cross-function calls remain structured.
+
+// CHECK: func.func @abi_inner(
+// CHECK-SAME: !emitc.opaque<"const std::array<Ciphertext<word>, 1>&">
+// CHECK-SAME: !emitc.opaque<"std::array<Ciphertext<word>, 1>&">
+func.func @abi_inner(
+    %input: memref<1x!cheddar.ciphertext>,
+    %output: memref<1x!cheddar.ciphertext> {bufferize.result}) {
+  return
+}
+
+// CHECK: func.func @abi_outer(
+// CHECK-SAME: !emitc.opaque<"const std::array<Ciphertext<word>, 1>&">
+// CHECK-SAME: !emitc.opaque<"std::array<Ciphertext<word>, 1>&">
+// CHECK: emitc.call_opaque "abi_inner"
+func.func @abi_outer(
+    %input: memref<1x!cheddar.ciphertext>,
+    %output: memref<1x!cheddar.ciphertext>) {
+  func.call @abi_inner(%input, %output)
+      : (memref<1x!cheddar.ciphertext>, memref<1x!cheddar.ciphertext>) -> ()
+  return
+}
+
+// Mutability propagates to a fixed point through more than one call edge.
+// CHECK: func.func @abi_outermost(
+// CHECK-SAME: !emitc.opaque<"const std::array<Ciphertext<word>, 1>&">
+// CHECK-SAME: !emitc.opaque<"std::array<Ciphertext<word>, 1>&">
+// CHECK: emitc.call_opaque "abi_outer"
+func.func @abi_outermost(
+    %input: memref<1x!cheddar.ciphertext>,
+    %output: memref<1x!cheddar.ciphertext>) {
+  func.call @abi_outer(%input, %output)
+      : (memref<1x!cheddar.ciphertext>, memref<1x!cheddar.ciphertext>) -> ()
+  return
+}
+
+// Rewriting a call to a refified function preserves ordinary scalar results.
+// CHECK: func.func @abi_result_inner
+func.func @abi_result_inner(
+    %value: i32,
+    %output: memref<1x!cheddar.ciphertext> {bufferize.result}) -> i32 {
+  return %value : i32
+}
+
+// CHECK: func.func @abi_result_outer
+// CHECK: %[[RESULT:[a-zA-Z0-9_]+]] = emitc.call_opaque "abi_result_inner"
+// CHECK: return %[[RESULT]] : i32
+func.func @abi_result_outer(
+    %value: i32,
+    %output: memref<1x!cheddar.ciphertext>) -> i32 {
+  %result = func.call @abi_result_inner(%value, %output)
+      : (i32, memref<1x!cheddar.ciphertext>) -> i32
+  return %result : i32
+}

--- a/tests/Conversions/CheddarToEmitC/boundary_tightening.mlir
+++ b/tests/Conversions/CheddarToEmitC/boundary_tightening.mlir
@@ -1,0 +1,27 @@
+// RUN: heir-opt --cheddar-bufferize --fold-memref-alias-ops --cse --canonicalize --convert-to-emitc=filter-dialects=cheddar,arith,scf --cheddar-emitc-boundary --reconcile-unrealized-casts %s | FileCheck %s
+
+// Function-boundary handling for the move-only CHEDDAR payload/handle types.
+// `--cheddar-bufferize` exposes each payload result as a trailing out-param
+// before One-Shot, and `--cheddar-emitc-boundary` re-types the args: a read-only
+// payload buffer arg is `const Ciphertext<word>&`, a written one (an out-param
+// or an in-place accumulator) is a mutable `Ciphertext<word>&`, and the
+// non-copyable handle types (Encoder / EvkMap / EvaluationKey) are `const T&`.
+
+!ciphertext = !cheddar.ciphertext
+!constant = !cheddar.constant
+!context = !cheddar.context
+!evk_map = !cheddar.evk_map
+!boot_context = !cheddar.boot_context
+
+// An EvkMap argument is a non-copyable handle, so it tightens to
+// `const EvkMap<word>&` rather than staying a by-value parameter.
+// CHECK: func.func @boot(
+// CHECK-SAME: !emitc.opaque<"const EvkMap<word>&">
+func.func @boot(%ctx: !boot_context, %ct: tensor<!ciphertext>, %evk: !evk_map)
+    -> tensor<!ciphertext> {
+  %d = tensor.empty() : tensor<!ciphertext>
+  %0 = cheddar.boot %ctx, %ct, %evk, %d
+      : (!boot_context, tensor<!ciphertext>, !evk_map, tensor<!ciphertext>)
+      -> tensor<!ciphertext>
+  return %0 : tensor<!ciphertext>
+}

--- a/tests/Conversions/CheddarToEmitC/cheddar_to_emitc.mlir
+++ b/tests/Conversions/CheddarToEmitC/cheddar_to_emitc.mlir
@@ -1,0 +1,196 @@
+// RUN: heir-opt --cheddar-bufferize --fold-memref-alias-ops --cse --canonicalize --drop-equivalent-buffer-results "--buffer-results-to-out-params=hoist-static-allocs=true modify-public-functions=true add-result-attr=true" --canonicalize --convert-to-emitc=filter-dialects=cheddar,arith,scf --cheddar-emitc-boundary --reconcile-unrealized-casts %s | FileCheck %s
+
+// End-to-end op coverage for the cheddar -> EmitC lowering, now driven by stock
+// `--convert-to-emitc` (cheddar's dialect interface) + the
+// `--cheddar-emitc-boundary` pass, over destination-passing-style cheddar ops.
+// Every payload-producing op carries a `tensor.empty` `$output`
+// destination; bufferization + `--buffer-results-to-out-params` turn func
+// results into trailing out-params, and the boundary pass re-types move-only
+// payload args as C++ references (`const T&` inputs, `T&` out-params).
+
+!ciphertext = !cheddar.ciphertext
+!plaintext = !cheddar.plaintext
+!constant = !cheddar.constant
+!context = !cheddar.context
+!encoder = !cheddar.encoder
+!eval_key = !cheddar.eval_key
+!evk_map = !cheddar.evk_map
+!user_interface = !cheddar.user_interface
+!parameter = !cheddar.parameter
+!boot_context = !cheddar.boot_context
+
+// A two-op chain: each op is `ctx->Method(out, a, b)`. The first op's result is
+// an intermediate local (`emitc.variable`); the second writes the function
+// out-param. Inputs are `const Ciphertext<word>&`, the out-param is mutable.
+// CHECK: func.func @arith(
+// CHECK-SAME: !emitc.ptr<!emitc.opaque<"Context<word>">>
+// CHECK-SAME: !emitc.opaque<"const Ciphertext<word>&">
+// CHECK-SAME: !emitc.opaque<"Ciphertext<word>&">
+// CHECK: emitc.member_call_opaque %arg0 "Add"(%[[V:.*]], %arg1, %arg2)
+// CHECK: emitc.member_call_opaque %arg0 "Mult"(%arg3, %[[V]], %arg2)
+func.func @arith(%ctx: !context, %a: tensor<!ciphertext>, %b: tensor<!ciphertext>) -> tensor<!ciphertext> {
+  %d0 = tensor.empty() : tensor<!ciphertext>
+  %r = cheddar.add %ctx, %a, %b, %d0 : (!context, tensor<!ciphertext>, tensor<!ciphertext>, tensor<!ciphertext>) -> tensor<!ciphertext>
+  %d1 = tensor.empty() : tensor<!ciphertext>
+  %s = cheddar.mult %ctx, %r, %b, %d1 : (!context, tensor<!ciphertext>, tensor<!ciphertext>, tensor<!ciphertext>) -> tensor<!ciphertext>
+  return %s : tensor<!ciphertext>
+}
+
+// A semantic ciphertext copy lowers to CHEDDAR's deep-copy API, never C++
+// copy-assignment on the move-only payload.
+// CHECK: func.func @copy
+// CHECK: emitc.member_call_opaque %arg0 "Copy"(%arg2, %arg1)
+func.func @copy(%ctx: !context, %input: tensor<!ciphertext>) -> tensor<!ciphertext> {
+  %dest = tensor.empty() : tensor<!ciphertext>
+  %result = cheddar.copy %ctx, %input, %dest : (!context, tensor<!ciphertext>, tensor<!ciphertext>) -> tensor<!ciphertext>
+  return %result : tensor<!ciphertext>
+}
+
+// A memref.copy that survives alias folding has true copy semantics and lowers
+// through the same CHEDDAR deep-copy API.
+// CHECK: func.func @memref_copy
+// CHECK: emitc.member_call_opaque %arg0 "Copy"(%arg2, %arg1)
+func.func @memref_copy(%ctx: !context, %input: memref<!ciphertext>,
+                       %output: memref<!ciphertext>) {
+  memref.copy %input, %output
+      : memref<!ciphertext> to memref<!ciphertext>
+  return
+}
+
+// CHEDDAR's Context overloads Add/Sub/Mult on the second operand type, so the
+// `*_plain` / `*_const` ops dispatch to the base method name.
+// CHECK: func.func @plain_const
+// CHECK: emitc.member_call_opaque %arg0 "Add"
+// CHECK: emitc.member_call_opaque %arg0 "Mult"
+func.func @plain_const(%ctx: !context, %ct: tensor<!ciphertext>, %pt: tensor<!plaintext>, %c: tensor<!constant>) -> tensor<!ciphertext> {
+  %d0 = tensor.empty() : tensor<!ciphertext>
+  %r1 = cheddar.add_plain %ctx, %ct, %pt, %d0 : (!context, tensor<!ciphertext>, tensor<!plaintext>, tensor<!ciphertext>) -> tensor<!ciphertext>
+  %d1 = tensor.empty() : tensor<!ciphertext>
+  %r2 = cheddar.mult_const %ctx, %r1, %c, %d1 : (!context, tensor<!ciphertext>, tensor<!constant>, tensor<!ciphertext>) -> tensor<!ciphertext>
+  return %r2 : tensor<!ciphertext>
+}
+
+// The level_down target level is appended as a trailing opaque constant arg.
+// CHECK: func.func @unary
+// CHECK: emitc.member_call_opaque %arg0 "Neg"
+// CHECK: emitc.member_call_opaque %arg0 "LevelDown"
+// CHECK-SAME: #emitc.opaque<"2">
+func.func @unary(%ctx: !context, %ct: tensor<!ciphertext>) -> tensor<!ciphertext> {
+  %d0 = tensor.empty() : tensor<!ciphertext>
+  %n = cheddar.neg %ctx, %ct, %d0 : (!context, tensor<!ciphertext>, tensor<!ciphertext>) -> tensor<!ciphertext>
+  %d1 = tensor.empty() : tensor<!ciphertext>
+  %l = cheddar.level_down %ctx, %n, %d1 {targetLevel = 2 : i64} : (!context, tensor<!ciphertext>, tensor<!ciphertext>) -> tensor<!ciphertext>
+  return %l : tensor<!ciphertext>
+}
+
+// CHECK: func.func @relin
+// CHECK: emitc.member_call_opaque %arg0 "Relinearize"
+// CHECK: emitc.member_call_opaque %arg0 "Rescale"
+func.func @relin(%ctx: !context, %ct: tensor<!ciphertext>, %k: !eval_key) -> tensor<!ciphertext> {
+  %d0 = tensor.empty() : tensor<!ciphertext>
+  %r1 = cheddar.relinearize %ctx, %ct, %k, %d0 : (!context, tensor<!ciphertext>, !eval_key, tensor<!ciphertext>) -> tensor<!ciphertext>
+  %d1 = tensor.empty() : tensor<!ciphertext>
+  %r2 = cheddar.rescale %ctx, %r1, %d1 : (!context, tensor<!ciphertext>, tensor<!ciphertext>) -> tensor<!ciphertext>
+  return %r2 : tensor<!ciphertext>
+}
+
+// The HMult `rescale` flag is appended as the trailing opaque constant arg.
+// CHECK: func.func @hmult
+// CHECK: emitc.member_call_opaque %arg0 "HMult"
+// CHECK-SAME: #emitc.opaque<"true">
+func.func @hmult(%ctx: !context, %a: tensor<!ciphertext>, %b: tensor<!ciphertext>, %k: !eval_key) -> tensor<!ciphertext> {
+  %d0 = tensor.empty() : tensor<!ciphertext>
+  %r = cheddar.hmult %ctx, %a, %b, %k, %d0 {rescale = true} : (!context, tensor<!ciphertext>, tensor<!ciphertext>, !eval_key, tensor<!ciphertext>) -> tensor<!ciphertext>
+  return %r : tensor<!ciphertext>
+}
+
+// Encode bridges a float message buffer through a std::vector<Complex> and
+// uses CHEDDAR's canonical per-level scale; encrypt is an out-param method
+// call.
+// CHECK: func.func @enc_chain
+// CHECK: emitc.address_of
+// CHECK: emitc.verbatim "{}.Encode({}, 5, {}.GetScale(5), {});"
+// CHECK: emitc.member_call_opaque %arg2 "Encrypt"
+func.func @enc_chain(%enc: !encoder, %msg: tensor<4xf64>, %ui: !user_interface) -> tensor<!ciphertext> {
+  %dp = tensor.empty() : tensor<!plaintext>
+  %pt = cheddar.encode %enc, %msg, %dp {level = 5 : i64, logScale = 37 : i64} : (!encoder, tensor<4xf64>, tensor<!plaintext>) -> tensor<!plaintext>
+  %dc = tensor.empty() : tensor<!ciphertext>
+  %ct = cheddar.encrypt %ui, %pt, %dc : (!user_interface, tensor<!plaintext>, tensor<!ciphertext>) -> tensor<!ciphertext>
+  return %ct : tensor<!ciphertext>
+}
+
+// Decrypt is an out-param method call; decode reads into a temporary
+// std::vector<Complex> then copies the real parts into the float buffer.
+// CHECK: func.func @dec_chain
+// CHECK: emitc.member_call_opaque %arg1 "Decrypt"
+// CHECK: emitc.verbatim "{}.Decode({}, {});"
+// CHECK: emitc.verbatim {{.*}}.at(_i).real();"
+func.func @dec_chain(%enc: !encoder, %ui: !user_interface, %ct: tensor<!ciphertext>, %dst: tensor<1x4xf32>) -> tensor<1x4xf32> {
+  %dp = tensor.empty() : tensor<!plaintext>
+  %pt = cheddar.decrypt %ui, %ct, %dp : (!user_interface, tensor<!ciphertext>, tensor<!plaintext>) -> tensor<!plaintext>
+  %msg = cheddar.decode %enc, %pt, %dst : (!encoder, tensor<!plaintext>, tensor<1x4xf32>) -> tensor<1x4xf32>
+  return %msg : tensor<1x4xf32>
+}
+
+// HRot/HConj keep their verbatim form. Static distance bakes the distance into
+// the format string; dynamic distance threads the SSA value twice.
+// CHECK: func.func @hrot_static
+// CHECK: emitc.verbatim "{}->HRot({}, {}, {}->GetRotationKey(5), 5);"
+func.func @hrot_static(%ctx: !context, %ui: !user_interface, %ct: tensor<!ciphertext>) -> tensor<!ciphertext> {
+  %d0 = tensor.empty() : tensor<!ciphertext>
+  %r = cheddar.hrot %ctx, %ui, %ct, %d0 {static_distance = 5 : i64} : (!context, !user_interface, tensor<!ciphertext>, tensor<!ciphertext>) -> tensor<!ciphertext>
+  return %r : tensor<!ciphertext>
+}
+
+// CHECK: func.func @hrot_dyn
+// CHECK: emitc.verbatim "{}->HRot({}, {}, {}->GetRotationKey({}), {});"
+// CHECK-SAME: %arg3, %arg3
+func.func @hrot_dyn(%ctx: !context, %ui: !user_interface, %ct: tensor<!ciphertext>, %d: index) -> tensor<!ciphertext> {
+  %d0 = tensor.empty() : tensor<!ciphertext>
+  %r = cheddar.hrot %ctx, %ui, %ct, %d0, %d : (!context, !user_interface, tensor<!ciphertext>, tensor<!ciphertext>, index) -> tensor<!ciphertext>
+  return %r : tensor<!ciphertext>
+}
+
+// CHECK: func.func @hconj_add
+// CHECK: emitc.verbatim "{}->HConjAdd({}, {}, {}, {}->GetConjugationKey());"
+func.func @hconj_add(%ctx: !context, %ui: !user_interface, %a: tensor<!ciphertext>, %b: tensor<!ciphertext>) -> tensor<!ciphertext> {
+  %d0 = tensor.empty() : tensor<!ciphertext>
+  %r = cheddar.hconj_add %ctx, %ui, %a, %b, %d0 : (!context, !user_interface, tensor<!ciphertext>, tensor<!ciphertext>, tensor<!ciphertext>) -> tensor<!ciphertext>
+  return %r : tensor<!ciphertext>
+}
+
+// Boot is a BootContext method; cheddar.boot requires a !cheddar.boot_context
+// (lowered to BootContext<word>*) so no downcast is needed.
+// CHECK: func.func @boot
+// CHECK: emitc.member_call_opaque %arg0 "Boot"
+func.func @boot(%ctx: !boot_context, %ct: tensor<!ciphertext>, %evk: !evk_map) -> tensor<!ciphertext> {
+  %d0 = tensor.empty() : tensor<!ciphertext>
+  %r = cheddar.boot %ctx, %ct, %evk, %d0 : (!boot_context, tensor<!ciphertext>, !evk_map, tensor<!ciphertext>) -> tensor<!ciphertext>
+  return %r : tensor<!ciphertext>
+}
+
+// eval_poly lowers to the real cheddar::EvalPoly<word> class -- there is no
+// `RunEvalPoly` in cheddar. It mirrors cheddar's own EvalMod: the level/scale
+// are taken from the actual input ciphertext (NPToLevel(in.GetNP()),
+// in.GetScale()) and target_scale is the square/divide recurrence over
+// GetRescalePrimeProd -- seeding the constructor with anything else silently
+// blows the Chebyshev basis recurrence up. The construct/Compile/Evaluate
+// (which need the move-only ciphertext as a method receiver + ctx->param_ + the
+// recurrence) are emitted as verbatim real-cheddar statements in a `{ }` block
+// scope so the EvalPoly (and its GPU power basis) is destroyed right after use.
+// CHECK: func.func @eval_poly
+// CHECK-SAME: !emitc.opaque<"const Ciphertext<word>&">
+// CHECK: emitc.verbatim "{"
+// CHECK: emitc.verbatim "ConstContextPtr<word> _ep_cp(ConstContextPtr<word>(), {}
+// CHECK: emitc.verbatim "int _ep_lvl = {}->param_.NPToLevel({}.GetNP());"
+// CHECK: emitc.verbatim "double _ep_is = {}.GetScale();"
+// CHECK: emitc.verbatim "_ep_ts = _ep_ts * _ep_ts / {}->param_.GetRescalePrimeProd
+// CHECK: emitc.verbatim "cheddar::EvalPoly<word> _ep({1, 2, 3}, _ep_lvl, _ep_is, _ep_ts, true);"
+// CHECK: emitc.verbatim "_ep.Compile(_ep_cp);"
+// CHECK: emitc.verbatim "_ep.Evaluate(_ep_cp, {}, {}, {}.GetMultiplicationKey());"
+// CHECK: emitc.verbatim "}"
+func.func @eval_poly(%ctx: !context, %enc: !encoder, %ct: tensor<!ciphertext>, %evk: !evk_map) -> tensor<!ciphertext> {
+  %d0 = tensor.empty() : tensor<!ciphertext>
+  %r = cheddar.eval_poly %ctx, %ct, %evk, %d0 {coefficients = [1.0 : f64, 2.0 : f64, 3.0 : f64], levelConsumption = 2 : i64} : (!context, tensor<!ciphertext>, !evk_map, tensor<!ciphertext>) -> tensor<!ciphertext>
+  return %r : tensor<!ciphertext>
+}

--- a/tests/Conversions/CheddarToEmitC/compile/BUILD
+++ b/tests/Conversions/CheddarToEmitC/compile/BUILD
@@ -1,0 +1,124 @@
+load("@bazel_skylib//rules:build_test.bzl", "build_test")
+load("@heir//bazel/cheddar:config.bzl", "requires_cheddar")
+load("@heir//tools:heir-opt.bzl", "heir_opt")
+load("@heir//tools:heir-translate.bzl", "heir_translate")
+load("@rules_cc//cc:cc_library.bzl", "cc_library")
+
+package(
+    default_applicable_licenses = ["@heir//:license"],
+    default_visibility = ["//visibility:public"],
+)
+
+# Compile-only guard that `cheddar-to-emitc` emits C++ which honours CHEDDAR's
+# move/const contract. Unlike the GPU end-to-end tests under
+# tests/Examples/cheddar, this compiles the emitted code against a header-only
+# stub (cheddar_stub.h) with no CUDA, so it runs in normal CI. The cheddar
+# dialect and pass are registered unconditionally in heir-opt/-translate, so
+# this needs neither a GPU nor --//:enable_cheddar.
+
+heir_opt(
+    name = "kernels_emitc",
+    src = "kernels.mlir",
+    generated_filename = "kernels_emitc.mlir",
+    pass_flags = [
+        "--cheddar-bufferize",
+        "--fold-memref-alias-ops",
+        "--cse",
+        "--canonicalize",
+        "--drop-equivalent-buffer-results",
+        "--buffer-results-to-out-params=hoist-static-allocs=true modify-public-functions=true add-result-attr=true",
+        "--canonicalize",
+        "--convert-to-emitc=filter-dialects=cheddar,arith,scf",
+        "--cheddar-emitc-boundary",
+        "--reconcile-unrealized-casts",
+    ],
+)
+
+heir_translate(
+    name = "kernels_cpp_raw",
+    src = ":kernels_emitc.mlir",
+    generated_filename = "kernels_raw.cc",
+    pass_flags = ["--mlir-to-cpp"],
+)
+
+# Prepend the includes/usings the emitted body relies on.
+genrule(
+    name = "kernels_lib_src",
+    srcs = [":kernels_raw.cc"],
+    outs = ["kernels_lib.cc"],
+    cmd = """cat > $@ <<'PRELUDE_EOF'
+// AUTO-GENERATED: do not edit. See tests/Conversions/CheddarToEmitC/compile/BUILD.
+#include <array>
+#include <complex>
+#include <cstdint>
+#include <initializer_list>
+#include <vector>
+#include "tests/Conversions/CheddarToEmitC/compile/cheddar_stub.h"
+using namespace cheddar;
+using word = uint64_t;
+PRELUDE_EOF
+cat $(location :kernels_raw.cc) >> $@
+""",
+)
+
+cc_library(
+    name = "cheddar_stub",
+    hdrs = ["cheddar_stub.h"],
+)
+
+cc_library(
+    name = "kernels_compiled",
+    srcs = [":kernels_lib_src"],
+    deps = [":cheddar_stub"],
+)
+
+# Compiling the generated C++ against the stub *is* the assertion: if the
+# emitter produced C++ that violates CHEDDAR's move/const contract, this fails
+# to build. build_test compiles without linking, so the stub only needs
+# declarations (no method bodies), and no GPU/CUDA is involved.
+build_test(
+    name = "compile_test",
+    targets = [":kernels_compiled"],
+)
+
+# Compile the same generated kernels against the pinned scale-snu CHEDDAR API.
+# The stub remains the fast CPU/CI contract check; this opt-in target detects
+# drift between that contract and the actual library headers.
+genrule(
+    name = "kernels_real_lib_src",
+    srcs = [":kernels_raw.cc"],
+    outs = ["kernels_real_lib.cc"],
+    cmd = """cat > $@ <<'PRELUDE_EOF'
+// AUTO-GENERATED: do not edit. See tests/Conversions/CheddarToEmitC/compile/BUILD.
+#include <array>
+#include <complex>
+#include <cstdint>
+#include <initializer_list>
+#include <memory>
+#include <utility>
+#include <vector>
+#include "UserInterface.h"
+#include "core/Context.h"
+#include "core/Encode.h"
+#include "core/Parameter.h"
+#include "extension/BootContext.h"
+#include "extension/EvalPoly.h"
+using namespace cheddar;
+using word = uint64_t;
+PRELUDE_EOF
+cat $(location :kernels_raw.cc) >> $@
+""",
+)
+
+cc_library(
+    name = "kernels_real_compiled",
+    srcs = [":kernels_real_lib_src"],
+    target_compatible_with = requires_cheddar(),
+    deps = ["@cheddar"],
+)
+
+build_test(
+    name = "real_compile_test",
+    target_compatible_with = requires_cheddar(),
+    targets = [":kernels_real_compiled"],
+)

--- a/tests/Conversions/CheddarToEmitC/compile/cheddar_stub.h
+++ b/tests/Conversions/CheddarToEmitC/compile/cheddar_stub.h
@@ -1,0 +1,198 @@
+// Header-only stub of the CHEDDAR C++ API, used to *compile* (not run) the
+// C++ that `cheddar-to-emitc` + `heir-translate --mlir-to-cpp` produce, with
+// no GPU/CUDA toolchain. This is a CI-runnable guard that the emitted code
+// honours CHEDDAR's move/const contract -- the kind of bug that FileCheck
+// (which only inspects emitted text) cannot catch.
+//
+// The move/const semantics below mirror the real library (verified against
+// CHEDDAR's include/core headers); only these properties matter here, so the
+// method bodies are empty and the data layout is omitted:
+//
+//   * Ciphertext/Plaintext/Constant/EvaluationKey -- move-only (copy deleted)
+//     *with* move-assignment, default-constructible.   (core/Container.h)
+//   * EvkMap -- move-only, copy deleted, *no* move-assignment. (core/EvkMap.h)
+//   * Context::MadUnsafe(Ct& res, ...) mutates `res` in place, so `res` is a
+//     non-const reference.                              (core/Context.h:377)
+//   * UserInterface::Get*Key() / GetEvkMap() return `const&`. (UserInterface.h)
+//
+// Kept deliberately narrow: the "setup/getter" surface (create_context,
+// create_user_interface, get_encoder, encode/decode) is *not* modelled here
+// because that part of the emitter has independent, pre-existing mismatches
+// against the real API and needs its own design pass.
+
+#ifndef TESTS_CONVERSIONS_CHEDDARTOEMITC_COMPILE_CHEDDAR_STUB_H_
+#define TESTS_CONVERSIONS_CHEDDARTOEMITC_COMPILE_CHEDDAR_STUB_H_
+
+#include <complex>
+#include <initializer_list>
+#include <map>
+#include <memory>
+#include <vector>
+
+namespace cheddar {
+
+using Complex = std::complex<double>;
+
+// Number-of-primes info a ciphertext carries; the EvalPoly emitter maps it back
+// to a level via Parameter::NPToLevel.
+struct NPInfo {
+  int num_main_ = 0;
+};
+
+// Minimal parameter stub: the EvalPoly emitter reads the level/q-product via
+// NPToLevel / GetRescalePrimeProd (mirroring EvalMod).
+template <typename word>
+struct Parameter {
+  double GetScale(int level) const;
+  double GetRescalePrimeProd(int level) const;
+  int NPToLevel(NPInfo np) const;
+};
+
+// The encoder exposes the per-level canonical scale (the EvalPoly emitter reads
+// input/target scales via `encoder.GetScale(level)`).
+template <typename word>
+struct Encoder {
+  double GetScale(int level) const;
+};
+
+// Move-only payload types with full move support (default + move-ctor +
+// move-assign; copy deleted).
+template <typename word>
+struct Ciphertext {
+  Ciphertext() = default;
+  Ciphertext(Ciphertext&&) = default;
+  Ciphertext& operator=(Ciphertext&&) = default;
+  Ciphertext(const Ciphertext&) = delete;
+  Ciphertext& operator=(const Ciphertext&) = delete;
+  // The EvalPoly emitter reads the actual level/scale off the input ct.
+  double GetScale() const;
+  NPInfo GetNP() const;
+};
+template <typename word>
+struct Plaintext {
+  Plaintext() = default;
+  Plaintext(Plaintext&&) = default;
+  Plaintext& operator=(Plaintext&&) = default;
+  Plaintext(const Plaintext&) = delete;
+  Plaintext& operator=(const Plaintext&) = delete;
+};
+template <typename word>
+struct Constant {
+  Constant() = default;
+  Constant(Constant&&) = default;
+  Constant& operator=(Constant&&) = default;
+  Constant(const Constant&) = delete;
+  Constant& operator=(const Constant&) = delete;
+};
+template <typename word>
+struct EvaluationKey {
+  EvaluationKey() = default;
+  EvaluationKey(EvaluationKey&&) = default;
+  EvaluationKey& operator=(EvaluationKey&&) = default;
+  EvaluationKey(const EvaluationKey&) = delete;
+  EvaluationKey& operator=(const EvaluationKey&) = delete;
+};
+
+// Move-only, and -- unlike the payload types -- has *no* move-assignment and
+// is not default-constructible (the real EvkMap inherits std::unordered_map
+// and declares only a move ctor). This is what makes the value+assign getter
+// shape uncompilable, so the stub preserves it.
+template <typename word>
+struct EvkMap {
+  EvkMap(EvkMap&&) = default;
+  EvkMap(const EvkMap&) = delete;
+  EvkMap& operator=(const EvkMap&) = delete;
+
+  const EvaluationKey<word>& GetRotationKey(int) const;
+  const EvaluationKey<word>& GetConjugationKey() const;
+  const EvaluationKey<word>& GetMultiplicationKey() const;
+};
+
+template <typename word>
+class UserInterface {
+ public:
+  using Ct = Ciphertext<word>;
+  using Pt = Plaintext<word>;
+  using Evk = EvaluationKey<word>;
+
+  void Encrypt(Ct& res, const Pt& a) const;
+  void Decrypt(Pt& res, const Ct& a) const;
+
+  const Evk& GetRotationKey(int rot_idx) const;
+  const Evk& GetConjugationKey() const;
+  const Evk& GetMultiplicationKey() const;
+  const EvkMap<word>& GetEvkMap() const;
+};
+
+template <typename word>
+class Context {
+ public:
+  using Ct = Ciphertext<word>;
+  using Pt = Plaintext<word>;
+  using Const = Constant<word>;
+  using Evk = EvaluationKey<word>;
+
+  // Overloaded ct/pt/const arithmetic -- the emitter dispatches the dialect's
+  // *_plain / *_const ops to the base name and relies on C++ overloading.
+  void Copy(Ct& res, const Ct& input) const;
+  void Add(Ct& res, const Ct& a, const Ct& b) const;
+  void Add(Ct& res, const Ct& a, const Pt& b) const;
+  void Add(Ct& res, const Ct& a, const Const& b) const;
+  void Sub(Ct& res, const Ct& a, const Ct& b) const;
+  void Sub(Ct& res, const Ct& a, const Pt& b) const;
+  void Mult(Ct& res, const Ct& a, const Ct& b) const;
+  void Mult(Ct& res, const Ct& a, const Pt& b) const;
+  void Mult(Ct& res, const Ct& a, const Const& b) const;
+
+  void Neg(Ct& res, const Ct& a) const;
+  void Rescale(Ct& res, const Ct& a) const;
+  void Relinearize(Ct& res, const Ct& a, const Evk& key) const;
+  void RelinearizeRescale(Ct& res, const Ct& a, const Evk& key) const;
+  void LevelDown(Ct& res, const Ct& a, int target_level) const;
+
+  void HMult(Ct& res, const Ct& a, const Ct& b, const Evk& mult_key,
+             bool rescale) const;
+  void HRot(Ct& res, const Ct& a, const Evk& rot_key, int rot_dist) const;
+  void HRotAdd(Ct& res, const Ct& a, const Ct& b, const Evk& rot_key,
+               int rot_dist) const;
+  void HConj(Ct& res, const Ct& a, const Evk& conj_key) const;
+  void HConjAdd(Ct& res, const Ct& a, const Ct& b, const Evk& conj_key) const;
+
+  // In-place multiply-accumulate: `res` is mutated, so it is a *non-const*
+  // reference. This is the crux of the mad_unsafe finding.
+  void MadUnsafe(Ct& res, const Ct& a, const Const& b) const;
+
+  // The EvalPoly emitter reads the canonical scale from here.
+  Parameter<word> param_;
+};
+
+// ConstContextPtr is a non-owning shared_ptr aliased onto the raw Context*.
+template <typename word>
+using ConstContextPtr = std::shared_ptr<const Context<word>>;
+
+// CHEDDAR's EvalPoly extension: also a class -- construct from coefficients,
+// Compile(), then Evaluate() with the multiplication key.
+template <typename word>
+class EvalPoly {
+ public:
+  EvalPoly(const std::vector<double>& coefficients, int input_level,
+           double input_scale, double target_scale, bool chebyshev = false);
+  void Compile(ConstContextPtr<word> context);
+  void Evaluate(ConstContextPtr<word> context, Ciphertext<word>& res,
+                const Ciphertext<word>& input,
+                const EvaluationKey<word>& mult_key) const;
+};
+
+// Boot lives on the derived BootContext (extension/BootContext.h), not Context.
+// cheddar.boot takes a !cheddar.boot_context, lowered to BootContext<word>*, so
+// the emitter calls `ctx->Boot(...)` directly; the stub mirrors that hierarchy.
+template <typename word>
+class BootContext : public Context<word> {
+ public:
+  using Ct = Ciphertext<word>;
+  void Boot(Ct& res, const Ct& a, const EvkMap<word>& evk_map) const;
+};
+
+}  // namespace cheddar
+
+#endif  // TESTS_CONVERSIONS_CHEDDARTOEMITC_COMPILE_CHEDDAR_STUB_H_

--- a/tests/Conversions/CheddarToEmitC/compile/kernels.mlir
+++ b/tests/Conversions/CheddarToEmitC/compile/kernels.mlir
@@ -1,0 +1,195 @@
+// Input for the cheddar-to-emitc *compile* test (see BUILD): every function
+// here is lowered to C++ and compiled against cheddar_stub.h. The point is to
+// exercise the emitter's move/const handling on the op surface that real
+// kernels use, with ctx / user_interface / keys / evk_map taken as function
+// arguments (the shape a CKKS-to-Cheddar lowering produces).
+//
+// Destination-passing form: each payload-producing cheddar op takes an explicit
+// shape-only `tensor.empty` destination (its `outs` init), a scalar payload
+// is a rank-0 `tensor<!cheddar.X>`, and the whole module flows through the same
+// pipeline the e2e examples use (one-shot-bufferize -> buffer-results-to-out-
+// params -> convert-to-emitc -> cheddar-emitc-boundary).
+//
+// Setup ops are intentionally absent: conversion and opt-in real CHEDDAR
+// compile tests cover them. Getter ops remain unsupported by this lowering.
+
+!ciphertext = !cheddar.ciphertext
+!plaintext = !cheddar.plaintext
+!constant = !cheddar.constant
+!context = !cheddar.context
+!encoder = !cheddar.encoder
+
+// Add / Sub / Mult chained on ciphertexts.
+func.func @arith(%ctx: !context, %a: tensor<!ciphertext>,
+                 %b: tensor<!ciphertext>) -> tensor<!ciphertext> {
+  %d0 = tensor.empty() : tensor<!ciphertext>
+  %0 = cheddar.add %ctx, %a, %b, %d0
+      : (!context, tensor<!ciphertext>, tensor<!ciphertext>, tensor<!ciphertext>) -> tensor<!ciphertext>
+  %d1 = tensor.empty() : tensor<!ciphertext>
+  %1 = cheddar.sub %ctx, %0, %b, %d1
+      : (!context, tensor<!ciphertext>, tensor<!ciphertext>, tensor<!ciphertext>) -> tensor<!ciphertext>
+  %d2 = tensor.empty() : tensor<!ciphertext>
+  %2 = cheddar.mult %ctx, %1, %a, %d2
+      : (!context, tensor<!ciphertext>, tensor<!ciphertext>, tensor<!ciphertext>) -> tensor<!ciphertext>
+  return %2 : tensor<!ciphertext>
+}
+
+// Explicit semantic deep copy through Context::Copy.
+func.func @copy(%ctx: !context, %input: tensor<!ciphertext>)
+    -> tensor<!ciphertext> {
+  %dest = tensor.empty() : tensor<!ciphertext>
+  %result = cheddar.copy %ctx, %input, %dest
+      : (!context, tensor<!ciphertext>, tensor<!ciphertext>)
+          -> tensor<!ciphertext>
+  return %result : tensor<!ciphertext>
+}
+
+// ct+pt and ct+const overloaded dispatch.
+func.func @ct_pt_const(%ctx: !context, %ct: tensor<!ciphertext>,
+                       %pt: tensor<!plaintext>, %c: tensor<!constant>)
+    -> tensor<!ciphertext> {
+  %d0 = tensor.empty() : tensor<!ciphertext>
+  %0 = cheddar.add_plain %ctx, %ct, %pt, %d0
+      : (!context, tensor<!ciphertext>, tensor<!plaintext>, tensor<!ciphertext>) -> tensor<!ciphertext>
+  %d1 = tensor.empty() : tensor<!ciphertext>
+  %1 = cheddar.sub_plain %ctx, %0, %pt, %d1
+      : (!context, tensor<!ciphertext>, tensor<!plaintext>, tensor<!ciphertext>) -> tensor<!ciphertext>
+  %d2 = tensor.empty() : tensor<!ciphertext>
+  %2 = cheddar.mult_plain %ctx, %1, %pt, %d2
+      : (!context, tensor<!ciphertext>, tensor<!plaintext>, tensor<!ciphertext>) -> tensor<!ciphertext>
+  %d3 = tensor.empty() : tensor<!ciphertext>
+  %3 = cheddar.add_const %ctx, %2, %c, %d3
+      : (!context, tensor<!ciphertext>, tensor<!constant>, tensor<!ciphertext>) -> tensor<!ciphertext>
+  %d4 = tensor.empty() : tensor<!ciphertext>
+  %4 = cheddar.mult_const %ctx, %3, %c, %d4
+      : (!context, tensor<!ciphertext>, tensor<!constant>, tensor<!ciphertext>) -> tensor<!ciphertext>
+  return %4 : tensor<!ciphertext>
+}
+
+// Unary ops.
+func.func @unary(%ctx: !context, %ct: tensor<!ciphertext>)
+    -> tensor<!ciphertext> {
+  %d0 = tensor.empty() : tensor<!ciphertext>
+  %0 = cheddar.neg %ctx, %ct, %d0
+      : (!context, tensor<!ciphertext>, tensor<!ciphertext>) -> tensor<!ciphertext>
+  %d1 = tensor.empty() : tensor<!ciphertext>
+  %1 = cheddar.rescale %ctx, %0, %d1
+      : (!context, tensor<!ciphertext>, tensor<!ciphertext>) -> tensor<!ciphertext>
+  %d2 = tensor.empty() : tensor<!ciphertext>
+  %2 = cheddar.level_down %ctx, %1, %d2 {targetLevel = 2 : i64}
+      : (!context, tensor<!ciphertext>, tensor<!ciphertext>) -> tensor<!ciphertext>
+  return %2 : tensor<!ciphertext>
+}
+
+// Relinearize / RelinearizeRescale with an evaluation-key argument.
+func.func @relin(%ctx: !context, %ct: tensor<!ciphertext>,
+                 %k: !cheddar.eval_key) -> tensor<!ciphertext> {
+  %d0 = tensor.empty() : tensor<!ciphertext>
+  %0 = cheddar.relinearize %ctx, %ct, %k, %d0
+      : (!context, tensor<!ciphertext>, !cheddar.eval_key, tensor<!ciphertext>) -> tensor<!ciphertext>
+  %d1 = tensor.empty() : tensor<!ciphertext>
+  %1 = cheddar.relinearize_rescale %ctx, %0, %k, %d1
+      : (!context, tensor<!ciphertext>, !cheddar.eval_key, tensor<!ciphertext>) -> tensor<!ciphertext>
+  return %1 : tensor<!ciphertext>
+}
+
+// HMult with an evaluation-key argument.
+func.func @hmult(%ctx: !context, %a: tensor<!ciphertext>,
+                 %b: tensor<!ciphertext>, %k: !cheddar.eval_key)
+    -> tensor<!ciphertext> {
+  %d0 = tensor.empty() : tensor<!ciphertext>
+  %0 = cheddar.hmult %ctx, %a, %b, %k, %d0 {rescale = true}
+      : (!context, tensor<!ciphertext>, tensor<!ciphertext>, !cheddar.eval_key, tensor<!ciphertext>)
+      -> tensor<!ciphertext>
+  return %0 : tensor<!ciphertext>
+}
+
+// Rotation / conjugation: the key is looked up inline via the UserInterface
+// argument, so these functions must carry a user_interface arg.
+func.func @rotations(%ctx: !context, %ui: !cheddar.user_interface,
+                     %a: tensor<!ciphertext>, %b: tensor<!ciphertext>)
+    -> tensor<!ciphertext> {
+  %d0 = tensor.empty() : tensor<!ciphertext>
+  %0 = cheddar.hrot %ctx, %ui, %a, %d0 {static_distance = 5 : i64}
+      : (!context, !cheddar.user_interface, tensor<!ciphertext>, tensor<!ciphertext>) -> tensor<!ciphertext>
+  %d1 = tensor.empty() : tensor<!ciphertext>
+  %1 = cheddar.hrot_add %ctx, %ui, %0, %b, %d1 {distance = 7 : i64}
+      : (!context, !cheddar.user_interface, tensor<!ciphertext>, tensor<!ciphertext>, tensor<!ciphertext>) -> tensor<!ciphertext>
+  %d2 = tensor.empty() : tensor<!ciphertext>
+  %2 = cheddar.hconj %ctx, %ui, %1, %d2
+      : (!context, !cheddar.user_interface, tensor<!ciphertext>, tensor<!ciphertext>) -> tensor<!ciphertext>
+  %d3 = tensor.empty() : tensor<!ciphertext>
+  %3 = cheddar.hconj_add %ctx, %ui, %2, %b, %d3
+      : (!context, !cheddar.user_interface, tensor<!ciphertext>, tensor<!ciphertext>, tensor<!ciphertext>) -> tensor<!ciphertext>
+  return %3 : tensor<!ciphertext>
+}
+
+// mad_unsafe with a *local* accumulator (the result of add): the accumulator
+// is the in-place DPS init, so MadUnsafe(acc, ...) binds fine. This path
+// already compiled; it's here as the control case.
+func.func @mad_local(%ctx: !context, %a: tensor<!ciphertext>,
+                     %b: tensor<!ciphertext>, %c: tensor<!constant>)
+    -> tensor<!ciphertext> {
+  %d0 = tensor.empty() : tensor<!ciphertext>
+  %acc = cheddar.add %ctx, %a, %b, %d0
+      : (!context, tensor<!ciphertext>, tensor<!ciphertext>, tensor<!ciphertext>) -> tensor<!ciphertext>
+  %r = cheddar.mad_unsafe %ctx, %acc, %a, %c
+      : (!context, tensor<!ciphertext>, tensor<!ciphertext>, tensor<!constant>)
+      -> tensor<!ciphertext>
+  return %r : tensor<!ciphertext>
+}
+
+// Bootstrapping-family ops taking an EvkMap argument (const EvkMap& at the C++
+// boundary).
+func.func @boot(%ctx: !cheddar.boot_context, %ct: tensor<!ciphertext>,
+                %evk: !cheddar.evk_map) -> tensor<!ciphertext> {
+  %d0 = tensor.empty() : tensor<!ciphertext>
+  %0 = cheddar.boot %ctx, %ct, %evk, %d0
+      : (!cheddar.boot_context, tensor<!ciphertext>, !cheddar.evk_map, tensor<!ciphertext>) -> tensor<!ciphertext>
+  return %0 : tensor<!ciphertext>
+}
+
+func.func @eval_poly(%ctx: !context, %enc: !encoder, %ct: tensor<!ciphertext>,
+                     %evk: !cheddar.evk_map) -> tensor<!ciphertext> {
+  %d0 = tensor.empty() : tensor<!ciphertext>
+  %0 = cheddar.eval_poly %ctx, %ct, %evk, %d0
+      {coefficients = [1.0 : f64, 2.0 : f64, 3.0 : f64], levelConsumption = 2 : i64}
+      : (!context, tensor<!ciphertext>, !cheddar.evk_map, tensor<!ciphertext>) -> tensor<!ciphertext>
+  return %0 : tensor<!ciphertext>
+}
+
+// Encrypt / Decrypt out-param calls on the UserInterface.
+func.func @encrypt_decrypt(%ui: !cheddar.user_interface, %pt: tensor<!plaintext>,
+                           %ct: tensor<!ciphertext>)
+    -> (tensor<!ciphertext>, tensor<!plaintext>) {
+  %d0 = tensor.empty() : tensor<!ciphertext>
+  %0 = cheddar.encrypt %ui, %pt, %d0
+      : (!cheddar.user_interface, tensor<!plaintext>, tensor<!ciphertext>) -> tensor<!ciphertext>
+  %d1 = tensor.empty() : tensor<!plaintext>
+  %1 = cheddar.decrypt %ui, %ct, %d1
+      : (!cheddar.user_interface, tensor<!ciphertext>, tensor<!plaintext>) -> tensor<!plaintext>
+  return %0, %1 : tensor<!ciphertext>, tensor<!plaintext>
+}
+
+// Destination-passing loop kernel: empty-tensor elimination redirects each
+// payload producer through tensor.insert_slice into element `i` of the output.
+// No payload store/copy remains after bufferization, and the boundary is a
+// mutable `std::array<Ciphertext<word>, 8>&`.
+func.func @loop_store(%ctx: !context, %in: tensor<!ciphertext>)
+    -> tensor<8x!ciphertext> {
+  %out = tensor.empty() : tensor<8x!ciphertext>
+  %c0 = arith.constant 0 : index
+  %c1 = arith.constant 1 : index
+  %c8 = arith.constant 8 : index
+  %r = scf.for %i = %c0 to %c8 step %c1 iter_args(%acc = %out)
+      -> (tensor<8x!ciphertext>) {
+    %d = tensor.empty() : tensor<!ciphertext>
+    %v = cheddar.add %ctx, %in, %in, %d
+        : (!context, tensor<!ciphertext>, tensor<!ciphertext>, tensor<!ciphertext>)
+        -> tensor<!ciphertext>
+    %ins = tensor.insert_slice %v into %acc[%i] [1] [1]
+        : tensor<!ciphertext> into tensor<8x!ciphertext>
+    scf.yield %ins : tensor<8x!ciphertext>
+  }
+  return %r : tensor<8x!ciphertext>
+}

--- a/tests/Conversions/CheddarToEmitC/debug.mlir
+++ b/tests/Conversions/CheddarToEmitC/debug.mlir
@@ -1,0 +1,45 @@
+// RUN: heir-opt --cheddar-bufferize --fold-memref-alias-ops --canonicalize --convert-to-emitc=filter-dialects=cheddar,arith,scf --cheddar-emitc-boundary --reconcile-unrealized-casts %s | FileCheck %s
+
+// A `__heir_debug_*` call (the form LWEToCheddar produces for cheddar --debug)
+// lowers to a free C++ `__heir_debug(encoder, ui, ct, "name", "metadata")`
+// call. The external `func.func` declaration is erased (the upstream Cpp
+// emitter cannot print an external func.func), so medusa's C++ prelude defines
+// `__heir_debug`.
+
+!ciphertext = !cheddar.ciphertext
+!context = !cheddar.context
+!encoder = !cheddar.encoder
+!user_interface = !cheddar.user_interface
+
+// The external declaration must NOT survive into the emitted module.
+// CHECK-NOT: @__heir_debug_0
+func.func private @__heir_debug_0(!encoder, !user_interface, tensor<!ciphertext>)
+
+// CHECK: func.func @debug_chain
+// Encoder + scalar ciphertext inputs are tightened to const C++ references; the
+// UserInterface stays a pointer.
+// CHECK-SAME: !emitc.opaque<"const Encoder<word>&">
+// CHECK-SAME: !emitc.ptr<!emitc.opaque<"UserInterface<word>">>
+// CHECK-SAME: !emitc.opaque<"const Ciphertext<word>&">
+// The debug.validate -> __heir_debug call: encoder, ui, ct operands plus the
+// name + metadata baked as trailing string-literal opaque args.
+// CHECK: emitc.call_opaque "__heir_debug"
+// CHECK-SAME: %arg0, %arg1, %arg2
+// CHECK-SAME: heir_val0
+// CHECK-SAME: heir_meta0
+func.func @debug_chain(%enc: !encoder, %ui: !user_interface, %ct: tensor<!ciphertext>) {
+  func.call @__heir_debug_0(%enc, %ui, %ct) {debug.name = "heir_val0", debug.metadata = "heir_meta0"} : (!encoder, !user_interface, tensor<!ciphertext>) -> ()
+  return
+}
+
+// A rank-1 (1-element array) ciphertext value -- the usual cheddar value rep --
+// lowers the ct operand to a const std::array<Ciphertext<word>, N>& (the medusa
+// C++ hook should accept both this and the scalar form, e.g. via a template).
+// CHECK: func.func @debug_arr
+// CHECK: emitc.call_opaque "__heir_debug"
+// CHECK-SAME: !emitc.opaque<"const std::array<Ciphertext<word>, 1>&">
+func.func private @__heir_debug_1(!encoder, !user_interface, tensor<1x!ciphertext>)
+func.func @debug_arr(%enc: !encoder, %ui: !user_interface, %ct: tensor<1x!ciphertext>) {
+  func.call @__heir_debug_1(%enc, %ui, %ct) {debug.name = "arr0", debug.metadata = "m"} : (!encoder, !user_interface, tensor<1x!ciphertext>) -> ()
+  return
+}

--- a/tests/Conversions/CheddarToEmitC/doctest.mlir
+++ b/tests/Conversions/CheddarToEmitC/doctest.mlir
@@ -1,0 +1,27 @@
+// RUN: heir-opt --cheddar-bufferize --fold-memref-alias-ops --cse --canonicalize --convert-to-emitc=filter-dialects=cheddar,arith,scf --cheddar-emitc-boundary --reconcile-unrealized-casts %s | FileCheck %s
+
+// A destination-passing `cheddar.add` (its `$output` operand is a
+// `tensor.empty`) lowers to an out-parameter `Context` method
+// call. `--cheddar-bufferize` turns the tensor result into a trailing memref
+// out-param before One-Shot, stock `--convert-to-emitc`
+// (with the cheddar dialect interface) emits `ctx->Add(out, a, b)`, and
+// `--cheddar-emitc-boundary` re-types the move-only payload args as C++
+// references: a mutable `Ciphertext<word>&` out-param and `const ...&` inputs.
+
+!ciphertext = !cheddar.ciphertext
+!context = !cheddar.context
+
+// CHECK: func.func @add(
+// CHECK-SAME: !emitc.ptr<!emitc.opaque<"Context<word>">>
+// CHECK-SAME: !emitc.opaque<"const Ciphertext<word>&">
+// CHECK-SAME: !emitc.opaque<"const Ciphertext<word>&">
+// CHECK-SAME: !emitc.opaque<"Ciphertext<word>&">
+// CHECK: emitc.member_call_opaque %arg0 "Add"(%arg3, %arg1, %arg2)
+func.func @add(%ctx: !context, %a: tensor<!ciphertext>,
+               %b: tensor<!ciphertext>) -> tensor<!ciphertext> {
+  %d = tensor.empty() : tensor<!ciphertext>
+  %c = cheddar.add %ctx, %a, %b, %d
+      : (!context, tensor<!ciphertext>, tensor<!ciphertext>, tensor<!ciphertext>)
+      -> tensor<!ciphertext>
+  return %c : tensor<!ciphertext>
+}

--- a/tests/Conversions/CheddarToEmitC/loop.mlir
+++ b/tests/Conversions/CheddarToEmitC/loop.mlir
@@ -1,0 +1,41 @@
+// RUN: heir-opt --cheddar-bufferize --fold-memref-alias-ops --cse --canonicalize --convert-to-emitc=filter-dialects=cheddar,arith,scf --cheddar-emitc-boundary --reconcile-unrealized-casts %s | FileCheck %s
+
+// A destination-passing loop kernel: an scf.for whose body computes a
+// ciphertext and writes it into element `i` of a locally allocated output via
+// `tensor.insert_slice`. Cheddar bufferization exposes the result out-parameter
+// before One-Shot, and the loop operates over a
+// `memref<8x!cheddar.ciphertext>`. Empty-tensor elimination redirects the
+// Cheddar producer into the dynamic-offset rank-reducing insertion subview, so
+// no payload copy/store survives bufferization. The Cheddar EmitC lowering
+// turns that destination into `out[i]`; SCF/Arith are lowered by their own
+// interfaces in the same pass.
+
+!ciphertext = !cheddar.ciphertext
+!context = !cheddar.context
+
+// The ops inside the `emitc.for` body print without the `emitc.` prefix (emitc
+// is the body region's default dialect), so match the bare op names there.
+// CHECK: func.func @loop_store
+// CHECK-SAME: %[[OUT:[a-zA-Z0-9_]+]]: !emitc.opaque<"std::array<Ciphertext<word>, 8>&"> {bufferize.result}
+// CHECK-NOT: emitc.variable
+// CHECK: emitc.for
+// CHECK: %[[ELEMENT:.*]] = subscript %[[OUT]][%{{.*}}]
+// CHECK: member_call_opaque %{{.*}} "Add"(%[[ELEMENT]],
+func.func @loop_store(%ctx: !context, %in: tensor<!ciphertext>)
+    -> tensor<8x!ciphertext> {
+  %out = tensor.empty() : tensor<8x!ciphertext>
+  %c0 = arith.constant 0 : index
+  %c1 = arith.constant 1 : index
+  %c8 = arith.constant 8 : index
+  %r = scf.for %i = %c0 to %c8 step %c1 iter_args(%acc = %out)
+      -> (tensor<8x!ciphertext>) {
+    %d = tensor.empty() : tensor<!ciphertext>
+    %v = cheddar.add %ctx, %in, %in, %d
+        : (!context, tensor<!ciphertext>, tensor<!ciphertext>, tensor<!ciphertext>)
+        -> tensor<!ciphertext>
+    %ins = tensor.insert_slice %v into %acc[%i] [1] [1]
+        : tensor<!ciphertext> into tensor<8x!ciphertext>
+    scf.yield %ins : tensor<8x!ciphertext>
+  }
+  return %r : tensor<8x!ciphertext>
+}

--- a/tests/Conversions/CheddarToEmitC/unsupported_getters.mlir
+++ b/tests/Conversions/CheddarToEmitC/unsupported_getters.mlir
@@ -1,0 +1,30 @@
+// RUN: heir-opt --cheddar-emitc-boundary --split-input-file --verify-diagnostics %s
+
+// The getter-style setup ops return a const reference to a move-only /
+// non-assignable CHEDDAR value (EvkMap, EvaluationKey, Encoder), which can't be
+// materialised into a local without a copy. The lowering rejects them rather
+// than emit uncompilable C++. Real kernels pass these as function arguments or
+// look them up inline (like HRot's rotation-key lookup). (create_user_interface
+// is now supported -- it is a DPS op producing an owning unique_ptr.)
+
+func.func @get_evk_map(%ui: !cheddar.user_interface) -> !cheddar.evk_map {
+  // expected-error @below {{lowering of 'cheddar.get_evk_map' is not supported}}
+  %m = cheddar.get_evk_map %ui : (!cheddar.user_interface) -> !cheddar.evk_map
+  return %m : !cheddar.evk_map
+}
+
+// -----
+
+func.func @get_mult_key(%ui: !cheddar.user_interface) -> !cheddar.eval_key {
+  // expected-error @below {{lowering of 'cheddar.get_mult_key' is not supported}}
+  %k = cheddar.get_mult_key %ui : (!cheddar.user_interface) -> !cheddar.eval_key
+  return %k : !cheddar.eval_key
+}
+
+// -----
+
+func.func @get_encoder(%ctx: !cheddar.context) -> !cheddar.encoder {
+  // expected-error @below {{lowering of 'cheddar.get_encoder' is not supported}}
+  %e = cheddar.get_encoder %ctx : (!cheddar.context) -> !cheddar.encoder
+  return %e : !cheddar.encoder
+}

--- a/tests/Conversions/CheddarToEmitC/unsupported_move_only_memref.mlir
+++ b/tests/Conversions/CheddarToEmitC/unsupported_move_only_memref.mlir
@@ -1,0 +1,46 @@
+// RUN: heir-opt --convert-to-emitc=filter-dialects=cheddar --split-input-file --verify-diagnostics %s
+
+// A dynamic-shape memref of a move-only cheddar payload can't be represented as
+// a fixed-size `std::array`, so the cheddar type converter refuses it and the
+// conversion fails -- rather than falling through to something stock
+// MemRefToEmitC would lower with copies of the move-only payloads.
+//
+// (Static multi-dimensional payload memrefs ARE supported now: they map to a
+// nested `std::array<std::array<...>>`, subscripted as `m[i][j]`. And a
+// move-only value carried through an scf.for iter_arg is likewise supported via
+// the destination-passing loop lowering -- see loop.mlir.)
+// expected-error @below {{failed to legalize operation 'func.func'}}
+func.func @dynamic(%m: memref<?x!cheddar.ciphertext>) {
+  return
+}
+
+// -----
+
+// Non-unit payload strides cannot be represented by a nested std::array.
+// expected-error @below {{failed to legalize operation 'func.func'}}
+func.func @strided_payload(
+    %m: memref<4x!cheddar.ciphertext, strided<[2]>>) {
+  return
+}
+
+// -----
+
+// Likewise, a raw float pointer would lose this stride and miscompile users.
+// expected-error @below {{failed to legalize operation 'func.func'}}
+func.func @strided_float(%ctx: !cheddar.context,
+                         %m: memref<4xf32, strided<[2]>>) {
+  return
+}
+
+// -----
+
+// A nested std::array subscript can remove only leading dimensions. Silently
+// treating a middle rank reduction as a leading one would select the wrong
+// ciphertext.
+func.func @drop_middle_dimension(
+    %m: memref<2x1x4x!cheddar.ciphertext>) {
+  // expected-error @below {{failed to legalize operation 'memref.subview'}}
+  %slice = memref.subview %m[0, 0, 0] [2, 1, 4] [1, 1, 1]
+      : memref<2x1x4x!cheddar.ciphertext> to memref<2x4x!cheddar.ciphertext>
+  return
+}

--- a/tests/Conversions/CheddarToEmitC/unsupported_payload_copy.mlir
+++ b/tests/Conversions/CheddarToEmitC/unsupported_payload_copy.mlir
@@ -1,0 +1,45 @@
+// RUN: heir-opt --convert-to-emitc=filter-dialects=cheddar --split-input-file --verify-diagnostics %s
+
+// A memref.copy is not an ownership-transfer operation. Moving from a borrowed
+// function argument would silently consume the caller's ciphertext.
+func.func @borrowed_source(
+    %src: memref<!cheddar.ciphertext>,
+    %dst: memref<!cheddar.ciphertext>) {
+  // expected-error @below {{copying a move-only Cheddar value with memref.copy is invalid}}
+  memref.copy %src, %dst
+      : memref<!cheddar.ciphertext> to memref<!cheddar.ciphertext>
+  return
+}
+
+// -----
+
+// A self-copy is a no-op, not a self-move.
+func.func @self_copy(%value: memref<!cheddar.ciphertext>) {
+  memref.copy %value, %value
+      : memref<!cheddar.ciphertext> to memref<!cheddar.ciphertext>
+  return
+}
+
+// -----
+
+// Local ownership does not turn memref.copy into an ownership transfer.
+func.func @local_source(%dst: memref<!cheddar.ciphertext>) {
+  %src = memref.alloc() : memref<!cheddar.ciphertext>
+  // expected-error @below {{copying a move-only Cheddar value with memref.copy is invalid}}
+  memref.copy %src, %dst
+      : memref<!cheddar.ciphertext> to memref<!cheddar.ciphertext>
+  return
+}
+
+// -----
+
+// The setup UI is represented by std::unique_ptr at an owning buffer boundary
+// and is subject to the same no-copy rule as ciphertext payloads.
+func.func @user_interface_copy(
+    %src: memref<!cheddar.user_interface>,
+    %dst: memref<!cheddar.user_interface>) {
+  // expected-error @below {{copying a move-only Cheddar value with memref.copy is invalid}}
+  memref.copy %src, %dst
+      : memref<!cheddar.user_interface> to memref<!cheddar.user_interface>
+  return
+}

--- a/tests/Conversions/CheddarToEmitC/unsupported_payload_copy.mlir
+++ b/tests/Conversions/CheddarToEmitC/unsupported_payload_copy.mlir
@@ -1,13 +1,26 @@
 // RUN: heir-opt --convert-to-emitc=filter-dialects=cheddar --split-input-file --verify-diagnostics %s
 
-// A memref.copy is not an ownership-transfer operation. Moving from a borrowed
-// function argument would silently consume the caller's ciphertext.
+// A ciphertext memref.copy is a real deep copy, not an ownership transfer.
 func.func @borrowed_source(
+    %ctx: !cheddar.context,
     %src: memref<!cheddar.ciphertext>,
     %dst: memref<!cheddar.ciphertext>) {
-  // expected-error @below {{copying a move-only Cheddar value with memref.copy is invalid}}
   memref.copy %src, %dst
       : memref<!cheddar.ciphertext> to memref<!cheddar.ciphertext>
+  return
+}
+
+// -----
+
+// Rank-0 subviews use an explicit strided layout. They have the same deep-copy
+// semantics as identity-layout ciphertext buffers.
+func.func @strided_scalar(
+    %ctx: !cheddar.context,
+    %src: memref<!cheddar.ciphertext, strided<[]>>,
+    %dst: memref<!cheddar.ciphertext, strided<[]>>) {
+  memref.copy %src, %dst
+      : memref<!cheddar.ciphertext, strided<[]>>
+        to memref<!cheddar.ciphertext, strided<[]>>
   return
 }
 
@@ -22,10 +35,22 @@ func.func @self_copy(%value: memref<!cheddar.ciphertext>) {
 
 // -----
 
-// Local ownership does not turn memref.copy into an ownership transfer.
-func.func @local_source(%dst: memref<!cheddar.ciphertext>) {
+// Local ownership does not change the copy semantics.
+func.func @local_source(%ctx: !cheddar.context,
+                        %dst: memref<!cheddar.ciphertext>) {
   %src = memref.alloc() : memref<!cheddar.ciphertext>
-  // expected-error @below {{copying a move-only Cheddar value with memref.copy is invalid}}
+  memref.copy %src, %dst
+      : memref<!cheddar.ciphertext> to memref<!cheddar.ciphertext>
+  return
+}
+
+// -----
+
+// CHEDDAR needs a context to perform a ciphertext deep copy.
+func.func @missing_context(
+    %src: memref<!cheddar.ciphertext>,
+    %dst: memref<!cheddar.ciphertext>) {
+  // expected-error @below {{cannot deep-copy a Cheddar ciphertext without a context argument}}
   memref.copy %src, %dst
       : memref<!cheddar.ciphertext> to memref<!cheddar.ciphertext>
   return
@@ -34,7 +59,7 @@ func.func @local_source(%dst: memref<!cheddar.ciphertext>) {
 // -----
 
 // The setup UI is represented by std::unique_ptr at an owning buffer boundary
-// and is subject to the same no-copy rule as ciphertext payloads.
+// and has no deep-copy operation.
 func.func @user_interface_copy(
     %src: memref<!cheddar.user_interface>,
     %dst: memref<!cheddar.user_interface>) {

--- a/tests/Conversions/CheddarToEmitC/unsupported_payload_store.mlir
+++ b/tests/Conversions/CheddarToEmitC/unsupported_payload_store.mlir
@@ -1,0 +1,36 @@
+// RUN: heir-opt --convert-to-emitc=filter-dialects=cheddar,arith --split-input-file --verify-diagnostics %s
+
+// memref.store has copy semantics. It cannot be reinterpreted as an ownership
+// transfer merely because a move-only payload happens to be dead or local.
+func.func @borrowed_source(
+    %src: memref<!cheddar.plaintext>,
+    %dst: memref<!cheddar.plaintext>) {
+  %value = memref.load %src[] : memref<!cheddar.plaintext>
+  // expected-error @below {{copying a move-only Cheddar payload with memref.store is invalid}}
+  memref.store %value, %dst[] : memref<!cheddar.plaintext>
+  return
+}
+
+// -----
+
+func.func @local_source(%dst: memref<!cheddar.plaintext>) {
+  %src = memref.alloc() : memref<!cheddar.plaintext>
+  %value = memref.load %src[] : memref<!cheddar.plaintext>
+  // expected-error @below {{copying a move-only Cheddar payload with memref.store is invalid}}
+  memref.store %value, %dst[] : memref<!cheddar.plaintext>
+  return
+}
+
+// -----
+
+func.func @source_used_twice(%dst: memref<2x!cheddar.plaintext>) {
+  %src = memref.alloc() : memref<!cheddar.plaintext>
+  %value = memref.load %src[] : memref<!cheddar.plaintext>
+  %c0 = arith.constant 0 : index
+  %c1 = arith.constant 1 : index
+  // expected-error @below {{copying a move-only Cheddar payload with memref.store is invalid}}
+  memref.store %value, %dst[%c0] : memref<2x!cheddar.plaintext>
+  // expected-error @below {{copying a move-only Cheddar payload with memref.store is invalid}}
+  memref.store %value, %dst[%c1] : memref<2x!cheddar.plaintext>
+  return
+}

--- a/tests/Dialect/Cheddar/IR/roundtrip.mlir
+++ b/tests/Dialect/Cheddar/IR/roundtrip.mlir
@@ -67,7 +67,7 @@ func.func @test_encode(
     %out: tensor<!cheddar.plaintext>) -> tensor<!cheddar.plaintext> {
   // CHECK: cheddar.encode
   // CHECK-SAME: level = 5
-  %pt = cheddar.encode %enc, %msg, %out {level = 5 : i64} : (!cheddar.encoder, tensor<4xf64>, tensor<!cheddar.plaintext>) -> tensor<!cheddar.plaintext>
+  %pt = cheddar.encode %enc, %msg, %out {level = 5 : i64, logScale = 37 : i64} : (!cheddar.encoder, tensor<4xf64>, tensor<!cheddar.plaintext>) -> tensor<!cheddar.plaintext>
   return %pt : tensor<!cheddar.plaintext>
 }
 
@@ -406,8 +406,7 @@ func.func @test_eval_poly(
     %out: tensor<!cheddar.ciphertext>) -> tensor<!cheddar.ciphertext> {
   // CHECK: cheddar.eval_poly
   // CHECK-SAME: coefficients = [1.000000e+00, 2.000000e+00, 3.000000e+00]
-  // CHECK-SAME: level = 5
-  // CHECK-SAME: outputLevel = 4
-  %result = cheddar.eval_poly %ctx, %ct, %evk, %out {coefficients = [1.0 : f64, 2.0 : f64, 3.0 : f64], level = 5 : i64, outputLevel = 4 : i64} : (!cheddar.context, tensor<!cheddar.ciphertext>, !cheddar.evk_map, tensor<!cheddar.ciphertext>) -> tensor<!cheddar.ciphertext>
+  // CHECK-SAME: levelConsumption = 2
+  %result = cheddar.eval_poly %ctx, %ct, %evk, %out {coefficients = [1.0 : f64, 2.0 : f64, 3.0 : f64], levelConsumption = 2 : i64} : (!cheddar.context, tensor<!cheddar.ciphertext>, !cheddar.evk_map, tensor<!cheddar.ciphertext>) -> tensor<!cheddar.ciphertext>
   return %result : tensor<!cheddar.ciphertext>
 }

--- a/tests/Examples/cheddar/add_e2e/BUILD
+++ b/tests/Examples/cheddar/add_e2e/BUILD
@@ -1,0 +1,86 @@
+load("@heir//bazel/cheddar:config.bzl", "requires_cheddar")
+load("@heir//tools:heir-opt.bzl", "heir_opt")
+load("@heir//tools:heir-translate.bzl", "heir_translate")
+load("@rules_cc//cc:cc_library.bzl", "cc_library")
+load("@rules_cc//cc:cc_test.bzl", "cc_test")
+
+package(
+    default_applicable_licenses = ["@heir//:license"],
+    default_visibility = ["//visibility:public"],
+)
+
+# End-to-end: additive grab-bag (ct+ct, ct-ct, ct+const) on two secret 1024-vectors. The cheddar-level IR is a full module (client
+# encrypt/decrypt helpers + compute), so the harness just calls the generated
+# functions; lower it the rest of the way to emitc.
+heir_opt(
+    name = "add_e2e_emitc",
+    src = "add_e2e.mlir",
+    generated_filename = "add_e2e_emitc.mlir",
+    pass_flags = [
+        "--cheddar-bufferize",
+        "--fold-memref-alias-ops",
+        "--cse",
+        "--canonicalize",
+        "--drop-equivalent-buffer-results",
+        "--buffer-results-to-out-params=hoist-static-allocs=true modify-public-functions=true add-result-attr=true",
+        "--canonicalize",
+        "--convert-to-emitc=filter-dialects=cheddar,arith,scf",
+        "--cheddar-emitc-boundary",
+        "--reconcile-unrealized-casts",
+    ],
+)
+
+heir_translate(
+    name = "add_e2e_cpp_raw",
+    src = ":add_e2e_emitc.mlir",
+    generated_filename = "add_e2e_raw.cc",
+    pass_flags = ["--mlir-to-cpp"],
+)
+
+genrule(
+    name = "add_e2e_lib_src",
+    srcs = [":add_e2e_raw.cc"],
+    outs = ["add_e2e_lib.cc"],
+    cmd = """cat > $@ <<'PRELUDE_EOF'
+// AUTO-GENERATED: do not edit. See tests/Examples/cheddar/add_e2e/BUILD.
+#include <array>
+#include <complex>
+#include <cstddef>
+#include <cstdint>
+#include <utility>
+#include <vector>
+#include "core/Context.h"
+#include "core/Encode.h"
+#include "core/Parameter.h"
+#include "UserInterface.h"
+using namespace cheddar;
+using word = uint64_t;
+using Complex = std::complex<double>;
+PRELUDE_EOF
+cat $(location :add_e2e_raw.cc) >> $@
+""",
+)
+
+cc_library(
+    name = "add_e2e_lib",
+    srcs = [":add_e2e_lib_src"],
+    target_compatible_with = requires_cheddar(),
+    deps = ["@cheddar"],
+)
+
+cc_test(
+    name = "add_e2e_test",
+    timeout = "long",
+    srcs = ["add_e2e_test.cpp"],
+    linkstatic = False,
+    tags = [
+        "exclusive",
+        "notap",
+    ],
+    target_compatible_with = requires_cheddar(),
+    deps = [
+        ":add_e2e_lib",
+        "@cheddar",
+        "@googletest//:gtest_main",
+    ],
+)

--- a/tests/Examples/cheddar/add_e2e/add_e2e.mlir
+++ b/tests/Examples/cheddar/add_e2e/add_e2e.mlir
@@ -1,0 +1,123 @@
+// Arithmetic grab-bag on two secret 1024-vectors at the cheddar level -- ct+ct,
+// then ct-ct, then ct*plaintext(2.0), then ct+plaintext(0.5), so the result is
+// 2*a + 0.5. Full-module e2e input (client encrypt/decrypt helpers + a
+// preprocessing that encodes the 2.0 and 0.5 constants + compute).
+//
+// Destination-passing form: each payload-producing cheddar op takes an explicit
+// shape-only `tensor.empty` destination (its `outs` init); a scalar payload
+// is a rank-0 `tensor<!cheddar.X>`, extracted from / inserted into the
+// `tensor<1x!cheddar.X>` packing container via rank-reducing slice ops.
+//
+// The plaintext multiply makes this depth-1 (max_level 1, two Q primes) -- a
+// single Q prime is not a viable CHEDDAR modulus chain. The 2.0 is encoded at
+// the top level (level 1); the product is rescaled back to the canonical scale
+// before adding the 0.5, which is encoded at level 0 -- so every op sees
+// matching per-level GetScale scales, no scale bake or tolerance needed.
+!ciphertext = !cheddar.ciphertext
+!context = !cheddar.context
+!encoder = !cheddar.encoder
+!eval_key = !cheddar.eval_key
+!plaintext = !cheddar.plaintext
+!user_interface = !cheddar.user_interface
+#layout = #tensor_ext.layout<"{ [i0] -> [ct, slot] : ct = 0 and (-i0 + slot) mod 1024 = 0 and 0 <= i0 <= 1023 and 0 <= slot <= 1023 }">
+#original_type = #tensor_ext.original_type<originalType = tensor<1024xf32>, layout = #layout>
+module attributes {backend.cheddar, cheddar.P = array<i64: 1152921504606994433>, cheddar.Q = array<i64: 36028797018652673, 35184372121601>, cheddar.logDefaultScale = 45 : i64, cheddar.logN = 13 : i64, scheme.actual_slot_count = 4096 : i64, scheme.requested_slot_count = 1024 : i64} {
+  func.func @add__preprocessing(%encoder: !encoder) -> (tensor<1x!plaintext>, tensor<1x!plaintext>) attributes {client.pack_func = {func_name = "add"}} {
+    %cst = arith.constant dense<2.000000e+00> : tensor<1024xf32>
+    %cst_0 = arith.constant dense<5.000000e-01> : tensor<1024xf32>
+    %d_pt = tensor.empty() : tensor<!plaintext>
+    %pt = cheddar.encode %encoder, %cst, %d_pt {level = 1 : i64} : (!encoder, tensor<1024xf32>, tensor<!plaintext>) -> tensor<!plaintext>
+    %d_pt_0 = tensor.empty() : tensor<!plaintext>
+    %pt_1 = cheddar.encode %encoder, %cst_0, %d_pt_0 {level = 0 : i64} : (!encoder, tensor<1024xf32>, tensor<!plaintext>) -> tensor<!plaintext>
+    %e0 = tensor.empty() : tensor<1x!plaintext>
+    %from_elements = tensor.insert_slice %pt_1 into %e0[0] [1] [1] : tensor<!plaintext> into tensor<1x!plaintext>
+    %e1 = tensor.empty() : tensor<1x!plaintext>
+    %from_elements_2 = tensor.insert_slice %pt into %e1[0] [1] [1] : tensor<!plaintext> into tensor<1x!plaintext>
+    return %from_elements, %from_elements_2 : tensor<1x!plaintext>, tensor<1x!plaintext>
+  }
+  func.func @add__preprocessed(%ctx: !context, %encoder: !encoder, %ui: !user_interface, %evk: !eval_key, %arg0: tensor<1x!ciphertext>, %arg1: tensor<1x!ciphertext>, %arg2: tensor<1x!plaintext>, %arg3: tensor<1x!plaintext>) -> tensor<1x!ciphertext> attributes {client.preprocessed_func = {func_name = "add"}} {
+    %pt_05 = tensor.extract_slice %arg2[0] [1] [1] : tensor<1x!plaintext> to tensor<!plaintext>
+    %pt_20 = tensor.extract_slice %arg3[0] [1] [1] : tensor<1x!plaintext> to tensor<!plaintext>
+    %a = tensor.extract_slice %arg0[0] [1] [1] : tensor<1x!ciphertext> to tensor<!ciphertext>
+    %b = tensor.extract_slice %arg1[0] [1] [1] : tensor<1x!ciphertext> to tensor<!ciphertext>
+    %d0 = tensor.empty() : tensor<!ciphertext>
+    %ct = cheddar.add %ctx, %a, %b, %d0 : (!context, tensor<!ciphertext>, tensor<!ciphertext>, tensor<!ciphertext>) -> tensor<!ciphertext>
+    %d1 = tensor.empty() : tensor<!ciphertext>
+    %ct_3 = cheddar.sub %ctx, %ct, %a, %d1 : (!context, tensor<!ciphertext>, tensor<!ciphertext>, tensor<!ciphertext>) -> tensor<!ciphertext>
+    %d2 = tensor.empty() : tensor<!ciphertext>
+    %ct_4 = cheddar.mult_plain %ctx, %ct_3, %pt_20, %d2 : (!context, tensor<!ciphertext>, tensor<!plaintext>, tensor<!ciphertext>) -> tensor<!ciphertext>
+    %d3 = tensor.empty() : tensor<!ciphertext>
+    %ct_5 = cheddar.rescale %ctx, %ct_4, %d3 : (!context, tensor<!ciphertext>, tensor<!ciphertext>) -> tensor<!ciphertext>
+    %d4 = tensor.empty() : tensor<!ciphertext>
+    %ct_6 = cheddar.add_plain %ctx, %ct_5, %pt_05, %d4 : (!context, tensor<!ciphertext>, tensor<!plaintext>, tensor<!ciphertext>) -> tensor<!ciphertext>
+    %e = tensor.empty() : tensor<1x!ciphertext>
+    %inserted = tensor.insert_slice %ct_6 into %e[0] [1] [1] : tensor<!ciphertext> into tensor<1x!ciphertext>
+    return %inserted : tensor<1x!ciphertext>
+  }
+  func.func @add(%ctx: !context, %encoder: !encoder, %ui: !user_interface, %evk: !eval_key, %arg0: tensor<1x!ciphertext> {tensor_ext.original_type = #original_type}, %arg1: tensor<1x!ciphertext> {tensor_ext.original_type = #original_type}) -> (tensor<1x!ciphertext> {tensor_ext.original_type = #original_type}) {
+    %0:2 = call @add__preprocessing(%encoder) : (!encoder) -> (tensor<1x!plaintext>, tensor<1x!plaintext>)
+    %1 = call @add__preprocessed(%ctx, %encoder, %ui, %evk, %arg0, %arg1, %0#0, %0#1) : (!context, !encoder, !user_interface, !eval_key, tensor<1x!ciphertext>, tensor<1x!ciphertext>, tensor<1x!plaintext>, tensor<1x!plaintext>) -> tensor<1x!ciphertext>
+    return %1 : tensor<1x!ciphertext>
+  }
+  func.func @add__encrypt__arg0(%ctx: !context, %encoder: !encoder, %ui: !user_interface, %evk: !eval_key, %arg0: tensor<1024xf32>, %ui_0: !user_interface) -> tensor<1x!ciphertext> attributes {client.enc_func = {func_name = "add", index = 0 : i64}} {
+    %c0 = arith.constant 0 : index
+    %cst = arith.constant dense<0.000000e+00> : tensor<1x1024xf32>
+    %c0_i32 = arith.constant 0 : i32
+    %c1_i32 = arith.constant 1 : i32
+    %c1024_i32 = arith.constant 1024 : i32
+    %0 = scf.for %arg1 = %c0_i32 to %c1024_i32 step %c1_i32 iter_args(%arg2 = %cst) -> (tensor<1x1024xf32>)  : i32 {
+      %1 = arith.index_cast %arg1 : i32 to index
+      %extracted = tensor.extract %arg0[%1] : tensor<1024xf32>
+      %inserted = tensor.insert %extracted into %arg2[%c0, %1] : tensor<1x1024xf32>
+      scf.yield %inserted : tensor<1x1024xf32>
+    }
+    %extracted_slice = tensor.extract_slice %0[0, 0] [1, 1024] [1, 1] : tensor<1x1024xf32> to tensor<1024xf32>
+    %d_pt = tensor.empty() : tensor<!plaintext>
+    %pt = cheddar.encode %encoder, %extracted_slice, %d_pt {level = 1 : i64} : (!encoder, tensor<1024xf32>, tensor<!plaintext>) -> tensor<!plaintext>
+    %d_ct = tensor.empty() : tensor<!ciphertext>
+    %ct = cheddar.encrypt %ui, %pt, %d_ct : (!user_interface, tensor<!plaintext>, tensor<!ciphertext>) -> tensor<!ciphertext>
+    %e = tensor.empty() : tensor<1x!ciphertext>
+    %from_elements = tensor.insert_slice %ct into %e[0] [1] [1] : tensor<!ciphertext> into tensor<1x!ciphertext>
+    return %from_elements : tensor<1x!ciphertext>
+  }
+  func.func @add__encrypt__arg1(%ctx: !context, %encoder: !encoder, %ui: !user_interface, %evk: !eval_key, %arg0: tensor<1024xf32>, %ui_0: !user_interface) -> tensor<1x!ciphertext> attributes {client.enc_func = {func_name = "add", index = 1 : i64}} {
+    %c0 = arith.constant 0 : index
+    %cst = arith.constant dense<0.000000e+00> : tensor<1x1024xf32>
+    %c0_i32 = arith.constant 0 : i32
+    %c1_i32 = arith.constant 1 : i32
+    %c1024_i32 = arith.constant 1024 : i32
+    %0 = scf.for %arg1 = %c0_i32 to %c1024_i32 step %c1_i32 iter_args(%arg2 = %cst) -> (tensor<1x1024xf32>)  : i32 {
+      %1 = arith.index_cast %arg1 : i32 to index
+      %extracted = tensor.extract %arg0[%1] : tensor<1024xf32>
+      %inserted = tensor.insert %extracted into %arg2[%c0, %1] : tensor<1x1024xf32>
+      scf.yield %inserted : tensor<1x1024xf32>
+    }
+    %extracted_slice = tensor.extract_slice %0[0, 0] [1, 1024] [1, 1] : tensor<1x1024xf32> to tensor<1024xf32>
+    %d_pt = tensor.empty() : tensor<!plaintext>
+    %pt = cheddar.encode %encoder, %extracted_slice, %d_pt {level = 1 : i64} : (!encoder, tensor<1024xf32>, tensor<!plaintext>) -> tensor<!plaintext>
+    %d_ct = tensor.empty() : tensor<!ciphertext>
+    %ct = cheddar.encrypt %ui, %pt, %d_ct : (!user_interface, tensor<!plaintext>, tensor<!ciphertext>) -> tensor<!ciphertext>
+    %e = tensor.empty() : tensor<1x!ciphertext>
+    %from_elements = tensor.insert_slice %ct into %e[0] [1] [1] : tensor<!ciphertext> into tensor<1x!ciphertext>
+    return %from_elements : tensor<1x!ciphertext>
+  }
+  func.func @add__decrypt__result0(%ctx: !context, %encoder: !encoder, %ui: !user_interface, %evk: !eval_key, %arg0: tensor<1x!ciphertext>, %ui_0: !user_interface) -> tensor<1024xf32> attributes {client.dec_func = {func_name = "add", index = 0 : i64}} {
+    %c0 = arith.constant 0 : index
+    %c1024_i32 = arith.constant 1024 : i32
+    %c1_i32 = arith.constant 1 : i32
+    %c0_i32 = arith.constant 0 : i32
+    %cst = arith.constant dense<0.000000e+00> : tensor<1024xf32>
+    %a_ct = tensor.extract_slice %arg0[0] [1] [1] : tensor<1x!ciphertext> to tensor<!ciphertext>
+    %d_pt = tensor.empty() : tensor<!plaintext>
+    %pt = cheddar.decrypt %ui, %a_ct, %d_pt : (!user_interface, tensor<!ciphertext>, tensor<!plaintext>) -> tensor<!plaintext>
+    %0 = tensor.empty() : tensor<1x1024xf32>
+    %1 = cheddar.decode %encoder, %pt, %0 : (!encoder, tensor<!plaintext>, tensor<1x1024xf32>) -> tensor<1x1024xf32>
+    %2 = scf.for %arg1 = %c0_i32 to %c1024_i32 step %c1_i32 iter_args(%arg2 = %cst) -> (tensor<1024xf32>)  : i32 {
+      %3 = arith.index_cast %arg1 : i32 to index
+      %extracted_1 = tensor.extract %1[%c0, %3] : tensor<1x1024xf32>
+      %inserted = tensor.insert %extracted_1 into %arg2[%3] : tensor<1024xf32>
+      scf.yield %inserted : tensor<1024xf32>
+    }
+    return %2 : tensor<1024xf32>
+  }
+}

--- a/tests/Examples/cheddar/add_e2e/add_e2e_test.cpp
+++ b/tests/Examples/cheddar/add_e2e/add_e2e_test.cpp
@@ -1,0 +1,95 @@
+// End-to-end GPU run of an arithmetic grab-bag (ct+ct, ct-ct,
+// ct*plaintext(2.0), ct+plaintext(0.5), so the result is 2*b + 0.5) via the
+// cheddar backend. The whole lowered module is exercised -- the generated
+// `add__encrypt__arg{0,1}` / `add__decrypt__result0` client helpers, the
+// `add__preprocessing` that encodes the 2.0/0.5 constants, and the `add`
+// compute kernel -- so the harness just calls the generated functions.
+
+#include <gtest/gtest.h>
+
+#include <algorithm>
+#include <array>
+#include <cmath>
+#include <complex>
+#include <cstdint>
+#include <cstdio>
+#include <memory>
+#include <random>
+#include <utility>
+#include <vector>
+
+#include "UserInterface.h"
+#include "core/Context.h"
+#include "core/Encode.h"
+#include "core/Parameter.h"
+
+using word = uint64_t;
+using Ct = cheddar::Ciphertext<word>;
+using Evk = cheddar::EvaluationKey<word>;
+using UI = cheddar::UserInterface<word>;
+
+void add__encrypt__arg0(cheddar::Context<word>* ctx,
+                        const cheddar::Encoder<word>& encoder, UI* ui,
+                        const Evk& evk, float a[1024], UI* ui2,
+                        std::array<Ct, 1>& out);
+void add__encrypt__arg1(cheddar::Context<word>* ctx,
+                        const cheddar::Encoder<word>& encoder, UI* ui,
+                        const Evk& evk, float b[1024], UI* ui2,
+                        std::array<Ct, 1>& out);
+void add(cheddar::Context<word>* ctx, const cheddar::Encoder<word>& encoder,
+         UI* ui, const Evk& evk, const std::array<Ct, 1>& a,
+         const std::array<Ct, 1>& b, std::array<Ct, 1>& out);
+void add__decrypt__result0(cheddar::Context<word>* ctx,
+                           const cheddar::Encoder<word>& encoder, UI* ui,
+                           const Evk& evk, const std::array<Ct, 1>& in, UI* ui2,
+                           float* out);
+
+namespace {
+constexpr int kN = 1024;
+constexpr int kMaxLevel = 1;  // one plaintext multiply -> depth 1
+cheddar::Parameter<word> MakeParam() {
+  std::vector<word> main_primes = {36028797018652673ULL, 35184372121601ULL};
+  std::vector<word> aux_primes = {1152921504606994433ULL};
+  std::vector<std::pair<int, int>> level_config;
+  for (int i = 1; i <= static_cast<int>(main_primes.size()); ++i)
+    level_config.emplace_back(i, 0);
+  return cheddar::Parameter<word>(
+      /*logN=*/13, /*scale=*/static_cast<double>(1ULL << 45), kMaxLevel,
+      level_config, main_primes, aux_primes);
+}
+}  // namespace
+
+TEST(CheddarAddE2E, GpuRun) {
+  std::mt19937 gen(123);
+  std::uniform_real_distribution<double> dist(-1.0, 1.0);
+  static float a[1024], b[1024];
+  static float ref[1024];
+  for (int i = 0; i < kN; ++i) {
+    a[i] = static_cast<float>(dist(gen));
+    b[i] = static_cast<float>(dist(gen));
+    ref[i] = 2.0f * b[i] + 0.5f;  // ((a + b) - a) * 2 + 0.5
+  }
+
+  auto param = MakeParam();
+  auto ctx = cheddar::Context<word>::Create(param);
+  auto ui = std::make_unique<UI>(ctx);
+  const Evk& evk = ui->GetMultiplicationKey();
+
+  std::array<Ct, 1> ca, cb, cout;
+  add__encrypt__arg0(ctx.get(), ctx->encoder_, ui.get(), evk, a, ui.get(), ca);
+  add__encrypt__arg1(ctx.get(), ctx->encoder_, ui.get(), evk, b, ui.get(), cb);
+  add(ctx.get(), ctx->encoder_, ui.get(), evk, ca, cb, cout);
+  static float result[1024];
+  add__decrypt__result0(ctx.get(), ctx->encoder_, ui.get(), evk, cout, ui.get(),
+                        result);
+
+  double max_abs = 0;
+  for (int i = 0; i < kN; ++i) {
+    double error = std::abs(static_cast<double>(result[i]) - ref[i]);
+    ASSERT_TRUE(std::isfinite(error)) << "non-finite result at slot " << i;
+    max_abs = std::max(max_abs, error);
+  }
+  std::printf("add: max|d|=%.6e (e.g. fhe[0]=%.5f ref[0]=%.5f)\n", max_abs,
+              result[0], ref[0]);
+  EXPECT_LT(max_abs, 1e-2);
+}

--- a/tests/Examples/cheddar/bootstrap/BUILD
+++ b/tests/Examples/cheddar/bootstrap/BUILD
@@ -1,0 +1,90 @@
+load("@heir//bazel/cheddar:config.bzl", "requires_cheddar")
+load("@heir//tools:heir-opt.bzl", "heir_opt")
+load("@heir//tools:heir-translate.bzl", "heir_translate")
+load("@rules_cc//cc:cc_library.bzl", "cc_library")
+load("@rules_cc//cc:cc_test.bzl", "cc_test")
+
+package(
+    default_applicable_licenses = ["@heir//:license"],
+    default_visibility = ["//visibility:public"],
+)
+
+# End-to-end: a real CHEDDAR GPU bootstrap. Encrypt at level 0, refresh with
+# cheddar.boot (-> BootContext::Boot), decrypt, and check boot(x) ~= x. The IR is
+# a curated cheddar-level module (like the lattigo bootstrap test): HEIR's param
+# generation can't produce CHEDDAR's deep bootstrap modulus chain, so the harness
+# drives the real bootparam_40_64bit param set and the IR only carries the
+# level-0 encode (baked to the exact GetScale(0)) + the boot/encrypt/decrypt ops.
+heir_opt(
+    name = "bootstrap_emitc",
+    src = "bootstrap.mlir",
+    generated_filename = "bootstrap_emitc.mlir",
+    pass_flags = [
+        "--cheddar-bufferize",
+        "--fold-memref-alias-ops",
+        "--cse",
+        "--canonicalize",
+        "--drop-equivalent-buffer-results",
+        "--buffer-results-to-out-params=hoist-static-allocs=true modify-public-functions=true add-result-attr=true",
+        "--canonicalize",
+        "--convert-to-emitc=filter-dialects=cheddar,arith,scf",
+        "--cheddar-emitc-boundary",
+        "--reconcile-unrealized-casts",
+    ],
+)
+
+heir_translate(
+    name = "bootstrap_cpp_raw",
+    src = ":bootstrap_emitc.mlir",
+    generated_filename = "bootstrap_raw.cc",
+    pass_flags = ["--mlir-to-cpp"],
+)
+
+genrule(
+    name = "bootstrap_lib_src",
+    srcs = [":bootstrap_raw.cc"],
+    outs = ["bootstrap_lib.cc"],
+    cmd = """cat > $@ <<'PRELUDE_EOF'
+// AUTO-GENERATED: do not edit. See tests/Examples/cheddar/bootstrap/BUILD.
+#include <array>
+#include <complex>
+#include <cstddef>
+#include <cstdint>
+#include <utility>
+#include <vector>
+#include "core/Context.h"
+#include "core/Encode.h"
+#include "core/Parameter.h"
+#include "extension/BootContext.h"
+#include "UserInterface.h"
+using namespace cheddar;
+using word = uint64_t;
+using Complex = std::complex<double>;
+PRELUDE_EOF
+cat $(location :bootstrap_raw.cc) >> $@
+""",
+)
+
+cc_library(
+    name = "bootstrap_lib",
+    srcs = [":bootstrap_lib_src"],
+    target_compatible_with = requires_cheddar(),
+    deps = ["@cheddar"],
+)
+
+cc_test(
+    name = "bootstrap_test",
+    timeout = "long",
+    srcs = ["bootstrap_test.cpp"],
+    linkstatic = False,
+    tags = [
+        "exclusive",
+        "notap",
+    ],
+    target_compatible_with = requires_cheddar(),
+    deps = [
+        ":bootstrap_lib",
+        "@cheddar",
+        "@googletest//:gtest_main",
+    ],
+)

--- a/tests/Examples/cheddar/bootstrap/bootstrap.mlir
+++ b/tests/Examples/cheddar/bootstrap/bootstrap.mlir
@@ -1,0 +1,86 @@
+// A real CHEDDAR GPU bootstrap at the cheddar level: encrypt a secret 1024-vector
+// at level 0 (the bottom), refresh its noise budget with cheddar.boot, then
+// decrypt -- so the result is (approximately) the input. Full-module e2e input
+// (client encrypt/decrypt helpers + the boot compute).
+//
+// This IR is curated rather than pipeline-generated, mirroring the lattigo
+// bootstrap example (tests/Examples/lattigo/ckks/bootstrapping): HEIR's CKKS
+// param generation produces only a shallow modulus chain, but a real CHEDDAR
+// Boot needs a deep bootstrap parameter set (CoeffToSlot + EvalMod + SlotToCoeff
+// consume many levels). The harness therefore drives CHEDDAR's curated
+// bootparam_40_64bit param set (logN=16, 26-prime chain, scale 2^40,
+// num_cts_levels=4, num_stc_levels=3) and this IR only carries the runtime-
+// relevant literals: the level-0 encode at scale GetScale(0) = 2^40 (clean at the
+// bottom, so no scale bake needed) and the boot/encrypt/decrypt ops. The harness
+// supplies the boot's evk_map from ui->GetEvkMap() after AddRequiredRotations.
+//
+// cheddar.boot takes a !cheddar.boot_context and lowers to `ctx->Boot(res, in,
+// evk_map)` on a BootContext<word>*; the harness passes the BootContext and
+// prepared evaluation-key map it built.
+!ciphertext = !cheddar.ciphertext
+!context = !cheddar.context
+!boot_context = !cheddar.boot_context
+!encoder = !cheddar.encoder
+!eval_key = !cheddar.eval_key
+!evk_map = !cheddar.evk_map
+!plaintext = !cheddar.plaintext
+!user_interface = !cheddar.user_interface
+#layout = #tensor_ext.layout<"{ [i0] -> [ct, slot] : ct = 0 and (-i0 + slot) mod 1024 = 0 and 0 <= i0 <= 1023 and 0 <= slot <= 1023 }">
+#original_type = #tensor_ext.original_type<originalType = tensor<1024xf32>, layout = #layout>
+module attributes {
+  backend.cheddar,
+  cheddar.boot.num_cts = 4 : i64,
+  cheddar.boot.num_stc = 3 : i64,
+  ckks.schemeParam = #ckks.scheme_param<logN = 16, Q = [1125899908022273, 1099515691009, 1099523555329, 1099525128193, 1099526176769, 1099529060353, 1099535220737, 1099536138241, 1099537580033, 1099538104321, 1099540725761, 1099540856833, 1099543085057, 36028797019488257, 36028797023420417, 36028797024206849, 36028797025124353, 36028797032202241, 36028797033644033, 36028797037576193, 36028797048324097, 36028797048586241, 36028797049896961, 36028797051863041, 36028797053698049, 36028797054222337], P = [72057594038321153, 72057594040680449, 72057594042646529, 72057594047889409, 72057594057195521, 72057594058375169, 72057594058899457], logDefaultScale = 40>,
+  scheme.actual_slot_count = 1024 : i64
+} {
+  func.func @boot(%ctx: !boot_context, %encoder: !encoder, %ui: !user_interface, %evk: !eval_key, %evk_map: !evk_map, %arg0: tensor<1x!ciphertext> {tensor_ext.original_type = #original_type}) -> (tensor<1x!ciphertext> {tensor_ext.original_type = #original_type}) {
+    %c0 = arith.constant 0 : index
+    %extracted = tensor.extract_slice %arg0[0] [1] [1] : tensor<1x!ciphertext> to tensor<!ciphertext>
+    %dps_1 = tensor.empty() : tensor<!ciphertext>
+    %ct = cheddar.boot %ctx, %extracted, %evk_map, %dps_1 : (!boot_context, tensor<!ciphertext>, !evk_map, tensor<!ciphertext>) -> tensor<!ciphertext>
+    %0 = tensor.empty() : tensor<1x!ciphertext>
+    %inserted = tensor.insert_slice %ct into %0[0] [1] [1] : tensor<!ciphertext> into tensor<1x!ciphertext>
+    return %inserted : tensor<1x!ciphertext>
+  }
+  func.func @boot__encrypt__arg0(%ctx: !context, %encoder: !encoder, %ui: !user_interface, %evk: !eval_key, %arg0: tensor<1024xf32>, %ui_0: !user_interface) -> tensor<1x!ciphertext> attributes {client.enc_func = {func_name = "boot", index = 0 : i64}} {
+    %c0 = arith.constant 0 : index
+    %cst = arith.constant dense<0.000000e+00> : tensor<1x1024xf32>
+    %c0_i32 = arith.constant 0 : i32
+    %c1_i32 = arith.constant 1 : i32
+    %c1024_i32 = arith.constant 1024 : i32
+    %0 = scf.for %arg1 = %c0_i32 to %c1024_i32 step %c1_i32 iter_args(%arg2 = %cst) -> (tensor<1x1024xf32>)  : i32 {
+      %1 = arith.index_cast %arg1 : i32 to index
+      %extracted = tensor.extract %arg0[%1] : tensor<1024xf32>
+      %inserted = tensor.insert %extracted into %arg2[%c0, %1] : tensor<1x1024xf32>
+      scf.yield %inserted : tensor<1x1024xf32>
+    }
+    %extracted_slice = tensor.extract_slice %0[0, 0] [1, 1024] [1, 1] : tensor<1x1024xf32> to tensor<1024xf32>
+    %dps_2 = tensor.empty() : tensor<!plaintext>
+    %pt = cheddar.encode %encoder, %extracted_slice, %dps_2 {level = 0 : i64} : (!encoder, tensor<1024xf32>, tensor<!plaintext>) -> tensor<!plaintext>
+    %dps_3 = tensor.empty() : tensor<!ciphertext>
+    %ct = cheddar.encrypt %ui, %pt, %dps_3 : (!user_interface, tensor<!plaintext>, tensor<!ciphertext>) -> tensor<!ciphertext>
+    %fe_4 = tensor.empty() : tensor<1x!ciphertext>
+    %from_elements = tensor.insert_slice %ct into %fe_4[0] [1] [1] : tensor<!ciphertext> into tensor<1x!ciphertext>
+    return %from_elements : tensor<1x!ciphertext>
+  }
+  func.func @boot__decrypt__result0(%ctx: !context, %encoder: !encoder, %ui: !user_interface, %evk: !eval_key, %arg0: tensor<1x!ciphertext>, %ui_0: !user_interface) -> tensor<1024xf32> attributes {client.dec_func = {func_name = "boot", index = 0 : i64}} {
+    %c0 = arith.constant 0 : index
+    %c1024_i32 = arith.constant 1024 : i32
+    %c1_i32 = arith.constant 1 : i32
+    %c0_i32 = arith.constant 0 : i32
+    %cst = arith.constant dense<0.000000e+00> : tensor<1024xf32>
+    %extracted = tensor.extract_slice %arg0[0] [1] [1] : tensor<1x!ciphertext> to tensor<!ciphertext>
+    %dps_5 = tensor.empty() : tensor<!plaintext>
+    %pt = cheddar.decrypt %ui, %extracted, %dps_5 : (!user_interface, tensor<!ciphertext>, tensor<!plaintext>) -> tensor<!plaintext>
+    %0 = tensor.empty() : tensor<1x1024xf32>
+    %1 = cheddar.decode %encoder, %pt, %0 : (!encoder, tensor<!plaintext>, tensor<1x1024xf32>) -> tensor<1x1024xf32>
+    %2 = scf.for %arg1 = %c0_i32 to %c1024_i32 step %c1_i32 iter_args(%arg2 = %cst) -> (tensor<1024xf32>)  : i32 {
+      %3 = arith.index_cast %arg1 : i32 to index
+      %extracted_1 = tensor.extract %1[%c0, %3] : tensor<1x1024xf32>
+      %inserted = tensor.insert %extracted_1 into %arg2[%3] : tensor<1024xf32>
+      scf.yield %inserted : tensor<1024xf32>
+    }
+    return %2 : tensor<1024xf32>
+  }
+}

--- a/tests/Examples/cheddar/bootstrap/bootstrap_test.cpp
+++ b/tests/Examples/cheddar/bootstrap/bootstrap_test.cpp
@@ -1,0 +1,132 @@
+// End-to-end GPU run of a real CHEDDAR bootstrap via the cheddar backend. The
+// lowered module's `boot` kernel takes a BootContext<word>* and calls
+// `ctx->Boot(...)`, so the harness builds a BootContext from CHEDDAR's curated
+// bootparam_40_64bit parameter set, runs the bootstrap preparation sequence
+// (PrepareEvalMod / PrepareEvalSpecialFFT / AddRequiredRotations -> rotation
+// keys), then calls the generated encrypt/boot/decrypt helpers and checks that
+// bootstrapping preserves the message (boot(x) ~= x). Mirrors CHEDDAR's own
+// Bootstrapping unit test, but driven through HEIR-emitted code.
+
+#include <gtest/gtest.h>
+
+#include <algorithm>
+#include <array>
+#include <cmath>
+#include <complex>
+#include <cstdint>
+#include <cstdio>
+#include <memory>
+#include <random>
+#include <utility>
+#include <vector>
+
+#include "UserInterface.h"
+#include "core/Context.h"
+#include "core/Encode.h"
+#include "core/EvkRequest.h"
+#include "core/Parameter.h"
+#include "extension/BootContext.h"
+
+using word = uint64_t;
+using Ct = cheddar::Ciphertext<word>;
+using Evk = cheddar::EvaluationKey<word>;
+using UI = cheddar::UserInterface<word>;
+using EvkMap = cheddar::EvkMap<word>;
+
+// Generated entry points (see tests/Examples/cheddar/bootstrap/BUILD).
+void boot__encrypt__arg0(cheddar::Context<word>* ctx,
+                         const cheddar::Encoder<word>& encoder, UI* ui,
+                         const Evk& evk, float a[1024], UI* ui2,
+                         std::array<Ct, 1>& out);
+void boot(cheddar::BootContext<word>* ctx,
+          const cheddar::Encoder<word>& encoder, UI* ui, const Evk& evk,
+          const EvkMap& evk_map, const std::array<Ct, 1>& in,
+          std::array<Ct, 1>& out);
+void boot__decrypt__result0(cheddar::Context<word>* ctx,
+                            const cheddar::Encoder<word>& encoder, UI* ui,
+                            const Evk& evk, const std::array<Ct, 1>& in,
+                            UI* ui2, float* out);
+
+namespace {
+constexpr int kN = 1024;
+// The encoded message has 1024 slots (the Encode vector length), so the sparse
+// bootstrap operates on 1024 of the logN=16 context's 32768 slots.
+constexpr int kNumSlots = 1024;
+
+// CHEDDAR's bootparam_40_64bit parameter set (logN=16, scale 2^40, 26-prime
+// main chain, 7 auxiliary primes, num_cts_levels=4, num_stc_levels=3).
+cheddar::Parameter<word> MakeParam() {
+  std::vector<word> main_primes = {
+      1125899908022273ULL,  1099515691009ULL,     1099523555329ULL,
+      1099525128193ULL,     1099526176769ULL,     1099529060353ULL,
+      1099535220737ULL,     1099536138241ULL,     1099537580033ULL,
+      1099538104321ULL,     1099540725761ULL,     1099540856833ULL,
+      1099543085057ULL,     36028797019488257ULL, 36028797023420417ULL,
+      36028797024206849ULL, 36028797025124353ULL, 36028797032202241ULL,
+      36028797033644033ULL, 36028797037576193ULL, 36028797048324097ULL,
+      36028797048586241ULL, 36028797049896961ULL, 36028797051863041ULL,
+      36028797053698049ULL, 36028797054222337ULL};
+  std::vector<word> aux_primes = {72057594038321153ULL, 72057594040680449ULL,
+                                  72057594042646529ULL, 72057594047889409ULL,
+                                  72057594057195521ULL, 72057594058375169ULL,
+                                  72057594058899457ULL};
+  std::vector<word> ter_primes = {};
+  std::vector<std::pair<int, int>> level_config;
+  for (int i = 1; i <= 26; ++i) level_config.emplace_back(i, 0);
+  std::pair<int, int> additional_base = {0, 0};
+  cheddar::Parameter<word> p(/*log_degree=*/16,
+                             /*base_scale=*/static_cast<double>(1ULL << 40),
+                             /*default_encryption_level=*/13, level_config,
+                             main_primes, aux_primes, ter_primes,
+                             additional_base);
+  p.SetDenseHammingWeight(32768);
+  p.SetSparseHammingWeight(32);
+  return p;
+}
+}  // namespace
+
+TEST(CheddarBootstrapE2E, GpuRun) {
+  std::mt19937 gen(123);
+  std::uniform_real_distribution<double> dist(-0.5, 0.5);
+  static float input[1024];
+  for (int i = 0; i < kN; ++i) input[i] = static_cast<float>(dist(gen));
+
+  auto param = MakeParam();
+  auto boot_ctx = cheddar::BootContext<word>::Create(
+      param, cheddar::BootParameter(param.max_level_, /*num_cts_levels=*/4,
+                                    /*num_stc_levels=*/3));
+  auto ui = std::make_unique<UI>(boot_ctx);
+
+  // Bootstrap preparation (one-time precompute + rotation keys).
+  boot_ctx->PrepareEvalMod();
+  boot_ctx->PrepareEvalSpecialFFT(kNumSlots);
+  cheddar::EvkRequest req;
+  boot_ctx->AddRequiredRotations(req, kNumSlots);
+  ui->PrepareRotationKey(req);
+  const EvkMap& evk_map = ui->GetEvkMap();
+  const Evk& evk = ui->GetMultiplicationKey();
+
+  std::array<Ct, 1> cin, cout;
+  boot__encrypt__arg0(boot_ctx.get(), boot_ctx->encoder_, ui.get(), evk, input,
+                      ui.get(), cin);
+  boot(boot_ctx.get(), boot_ctx->encoder_, ui.get(), evk, evk_map, cin, cout);
+  EXPECT_EQ(boot_ctx->param_.NPToLevel(cin[0].GetNP()), 0);
+  EXPECT_EQ(boot_ctx->param_.NPToLevel(cout[0].GetNP()),
+            boot_ctx->boot_param_.GetEndLevel());
+  EXPECT_EQ(boot_ctx->param_.NPToLevel(cout[0].GetNP()), 10);
+  static float result[1024];
+  boot__decrypt__result0(boot_ctx.get(), boot_ctx->encoder_, ui.get(), evk,
+                         cout, ui.get(), result);
+
+  double max_abs = 0;
+  for (int i = 0; i < kN; ++i) {
+    double error = std::abs(static_cast<double>(result[i]) - input[i]);
+    ASSERT_TRUE(std::isfinite(error)) << "non-finite result at slot " << i;
+    max_abs = std::max(max_abs, error);
+  }
+  std::printf("bootstrap: max|d|=%.6e (e.g. fhe[0]=%.6f in[0]=%.6f)\n", max_abs,
+              result[0], input[0]);
+  // Bootstrapping is approximate; expect the message preserved to CKKS boot
+  // precision (observed max|d| ~7e-7 for this param set).
+  EXPECT_LT(max_abs, 1e-4);
+}

--- a/tests/Examples/cheddar/emitc_abi/BUILD
+++ b/tests/Examples/cheddar/emitc_abi/BUILD
@@ -1,0 +1,63 @@
+load("@heir//bazel/cheddar:config.bzl", "requires_cheddar")
+load("@heir//tools:heir-opt.bzl", "heir_opt")
+load("@heir//tools:heir-translate.bzl", "heir_translate")
+load("@rules_cc//cc:cc_library.bzl", "cc_library")
+load("@rules_cc//cc:cc_test.bzl", "cc_test")
+
+package(
+    default_applicable_licenses = ["@heir//:license"],
+    default_visibility = ["//visibility:public"],
+)
+
+heir_opt(
+    name = "abi_emitc",
+    src = "abi.mlir",
+    generated_filename = "abi_emitc.mlir",
+    pass_flags = [
+        "--convert-to-emitc=filter-dialects=cheddar",
+        "--cheddar-emitc-boundary",
+        "--reconcile-unrealized-casts",
+    ],
+)
+
+heir_translate(
+    name = "abi_cpp_raw",
+    src = ":abi_emitc.mlir",
+    generated_filename = "abi_raw.cc",
+    pass_flags = ["--mlir-to-cpp"],
+)
+
+genrule(
+    name = "abi_lib_src",
+    srcs = [":abi_raw.cc"],
+    outs = ["abi_lib.cc"],
+    cmd = """cat > $@ <<'PRELUDE_EOF'
+// AUTO-GENERATED: do not edit. See tests/Examples/cheddar/emitc_abi/BUILD.
+#include <array>
+#include <cstdint>
+#include "core/Context.h"
+using namespace cheddar;
+using word = uint64_t;
+PRELUDE_EOF
+cat $(location :abi_raw.cc) >> $@
+""",
+)
+
+cc_library(
+    name = "abi_lib",
+    srcs = [":abi_lib_src"],
+    target_compatible_with = requires_cheddar(),
+    deps = ["@cheddar"],
+)
+
+cc_test(
+    name = "abi_test",
+    srcs = ["abi_test.cpp"],
+    linkstatic = False,
+    target_compatible_with = requires_cheddar(),
+    deps = [
+        ":abi_lib",
+        "@cheddar",
+        "@googletest//:gtest_main",
+    ],
+)

--- a/tests/Examples/cheddar/emitc_abi/abi.mlir
+++ b/tests/Examples/cheddar/emitc_abi/abi.mlir
@@ -1,0 +1,13 @@
+func.func @abi_inner(
+    %input: memref<1x!cheddar.ciphertext>,
+    %output: memref<1x!cheddar.ciphertext> {bufferize.result}) {
+  return
+}
+
+func.func @abi_outer(
+    %input: memref<1x!cheddar.ciphertext>,
+    %output: memref<1x!cheddar.ciphertext> {bufferize.result}) {
+  func.call @abi_inner(%input, %output)
+      : (memref<1x!cheddar.ciphertext>, memref<1x!cheddar.ciphertext>) -> ()
+  return
+}

--- a/tests/Examples/cheddar/emitc_abi/abi_test.cpp
+++ b/tests/Examples/cheddar/emitc_abi/abi_test.cpp
@@ -1,0 +1,18 @@
+#include <array>
+#include <cstdint>
+
+#include "core/Context.h"
+#include "gtest/gtest.h"
+
+using namespace cheddar;
+using word = uint64_t;
+
+void abi_outer(const std::array<Ciphertext<word>, 1>& input,
+               std::array<Ciphertext<word>, 1>& output);
+
+TEST(CheddarEmitCAbiTest, CallsGeneratedPayloadBoundaryTwice) {
+  std::array<Ciphertext<word>, 1> input;
+  std::array<Ciphertext<word>, 1> output;
+  abi_outer(input, output);
+  abi_outer(input, output);
+}

--- a/tools/BUILD
+++ b/tools/BUILD
@@ -33,6 +33,7 @@ cc_binary(
         "@heir//lib/Analysis/NoiseAnalysis",  # buildcleaner: keep
         "@heir//lib/Analysis/NoiseAnalysis/BFV:NoiseAnalysis",  # buildcleaner: keep
         "@heir//lib/Analysis/NoiseAnalysis/BGV:NoiseAnalysis",  # buildcleaner: keep
+        "@heir//lib/Conversions/CheddarToEmitC",
         "@heir//lib/Dialect:HEIRInterfaces",
         "@heir//lib/Dialect:reduces_level_op_interface_registration",
         "@heir//lib/Dialect/Arith/Conversions/ArithToCGGI",
@@ -264,6 +265,8 @@ cc_binary(
         "@heir//lib/Target/TfheRustHL:TfheRustHLEmitter",
         "@heir//lib/Target/Verilog:VerilogEmitter",
         "@llvm-project//llvm:Support",
+        "@llvm-project//mlir:AllTranslations",
+        "@llvm-project//mlir:TargetCpp",
         "@llvm-project//mlir:TranslateLib",
     ],
 )

--- a/tools/heir-opt.cpp
+++ b/tools/heir-opt.cpp
@@ -3,6 +3,7 @@
 #include <memory>
 #include <string>
 
+#include "lib/Conversions/CheddarToEmitC/CheddarToEmitC.h"
 #include "lib/Dialect/Arith/Conversions/ArithToCGGI/ArithToCGGI.h"
 #include "lib/Dialect/Arith/Conversions/ArithToCGGIQuart/ArithToCGGIQuart.h"
 #include "lib/Dialect/Arith/Conversions/ArithToModArith/ArithToModArith.h"
@@ -320,11 +321,14 @@ int main(int argc, char** argv) {
   mlir::registerConvertFuncToEmitCInterface(registry);
   mlir::registerConvertMemRefToEmitCInterface(registry);
   mlir::registerConvertSCFToEmitCInterface(registry);
+  mlir::heir::registerCheddarToEmitCExternalModels(registry);
+  mlir::heir::registerCheddarConvertToEmitCInterface(registry);
 
   // Misc
   registerTransformsPasses();      // canonicalize, cse, etc.
   affine::registerAffinePasses();  // loop unrolling
   registerLinalgPasses();          // linalg to loops
+  memref::registerMemRefPasses();  // fold-memref-alias-ops, etc.
 
   // These are only needed by two tests that build a pass pipeline
   // from the CLI. Those tests can probably eventually be removed.
@@ -378,6 +382,7 @@ int main(int argc, char** argv) {
 
   // Custom passes in HEIR
   registerEmitCInterfacePass();
+  registerCheddarToEmitCPasses();
   cggi::registerCGGIPasses();
   debug::registerDebugPasses();
   ckks::registerCKKSPasses();

--- a/tools/heir-translate.cpp
+++ b/tools/heir-translate.cpp
@@ -13,9 +13,11 @@
 #include "lib/Target/TfheRustHL/TfheRustHLEmitter.h"
 #include "lib/Target/Verilog/VerilogEmitter.h"
 #include "llvm/include/llvm/Support/LogicalResult.h"  // from @llvm-project
+#include "mlir/include/mlir/InitAllTranslations.h"    // from @llvm-project
 #include "mlir/include/mlir/Tools/mlir-translate/MlirTranslateMain.h"  // from @llvm-project
 
 int main(int argc, char** argv) {
+  mlir::registerToCppTranslation();
   // Verilog output
   mlir::heir::registerToVerilogTranslation();
   mlir::heir::registerMetadataEmitter();


### PR DESCRIPTION
Map core Cheddar operations directly to the pinned scale-snu runtime API on top of the safe payload and function ABI substrate.

Compile generated C++ against the real dependency and execute arithmetic and bootstrap GPU tests with numerical checks.

---

<sub>Stack created with <a href="https://github.com/github/gh-stack">GitHub Stacks CLI</a> • <a href="https://gh.io/stacks-feedback">Give Feedback 💬</a></sub>