### PR TITLE
cheddar: register backend target semantics

### DIFF
--- a/lib/Dialect/Mgmt/IR/BUILD
+++ b/lib/Dialect/Mgmt/IR/BUILD
@@ -27,6 +27,7 @@ cc_library(
         ":ops_inc_gen",
         "@heir//lib/Analysis/SecretnessAnalysis",
         "@heir//lib/Dialect:HEIRInterfaces",
+        "@heir//lib/Target/CompilationTarget",
         "@heir//lib/Utils:AttributeUtils",
         "@llvm-project//llvm:Support",
         "@llvm-project//mlir:Analysis",

--- a/lib/Dialect/Mgmt/IR/MgmtOps.cpp
+++ b/lib/Dialect/Mgmt/IR/MgmtOps.cpp
@@ -2,13 +2,32 @@
 
 #include "lib/Dialect/Mgmt/IR/MgmtAttributes.h"
 #include "lib/Dialect/Mgmt/IR/MgmtPatterns.h"
-#include "mlir/include/mlir/IR/MLIRContext.h"   // from @llvm-project
-#include "mlir/include/mlir/IR/Operation.h"     // from @llvm-project
-#include "mlir/include/mlir/IR/PatternMatch.h"  // from @llvm-project
+#include "lib/Target/CompilationTarget/CompilationTarget.h"
+#include "llvm/include/llvm/ADT/STLExtras.h"         // from @llvm-project
+#include "mlir/include/mlir/IR/BuiltinAttributes.h"  // from @llvm-project
+#include "mlir/include/mlir/IR/BuiltinOps.h"         // from @llvm-project
+#include "mlir/include/mlir/IR/MLIRContext.h"        // from @llvm-project
+#include "mlir/include/mlir/IR/Operation.h"          // from @llvm-project
+#include "mlir/include/mlir/IR/PatternMatch.h"       // from @llvm-project
 
 namespace mlir {
 namespace heir {
 namespace mgmt {
+
+// Targets without same-level scale adjustment require rescale to remain before
+// level reduction. Moving it after level reduction would apply rescale to the
+// squared scale at the wrong level.
+static bool hasCanonicalScalePerLevel(Operation* op) {
+  auto module = op->getParentOfType<ModuleOp>();
+  if (!module) return false;
+  bool hasBackend = llvm::any_of(module->getAttrs(), [](NamedAttribute attr) {
+    return isa<UnitAttr>(attr.getValue()) &&
+           attr.getName().getValue().starts_with("backend.");
+  });
+  if (!hasBackend) return false;
+  auto target = getTargetConfig(module);
+  return succeeded(target) && !target->can_emit_adjust_scale;
+}
 
 //===----------------------------------------------------------------------===//
 // Canonicalization Patterns
@@ -19,6 +38,7 @@ struct ModReduceAfterLevelReduce : public OpRewritePattern<LevelReduceOp> {
 
   LogicalResult matchAndRewrite(LevelReduceOp op,
                                 PatternRewriter& rewriter) const override {
+    if (hasCanonicalScalePerLevel(op)) return failure();
     auto modReduceOp = op.getInput().getDefiningOp<ModReduceOp>();
     if (!modReduceOp || !modReduceOp->hasOneUse() || !op->hasOneUse())
       return failure();
@@ -170,6 +190,7 @@ struct MergeModReduce : public OpRewritePattern<ModReduceOp> {
 
   LogicalResult matchAndRewrite(ModReduceOp op,
                                 PatternRewriter& rewriter) const override {
+    if (hasCanonicalScalePerLevel(op)) return failure();
     auto innerMr = op.getInput().getDefiningOp<ModReduceOp>();
     if (!innerMr || !innerMr->hasOneUse()) return failure();
 

--- a/lib/Dialect/ModuleAttributes.cpp
+++ b/lib/Dialect/ModuleAttributes.cpp
@@ -112,9 +112,15 @@ bool moduleIsLattigo(Operation* moduleOp) {
          nullptr;
 }
 
+bool moduleIsCheddar(Operation* moduleOp) {
+  return moduleOp->getAttrOfType<mlir::UnitAttr>(kCheddarBackendAttrName) !=
+         nullptr;
+}
+
 void moduleClearBackend(Operation* moduleOp) {
   moduleOp->removeAttr(kOpenfheBackendAttrName);
   moduleOp->removeAttr(kLattigoBackendAttrName);
+  moduleOp->removeAttr(kCheddarBackendAttrName);
 }
 
 void moduleSetOpenfhe(Operation* moduleOp) {
@@ -126,6 +132,12 @@ void moduleSetOpenfhe(Operation* moduleOp) {
 void moduleSetLattigo(Operation* moduleOp) {
   moduleClearBackend(moduleOp);
   moduleOp->setAttr(kLattigoBackendAttrName,
+                    mlir::UnitAttr::get(moduleOp->getContext()));
+}
+
+void moduleSetCheddar(Operation* moduleOp) {
+  moduleClearBackend(moduleOp);
+  moduleOp->setAttr(kCheddarBackendAttrName,
                     mlir::UnitAttr::get(moduleOp->getContext()));
 }
 

--- a/lib/Dialect/ModuleAttributes.h
+++ b/lib/Dialect/ModuleAttributes.h
@@ -61,14 +61,18 @@ constexpr const static ::llvm::StringLiteral kOpenfheBackendAttrName =
     "backend.openfhe";
 constexpr const static ::llvm::StringLiteral kLattigoBackendAttrName =
     "backend.lattigo";
+constexpr const static ::llvm::StringLiteral kCheddarBackendAttrName =
+    "backend.cheddar";
 
 bool moduleIsOpenfhe(Operation* moduleOp);
 bool moduleIsLattigo(Operation* moduleOp);
+bool moduleIsCheddar(Operation* moduleOp);
 
 void moduleClearBackend(Operation* moduleOp);
 
 void moduleSetOpenfhe(Operation* moduleOp);
 void moduleSetLattigo(Operation* moduleOp);
+void moduleSetCheddar(Operation* moduleOp);
 
 // Func attributes for client helpers
 //

--- a/lib/Tablegen/CompilationTargetEmitter.cpp
+++ b/lib/Tablegen/CompilationTargetEmitter.cpp
@@ -87,6 +87,9 @@ bool emitCompilationTargetRegistration(const llvm::RecordKeeper& records,
         target->getValueAsInt("has_kernel_linear_transform");
     auto hasPreparedLinearTransform =
         target->getValueAsInt("has_prepared_linear_transform");
+    auto requiresMatchingCiphertextPlaintextLevels =
+        target->getValueAsInt("requires_matching_ciphertext_plaintext_levels");
+    auto canEmitAdjustScale = target->getValueAsInt("can_emit_adjust_scale");
 
     os << "void registerTarget" << name << "() {\n"
        << "  "
@@ -94,7 +97,8 @@ bool emitCompilationTargetRegistration(const llvm::RecordKeeper& records,
           "BackendName::"
        << name << ", " << bootstrapLevelsConsumed << ", " << hasKernelChebyshev
        << ", " << hasKernelLinearTransform << ", " << hasPreparedLinearTransform
-       << "});\n"
+       << ", " << requiresMatchingCiphertextPlaintextLevels << ", "
+       << canEmitAdjustScale << "});\n"
        << "}\n\n";
   }
   return false;

--- a/lib/Target/Cheddar/BUILD
+++ b/lib/Target/Cheddar/BUILD
@@ -1,0 +1,11 @@
+load("@heir//lib/Target/CompilationTarget:defs.bzl", "heir_backend_config")
+
+package(
+    default_applicable_licenses = ["@heir//:license"],
+    default_visibility = ["//visibility:public"],
+)
+
+heir_backend_config(
+    name = "cheddar_backend_config",
+    srcs = ["TargetConfig.td"],
+)

--- a/lib/Target/Cheddar/TargetConfig.td
+++ b/lib/Target/Cheddar/TargetConfig.td
@@ -1,0 +1,19 @@
+include "lib/Target/CompilationTarget/HEIRTarget.td"
+
+def Cheddar : CompilationTarget<"cheddar"> {
+  // scale-snu/cheddar's bootstrap circuit uses a separate extension of the
+  // compute modulus chain, so a bootstrap consumes no compute levels.
+  let bootstrapLevelsConsumed = 0;
+
+  // Keep linear transforms decomposed until the separate Cheddar LT stack is
+  // present. Advertising this capability would leave kernel.linear_transform
+  // operations that LWEToCheddar intentionally cannot lower.
+  let has_kernel_linear_transform = 0;
+
+  // Cheddar rejects ciphertext-plaintext operations with different prime sets.
+  let requires_matching_ciphertext_plaintext_levels = 1;
+
+  // scale-snu/cheddar exposes one canonical scale per level and has no
+  // operation for a same-level scalar scale correction.
+  let can_emit_adjust_scale = 0;
+}

--- a/lib/Target/CompilationTarget/AllTargets.td
+++ b/lib/Target/CompilationTarget/AllTargets.td
@@ -1,2 +1,3 @@
+include "lib/Target/Cheddar/TargetConfig.td"
 include "lib/Target/Lattigo/TargetConfig.td"
 include "lib/Target/OpenFhePke/TargetConfig.td"

--- a/lib/Target/CompilationTarget/BUILD
+++ b/lib/Target/CompilationTarget/BUILD
@@ -36,6 +36,7 @@ td_library(
     includes = ["../../.."],
     deps = [
         ":td_files",
+        "@heir//lib/Target/Cheddar:cheddar_backend_config_td",
         "@heir//lib/Target/Lattigo:lattigo_backend_config_td",
         "@heir//lib/Target/OpenFhePke:openfhe_backend_config_td",
     ],
@@ -71,6 +72,7 @@ cc_library(
     hdrs = ["RegisterAllBackends.h"],
     deps = [
         ":CompilationTarget",
+        "@heir//lib/Target/Cheddar:cheddar_backend_config",
         "@heir//lib/Target/Lattigo:lattigo_backend_config",
         "@heir//lib/Target/OpenFhePke:openfhe_backend_config",
     ],

--- a/lib/Target/CompilationTarget/HEIRTarget.td
+++ b/lib/Target/CompilationTarget/HEIRTarget.td
@@ -10,6 +10,9 @@ class CompilationTarget<string name> {
   // diagonals into plaintexts) and apply it to many ciphertexts, via
   // kernel.prepare_linear_transform / kernel.apply_linear_transform.
   int has_prepared_linear_transform = 0;
+  // Whether ciphertext-plaintext operations require equal modulus-chain levels.
+  int requires_matching_ciphertext_plaintext_levels = 0;
+  int can_emit_adjust_scale = 1;
 }
 
 #endif // LIB_TARGET_COMPILATIONTARGET_HEIRTARGET_TD_

--- a/lib/Target/CompilationTarget/RegisterAllBackends.cpp
+++ b/lib/Target/CompilationTarget/RegisterAllBackends.cpp
@@ -7,10 +7,12 @@
 namespace mlir {
 namespace heir {
 
+#include "lib/Target/Cheddar/cheddar_backend_config.cpp.inc"
 #include "lib/Target/Lattigo/lattigo_backend_config.cpp.inc"
 #include "lib/Target/OpenFhePke/openfhe_backend_config.cpp.inc"
 
 void registerAllBackends() {
+  registerTargetCheddar();
   registerTargetLattigo();
   registerTargetOpenFHE();
 }

--- a/lib/Transforms/AnnotateModule/AnnotateModule.cpp
+++ b/lib/Transforms/AnnotateModule/AnnotateModule.cpp
@@ -49,6 +49,9 @@ struct AnnotateModule : impl::AnnotateModuleBase<AnnotateModule> {
         case BackendName::Lattigo:
           moduleSetLattigo(module);
           break;
+        case BackendName::Cheddar:
+          moduleSetCheddar(module);
+          break;
       }
     }
   }

--- a/lib/Transforms/AnnotateModule/AnnotateModule.td
+++ b/lib/Transforms/AnnotateModule/AnnotateModule.td
@@ -20,6 +20,7 @@ def AnnotateModule : Pass<"annotate-module"> {
     Available backend:
       - `openfhe`
       - `lattigo`
+      - `cheddar`
 
     (* example filepath=tests/Transforms/annotate_module/pass.mlir *)
   }];

--- a/lib/Transforms/SecretInsertMgmt/Pipeline.cpp
+++ b/lib/Transforms/SecretInsertMgmt/Pipeline.cpp
@@ -126,11 +126,13 @@ LogicalResult runInsertMgmtPipeline(Operation* top,
   }
 
   int64_t bootstrapLevelsConsumed = 0;
+  bool canEmitAdjustScale = true;
   // A default large value when the user does not set a level budget. Used for
   // ensuring subesquent passes that require a level budget get one.
   int64_t maxLevel = 100;
   if (succeeded(target)) {
     bootstrapLevelsConsumed = target->bootstrapLevelsConsumed;
+    canEmitAdjustScale = target->can_emit_adjust_scale;
   }
 
   int budget = options.levelBudget == -1
@@ -197,7 +199,8 @@ LogicalResult runInsertMgmtPipeline(Operation* top,
   adjustScalesForRegionBranchOps(top, &idCounter);
 
   LDBG(2) << "Handling cross level ops";
-  handleCrossLevelOps(top, &idCounter, options.includeFloats, budget);
+  handleCrossLevelOps(top, &idCounter, options.includeFloats, budget,
+                      canEmitAdjustScale);
 
   LDBG(2) << "Handling cross mul depth ops";
   handleCrossMulDepthOps(top, &idCounter, options.includeFloats, budget);
@@ -298,7 +301,7 @@ void insertRelinearizeAfterMult(Operation* top, bool includeFloats) {
 }
 
 void handleCrossLevelOps(Operation* top, int* idCounter, bool includeFloats,
-                         int levelBudget) {
+                         int levelBudget, bool canEmitAdjustScale) {
   DataFlowSolver solver;
   makeAndRunSecretnessAndLevelSolver(top, solver, levelBudget);
   MLIRContext* ctx = top->getContext();
@@ -306,10 +309,12 @@ void handleCrossLevelOps(Operation* top, int* idCounter, bool includeFloats,
   patterns.add<MatchCrossLevel<arith::AddIOp>, MatchCrossLevel<arith::SubIOp>,
                MatchCrossLevel<arith::MulIOp>,
                MatchCrossLevel<tensor::InsertSliceOp>,
-               MatchCrossLevel<tensor::InsertOp>>(ctx, idCounter, top, &solver);
+               MatchCrossLevel<tensor::InsertOp>>(ctx, idCounter, top, &solver,
+                                                  canEmitAdjustScale);
   if (includeFloats)
     patterns.add<MatchCrossLevel<arith::AddFOp>, MatchCrossLevel<arith::SubFOp>,
-                 MatchCrossLevel<arith::MulFOp>>(ctx, idCounter, top, &solver);
+                 MatchCrossLevel<arith::MulFOp>>(ctx, idCounter, top, &solver,
+                                                 canEmitAdjustScale);
   (void)walkAndApplyPatterns(top, std::move(patterns));
 }
 

--- a/lib/Transforms/SecretInsertMgmt/Pipeline.h
+++ b/lib/Transforms/SecretInsertMgmt/Pipeline.h
@@ -39,7 +39,7 @@ void adjustLevelsForRegionBranchOps(Operation* top, int levelBudget = 40);
 void adjustScalesForRegionBranchOps(Operation* top, int* idCounter);
 
 void handleCrossLevelOps(Operation* top, int* idCounter, bool includeFloats,
-                         int levelBudget = 40);
+                         int levelBudget = 40, bool canEmitAdjustScale = true);
 
 void handleCrossMulDepthOps(Operation* top, int* idCounter, bool includeFloats,
                             int levelBudget = 40);

--- a/lib/Transforms/SecretInsertMgmt/SecretInsertMgmtCKKS.cpp
+++ b/lib/Transforms/SecretInsertMgmt/SecretInsertMgmtCKKS.cpp
@@ -1,7 +1,9 @@
+#include "lib/Dialect/Mgmt/IR/MgmtOps.h"
 #include "lib/Dialect/Mgmt/Transforms/AnnotateMgmt.h"
 #include "lib/Dialect/Mgmt/Transforms/Passes.h"
 #include "lib/Dialect/ModuleAttributes.h"
 #include "lib/Dialect/Secret/IR/SecretOps.h"
+#include "lib/Target/CompilationTarget/CompilationTarget.h"
 #include "lib/Transforms/SecretInsertMgmt/Passes.h"
 #include "lib/Transforms/SecretInsertMgmt/Pipeline.h"
 #include "llvm/include/llvm/Support/Debug.h"  // from @llvm-project
@@ -28,10 +30,17 @@ struct SecretInsertMgmtCKKS
     // Helper for future lowerings that want to know what scheme was used
     moduleSetCKKS(getOperation());
 
+    bool canEmitAdjustScale = true;
+    if (auto target = getTargetConfig(getOperation()); succeeded(target))
+      canEmitAdjustScale = target->can_emit_adjust_scale;
+
     InsertMgmtPipelineOptions options;
     options.includeFloats = true;
     options.levelBudget = levelBudget;
-    options.modReduceAfterMul = afterMul;
+    // A target with one canonical scale per level must rescale immediately
+    // after multiplication. This turns scale mismatches into cross-level
+    // mismatches that can be resolved with a level reduction.
+    options.modReduceAfterMul = afterMul || !canEmitAdjustScale;
     options.modReduceBeforeMulIncludeFirstMul = beforeMulIncludeFirstMul;
     options.bootstrapWaterline = bootstrapWaterline;
     LogicalResult result = runInsertMgmtPipeline(getOperation(), options);
@@ -58,6 +67,15 @@ struct SecretInsertMgmtCKKS
     annotateOptions.levelBudget = levelBudget;
     pipeline.addPass(mgmt::createAnnotateMgmt(annotateOptions));
     (void)runPipeline(pipeline, getOperation());
+
+    if (!canEmitAdjustScale) {
+      bool foundUnsupportedOp = false;
+      getOperation()->walk([&](mgmt::AdjustScaleOp op) {
+        op.emitError("target does not support mgmt.adjust_scale");
+        foundUnsupportedOp = true;
+      });
+      if (foundUnsupportedOp) signalPassFailure();
+    }
   }
 };
 

--- a/lib/Transforms/SecretInsertMgmt/SecretInsertMgmtPatterns.cpp
+++ b/lib/Transforms/SecretInsertMgmt/SecretInsertMgmtPatterns.cpp
@@ -242,6 +242,11 @@ LogicalResult MatchCrossLevel<Op>::matchAndRewrite(
       if (resultLevelState.isMaxLevel()) {
         managed =
             mgmt::LevelReduceMinOp::create(rewriter, op.getLoc(), managed);
+      } else if (!canEmitAdjustScale) {
+        auto resultLevel = resultLevelState.getInt();
+        auto level = levelState.getInt();
+        managed = mgmt::LevelReduceOp::create(rewriter, op.getLoc(), managed,
+                                              resultLevel - level);
       } else {
         auto resultLevel = resultLevelState.getInt();
         auto level = levelState.getInt();

--- a/lib/Transforms/SecretInsertMgmt/SecretInsertMgmtPatterns.h
+++ b/lib/Transforms/SecretInsertMgmt/SecretInsertMgmtPatterns.h
@@ -116,11 +116,12 @@ struct MatchCrossLevel : public OpRewritePattern<Op> {
   using OpRewritePattern<Op>::OpRewritePattern;
 
   MatchCrossLevel(MLIRContext* context, int* idCounter, Operation* top,
-                  DataFlowSolver* solver)
+                  DataFlowSolver* solver, bool canEmitAdjustScale = true)
       : OpRewritePattern<Op>(context, /*benefit=*/1),
         idCounter(idCounter),
         top(top),
-        solver(solver) {}
+        solver(solver),
+        canEmitAdjustScale(canEmitAdjustScale) {}
 
   LogicalResult matchAndRewrite(Op op,
                                 PatternRewriter& rewriter) const override;
@@ -129,6 +130,7 @@ struct MatchCrossLevel : public OpRewritePattern<Op> {
   int* idCounter;
   Operation* top;
   DataFlowSolver* solver;
+  bool canEmitAdjustScale;
 };
 
 /// Similar to MatchCrossLevel, see its description for behavior.

--- a/tests/Tablegen/compilation_target.td
+++ b/tests/Tablegen/compilation_target.td
@@ -7,6 +7,9 @@ class CompilationTarget<string name> {
   int bootstrapLevelsConsumed = 0;
   int has_kernel_chebyshev = 0;
   int has_kernel_linear_transform = 0;
+  int has_prepared_linear_transform = 0;
+  int requires_matching_ciphertext_plaintext_levels = 0;
+  int can_emit_adjust_scale = 1;
 }
 
 def TestTarget : CompilationTarget<"test_target"> {
@@ -14,7 +17,7 @@ def TestTarget : CompilationTarget<"test_target"> {
 }
 
 // REG: void registerTargetTestTarget() {
-// REG:   CompilationTargetRegistry::registerTarget(CompilationTarget{BackendName::TestTarget, 1, 0, 0});
+// REG:   CompilationTargetRegistry::registerTarget(CompilationTarget{BackendName::TestTarget, 1, 0, 0, 0, 0, 1});
 // REG: }
 
 // OVERRIDE: mlir::LogicalResult applyCompilationTargetOverride(CompilationTarget& target,
@@ -39,6 +42,18 @@ def TestTarget : CompilationTarget<"test_target"> {
 // OVERRIDE:     target.has_kernel_linear_transform = attr.getInt();
 // OVERRIDE:     return success();
 // OVERRIDE:   }
+// OVERRIDE:   if (key == "requires_matching_ciphertext_plaintext_levels") {
+// OVERRIDE:     auto attr = dyn_cast<IntegerAttr>(value);
+// OVERRIDE:     if (!attr) { return emitError(loc, "expected integer attribute for key: ") << key; }
+// OVERRIDE:     target.requires_matching_ciphertext_plaintext_levels = attr.getInt();
+// OVERRIDE:     return success();
+// OVERRIDE:   }
+// OVERRIDE:   if (key == "can_emit_adjust_scale") {
+// OVERRIDE:     auto attr = dyn_cast<IntegerAttr>(value);
+// OVERRIDE:     if (!attr) { return emitError(loc, "expected integer attribute for key: ") << key; }
+// OVERRIDE:     target.can_emit_adjust_scale = attr.getInt();
+// OVERRIDE:     return success();
+// OVERRIDE:   }
 // OVERRIDE:   return emitError(loc, "Cannot override backend config for unknown key: ") << key;
 // OVERRIDE: }
 
@@ -61,6 +76,20 @@ def TestTarget : CompilationTarget<"test_target"> {
 // OVERRIDE:     return Attribute(IntegerAttr::get(IntegerType::get(ctx, 64), intVal));
 // OVERRIDE:   }
 // OVERRIDE:   if (key == "has_kernel_linear_transform") {
+// OVERRIDE:     int64_t intVal;
+// OVERRIDE:     if (value.getAsInteger(10, intVal)) {
+// OVERRIDE:       return emitError(loc, "expected base-10 integer attribute for key: ") << key;
+// OVERRIDE:     }
+// OVERRIDE:     return Attribute(IntegerAttr::get(IntegerType::get(ctx, 64), intVal));
+// OVERRIDE:   }
+// OVERRIDE:   if (key == "requires_matching_ciphertext_plaintext_levels") {
+// OVERRIDE:     int64_t intVal;
+// OVERRIDE:     if (value.getAsInteger(10, intVal)) {
+// OVERRIDE:       return emitError(loc, "expected base-10 integer attribute for key: ") << key;
+// OVERRIDE:     }
+// OVERRIDE:     return Attribute(IntegerAttr::get(IntegerType::get(ctx, 64), intVal));
+// OVERRIDE:   }
+// OVERRIDE:   if (key == "can_emit_adjust_scale") {
 // OVERRIDE:     int64_t intVal;
 // OVERRIDE:     if (value.getAsInteger(10, intVal)) {
 // OVERRIDE:       return emitError(loc, "expected base-10 integer attribute for key: ") << key;
@@ -92,4 +121,7 @@ def TestTarget : CompilationTarget<"test_target"> {
 // STRUCT:   int64_t bootstrapLevelsConsumed = 0;
 // STRUCT:   int64_t has_kernel_chebyshev = 0;
 // STRUCT:   int64_t has_kernel_linear_transform = 0;
+// STRUCT:   int64_t has_prepared_linear_transform = 0;
+// STRUCT:   int64_t requires_matching_ciphertext_plaintext_levels = 0;
+// STRUCT:   int64_t can_emit_adjust_scale = 1;
 // STRUCT: };

--- a/tests/Transforms/annotate_module/pass.mlir
+++ b/tests/Transforms/annotate_module/pass.mlir
@@ -1,6 +1,8 @@
 // RUN: heir-opt --annotate-module="backend=openfhe scheme=ckks" %s | FileCheck %s
+// RUN: heir-opt --annotate-module="backend=cheddar scheme=ckks" %s | FileCheck %s --check-prefix=CHECK-CHEDDAR
 
 // CHECK: module attributes {backend.openfhe, scheme.ckks}
+// CHECK-CHEDDAR: module attributes {backend.cheddar, scheme.ckks}
 module {
 
 }

--- a/tests/Transforms/secret_insert_mgmt/ckks/cheddar_cross_level.mlir
+++ b/tests/Transforms/secret_insert_mgmt/ckks/cheddar_cross_level.mlir
@@ -1,0 +1,23 @@
+// RUN: heir-opt --secret-insert-mgmt-ckks="min-slot-count=8" %s | FileCheck %s
+
+// scale-snu/cheddar has one canonical scale per level. A cross-level addition
+// must therefore lower the higher operand with level_reduce, without an
+// adjust_scale that the target cannot emit.
+
+// CHECK: func @cross_level
+// CHECK-NOT: mgmt.adjust_scale
+// CHECK: mgmt.level_reduce
+module attributes {backend.cheddar, scheme.ckks} {
+  func.func @cross_level(
+      %arg0: !secret.secret<tensor<8xf32>>,
+      %arg1: !secret.secret<tensor<8xf32>>) -> !secret.secret<tensor<8xf32>> {
+    %0 = secret.generic(%arg0 : !secret.secret<tensor<8xf32>>, %arg1 : !secret.secret<tensor<8xf32>>) {
+    ^body(%input0: tensor<8xf32>, %input1: tensor<8xf32>):
+      %m1 = arith.mulf %input0, %input1 : tensor<8xf32>
+      %m2 = arith.mulf %m1, %m1 : tensor<8xf32>
+      %result = arith.addf %m2, %m1 : tensor<8xf32>
+      secret.yield %result : tensor<8xf32>
+    } -> !secret.secret<tensor<8xf32>>
+    return %0 : !secret.secret<tensor<8xf32>>
+  }
+}


### PR DESCRIPTION
Rather than gating Cheddar's special management requirements behind "module == cheddar" checks, I figured I'd use the fancy new backend configuration system to define the idea of "canEmitAdjustScale true/false", with all our existing backends being able to do this, but Cheddar (at least until we add precise scale tracking) not accepting our adjust scale (the reason for this is that adjust_scale gets converted to a basic mul-with-constant and during the emitter, we can't tell if something is a computation value that happens to be 2^log(scale) or if it's actually supposed to be (scale) and we should replace it with the exact one.   

<sub>Stack created with <a href="https://github.com/github/gh-stack">GitHub Stacks CLI</a> • <a href="https://gh.io/stacks-feedback">Give Feedback 💬</a></sub>