### PR TITLE
cheddar: generate parameters and configure crypto context

### DIFF
--- a/lib/Analysis/RotationAnalysis/RotationAnalysis.cpp
+++ b/lib/Analysis/RotationAnalysis/RotationAnalysis.cpp
@@ -70,7 +70,11 @@ LogicalResult RotationAnalysis::handleScfFor(scf::ForOp forOp) {
   rotationIndices.insert(shifts.begin(), shifts.end());
 
   // All the rotation ops within the outermost for loop are analyzed.
-  outermostFor->walk([&](RotationOpInterface rotOp) { markVisited(rotOp); });
+  outermostFor->walk([&](RotationOpInterface rotOp) {
+    rotationIndicesByOp[rotOp.getOperation()].insert(shifts.begin(),
+                                                     shifts.end());
+    markVisited(rotOp);
+  });
 
   return success();
 }
@@ -110,6 +114,8 @@ LogicalResult RotationAnalysis::analyzeRotationOp(
     LDBG() << "Rotation op has constant indices: "
            << *rotationOp.getOperation();
     rotationIndices.insert(constantIndices.begin(), constantIndices.end());
+    rotationIndicesByOp[rotationOp.getOperation()].insert(
+        constantIndices.begin(), constantIndices.end());
     markVisited(rotationOp);
     return success();
   }

--- a/lib/Analysis/RotationAnalysis/RotationAnalysis.h
+++ b/lib/Analysis/RotationAnalysis/RotationAnalysis.h
@@ -1,9 +1,11 @@
 #ifndef LIB_ANALYSIS_ROTATIONANALYSIS_ROTATIONANALYSIS_H_
 #define LIB_ANALYSIS_ROTATIONANALYSIS_ROTATIONANALYSIS_H_
 
+#include <cassert>
 #include <cstdint>
 
 #include "lib/Dialect/HEIRInterfaces.h"
+#include "llvm/include/llvm/ADT/DenseMap.h"        // from @llvm-project
 #include "mlir/include/mlir/Dialect/SCF/IR/SCF.h"  // from @llvm-project
 #include "mlir/include/mlir/IR/Operation.h"        // from @llvm-project
 #include "mlir/include/mlir/Support/LLVM.h"        // from @llvm-project
@@ -20,6 +22,12 @@ class RotationAnalysis {
 
   const DenseSet<int64_t>& getRotationIndices() const {
     return rotationIndices;
+  }
+
+  const DenseSet<int64_t>& getRotationIndices(RotationOpInterface op) const {
+    auto it = rotationIndicesByOp.find(op.getOperation());
+    assert(it != rotationIndicesByOp.end());
+    return it->second;
   }
 
   LogicalResult run(Operation* op);
@@ -40,6 +48,7 @@ class RotationAnalysis {
   void markVisited(Operation* op) { visitedRotationOps.insert(op); }
 
   DenseSet<int64_t> rotationIndices;
+  DenseMap<Operation*, DenseSet<int64_t>> rotationIndicesByOp;
   DenseSet<Operation*> visitedRotationOps;
 };
 

--- a/lib/Conversions/CheddarToEmitC/CheddarToEmitC.cpp
+++ b/lib/Conversions/CheddarToEmitC/CheddarToEmitC.cpp
@@ -1,5 +1,6 @@
 #include "lib/Conversions/CheddarToEmitC/CheddarToEmitC.h"
 
+#include <cstdint>
 #include <cstdio>
 #include <functional>
 #include <optional>
@@ -330,6 +331,26 @@ bool diagnoseUnsupportedGetters(Operation* root) {
       found = true;
     }
   });
+  root->walk([&](func::FuncOp func) {
+    unsigned parameters = 0;
+    unsigned bootstraps = 0;
+    func.walk([&](Operation* op) {
+      parameters += isa<cheddar::MakeParameterOp>(op);
+      bootstraps += isa<cheddar::PrepareBootstrapOp>(op);
+    });
+    if (parameters > 1) {
+      func.emitError(
+          "cheddar-to-emitc supports at most one "
+          "cheddar.make_parameter per function");
+      found = true;
+    }
+    if (bootstraps > 1) {
+      func.emitError(
+          "cheddar-to-emitc supports at most one "
+          "cheddar.prepare_bootstrap per function");
+      found = true;
+    }
+  });
   return found;
 }
 
@@ -368,6 +389,143 @@ struct OutParamDpsPattern : public OpConversionPattern<Op> {
 
   std::string method;
   std::function<std::string(Op)> extra;
+};
+
+template <typename Op>
+struct ConvertSetupAssign : public OpConversionPattern<Op> {
+  ConvertSetupAssign(const TypeConverter& tc, MLIRContext* ctx,
+                     StringRef rhsCallee)
+      : OpConversionPattern<Op>(tc, ctx), rhsCallee(rhsCallee.str()) {}
+
+  LogicalResult matchAndRewrite(
+      Op op, typename Op::Adaptor adaptor,
+      ConversionPatternRewriter& rewriter) const override {
+    auto operands = adaptor.getOperands();
+    VerbatimOp::create(rewriter, op.getLoc(), "{} = " + rhsCallee + "({});",
+                       ValueRange{operands[1], operands[0]});
+    rewriter.eraseOp(op);
+    return success();
+  }
+
+  std::string rhsCallee;
+};
+
+struct ConvertMakeParameter
+    : public OpConversionPattern<cheddar::MakeParameterOp> {
+  using OpConversionPattern::OpConversionPattern;
+  LogicalResult matchAndRewrite(
+      cheddar::MakeParameterOp op, OpAdaptor /*adaptor*/,
+      ConversionPatternRewriter& rewriter) const override {
+    Type resultType = typeConverter->convertType(op.getResult().getType());
+    ArrayRef<int64_t> mainPrimes = op.getMainPrimes();
+    int64_t defaultLevel = op.getDefaultEncryptionLevel()
+                               ? op.getDefaultEncryptionLevelAttr().getInt()
+                               : static_cast<int64_t>(mainPrimes.size()) - 1;
+
+    std::string levels = "std::vector<std::pair<int, int>>{";
+    for (size_t i = 0; i < mainPrimes.size(); ++i) {
+      if (i) levels += ", ";
+      levels += "{" + std::to_string(i + 1) + ", 0}";
+    }
+    levels += "}";
+    auto primes = [](ArrayRef<int64_t> values) {
+      std::string result = "std::vector<word>{";
+      for (size_t i = 0; i < values.size(); ++i) {
+        if (i) result += ", ";
+        result += std::to_string(static_cast<uint64_t>(values[i])) + "ULL";
+      }
+      return result + "}";
+    };
+    std::string scale = "static_cast<double>(static_cast<word>(1) << " +
+                        std::to_string(op.getLogScale().getInt()) + ")";
+    std::string args = std::to_string(op.getLogN().getInt()) + ", " + scale +
+                       ", " + std::to_string(defaultLevel) + ", " + levels +
+                       ", " + primes(mainPrimes) + ", " +
+                       primes(op.getAuxPrimes());
+
+    StringRef name = "cheddar_param";
+    VerbatimOp::create(
+        rewriter, op.getLoc(),
+        ("static Parameter<word> " + name + "(" + args + ");").str(),
+        ValueRange{});
+    if (auto weight = op.getDenseHammingWeightAttr())
+      VerbatimOp::create(
+          rewriter, op.getLoc(),
+          (name + ".SetDenseHammingWeight(" + intLit(weight) + ");").str(),
+          ValueRange{});
+    if (auto weight = op.getSparseHammingWeightAttr())
+      VerbatimOp::create(
+          rewriter, op.getLoc(),
+          (name + ".SetSparseHammingWeight(" + intLit(weight) + ");").str(),
+          ValueRange{});
+    auto literal =
+        emitc::LiteralOp::create(rewriter, op.getLoc(), resultType, name);
+    rewriter.replaceOp(op, literal.getResult());
+    return success();
+  }
+};
+
+struct ConvertPrepareRotKey
+    : public OpConversionPattern<cheddar::PrepareRotKeyOp> {
+  using OpConversionPattern::OpConversionPattern;
+  LogicalResult matchAndRewrite(
+      cheddar::PrepareRotKeyOp op, OpAdaptor adaptor,
+      ConversionPatternRewriter& rewriter) const override {
+    VerbatimOp::create(rewriter, op.getLoc(),
+                       "{}->PrepareRotationKey(" +
+                           intLit(op.getDistanceAttr()) + ", " +
+                           intLit(op.getMaxLevelAttr()) + ");",
+                       ValueRange{adaptor.getUi()});
+    rewriter.eraseOp(op);
+    return success();
+  }
+};
+
+struct ConvertCreateBootContext
+    : public OpConversionPattern<cheddar::CreateBootContextOp> {
+  using OpConversionPattern::OpConversionPattern;
+  LogicalResult matchAndRewrite(
+      cheddar::CreateBootContextOp op, OpAdaptor adaptor,
+      ConversionPatternRewriter& rewriter) const override {
+    std::string ratio;
+    if (auto attr = op.getLogMessageRatioAttr()) ratio = ", " + intLit(attr);
+    VerbatimOp::create(
+        rewriter, op.getLoc(),
+        "{} = BootContext<word>::Create({}, BootParameter({}.max_level_, " +
+            std::to_string(op.getNumCtsLevels().getInt()) + ", " +
+            std::to_string(op.getNumStcLevels().getInt()) + ratio + "));",
+        ValueRange{adaptor.getOutput(), adaptor.getParams(),
+                   adaptor.getParams()});
+    rewriter.eraseOp(op);
+    return success();
+  }
+};
+
+struct ConvertPrepareBootstrap
+    : public OpConversionPattern<cheddar::PrepareBootstrapOp> {
+  using OpConversionPattern::OpConversionPattern;
+  LogicalResult matchAndRewrite(
+      cheddar::PrepareBootstrapOp op, OpAdaptor adaptor,
+      ConversionPatternRewriter& rewriter) const override {
+    std::string slots = std::to_string(op.getNumSlots().getInt());
+    Value context = adaptor.getCtx();
+    VerbatimOp::create(rewriter, op.getLoc(), "{}->PrepareEvalMod();",
+                       ValueRange{context});
+    VerbatimOp::create(rewriter, op.getLoc(),
+                       "{}->PrepareEvalSpecialFFT(" + slots +
+                           ", BootVariant::kImaginaryRemoving);",
+                       ValueRange{context});
+    VerbatimOp::create(rewriter, op.getLoc(), "EvkRequest boot_evk_req;",
+                       ValueRange{});
+    VerbatimOp::create(rewriter, op.getLoc(),
+                       "{}->AddRequiredRotations(boot_evk_req, " + slots + ");",
+                       ValueRange{context});
+    VerbatimOp::create(rewriter, op.getLoc(),
+                       "{}->PrepareRotationKey(boot_evk_req);",
+                       ValueRange{adaptor.getUi()});
+    rewriter.eraseOp(op);
+    return success();
+  }
 };
 
 // cheddar.encode: fill a std::vector<Complex> from the float message buffer,
@@ -1382,9 +1540,15 @@ struct CheddarToEmitCDialectInterface : public ConvertToEmitCPatternInterface {
     patterns.add<ConvertCiphertextCopy>(typeConverter, ctx, /*benefit=*/3);
 
     patterns
-        .add<ConvertEncode, ConvertEncodeConstant, ConvertDecode, ConvertHRot,
-             ConvertHRotAdd, ConvertHConj, ConvertHConjAdd, ConvertEvalPoly>(
-            typeConverter, ctx);
+        .add<ConvertMakeParameter, ConvertPrepareRotKey,
+             ConvertCreateBootContext, ConvertPrepareBootstrap, ConvertEncode,
+             ConvertEncodeConstant, ConvertDecode, ConvertHRot, ConvertHRotAdd,
+             ConvertHConj, ConvertHConjAdd, ConvertEvalPoly>(typeConverter,
+                                                             ctx);
+    patterns.add<ConvertSetupAssign<cheddar::CreateContextOp>>(
+        typeConverter, ctx, "Context<word>::Create");
+    patterns.add<ConvertSetupAssign<cheddar::CreateUserInterfaceOp>>(
+        typeConverter, ctx, "std::make_unique<UserInterface<word>>");
 
     auto addDps = [&](StringRef name, auto opTag,
                       std::function<std::string(decltype(opTag))> extra =

--- a/lib/Dialect/Cheddar/IR/CheddarOps.td
+++ b/lib/Dialect/Cheddar/IR/CheddarOps.td
@@ -573,6 +573,7 @@ def Cheddar_HRotOp : Cheddar_DpsOp<"hrot", [
   let description = [{
     Calls context->HRot(res, a, rot_key, distance). The rotation key is looked
     up from the `$ui` UserInterface operand using `distance`.
+    `level` is the modulus level at which the rotation executes.
     Single fused GPU kernel. Supports both static and dynamic distances.
   }];
   let arguments = (ins
@@ -581,7 +582,8 @@ def Cheddar_HRotOp : Cheddar_DpsOp<"hrot", [
     Cheddar_CtLike:$input,
     Cheddar_CtLike:$output,
     Optional<AnySignlessIntegerOrIndex>:$dynamic_distance,
-    OptionalAttr<Builtin_IntegerAttr>:$static_distance
+    OptionalAttr<Builtin_IntegerAttr>:$static_distance,
+    Builtin_IntegerAttr:$level
   );
   let results = (outs Cheddar_CtResult:$result);
   let hasVerifier = 1;
@@ -595,6 +597,7 @@ def Cheddar_HRotAddOp : Cheddar_DpsOp<"hrot_add", [
     Computes res = rotate(a, distance) + b in a single fused GPU kernel.
     Calls context->HRotAdd(res, a, b, rot_key, distance). The rotation key
     is looked up from the `$ui` UserInterface operand using `distance`.
+    `level` is the modulus level at which the rotation executes.
   }];
   let arguments = (ins
     Cheddar_AnyContext:$ctx,
@@ -602,7 +605,8 @@ def Cheddar_HRotAddOp : Cheddar_DpsOp<"hrot_add", [
     Cheddar_CtLike:$input,
     Cheddar_CtLike:$addend,
     Cheddar_CtLike:$output,
-    Builtin_IntegerAttr:$distance
+    Builtin_IntegerAttr:$distance,
+    Builtin_IntegerAttr:$level
   );
   let results = (outs Cheddar_CtResult:$result);
 }

--- a/lib/Dialect/Cheddar/Transforms/BUILD
+++ b/lib/Dialect/Cheddar/Transforms/BUILD
@@ -50,6 +50,33 @@ cc_library(
     ],
 )
 
+cc_library(
+    name = "ConfigureCryptoContext",
+    srcs = ["ConfigureCryptoContext.cpp"],
+    hdrs = ["ConfigureCryptoContext.h"],
+    deps = [
+        ":configure_crypto_context_inc_gen",
+        "@heir//lib/Analysis/RotationAnalysis",
+        "@heir//lib/Dialect:ModuleAttributes",
+        "@heir//lib/Dialect/CKKS/IR:Dialect",
+        "@heir//lib/Dialect/Cheddar/IR:Dialect",
+        "@heir//lib/Utils:TransformUtils",
+        "@llvm-project//llvm:Support",
+        "@llvm-project//mlir:FuncDialect",
+        "@llvm-project//mlir:IR",
+        "@llvm-project//mlir:Pass",
+        "@llvm-project//mlir:TensorDialect",
+        "@llvm-project//mlir:Transforms",
+    ],
+)
+
+add_heir_transforms(
+    generated_target_name = "configure_crypto_context_inc_gen",
+    header_filename = "ConfigureCryptoContext.h.inc",
+    pass_name = "CheddarConfigureCryptoContext",
+    td_file = "ConfigureCryptoContext.td",
+)
+
 add_heir_transforms(
     header_filename = "Passes.h.inc",
     pass_name = "Cheddar",

--- a/lib/Dialect/Cheddar/Transforms/ConfigureCryptoContext.cpp
+++ b/lib/Dialect/Cheddar/Transforms/ConfigureCryptoContext.cpp
@@ -1,0 +1,340 @@
+#include "lib/Dialect/Cheddar/Transforms/ConfigureCryptoContext.h"
+
+#include <algorithm>
+#include <string>
+#include <utility>
+
+#include "lib/Analysis/RotationAnalysis/RotationAnalysis.h"
+#include "lib/Dialect/CKKS/IR/CKKSAttributes.h"
+#include "lib/Dialect/CKKS/IR/CKKSDialect.h"
+#include "lib/Dialect/Cheddar/IR/CheddarOps.h"
+#include "lib/Dialect/Cheddar/IR/CheddarTypes.h"
+#include "lib/Dialect/ModuleAttributes.h"
+#include "lib/Utils/TransformUtils.h"
+#include "llvm/include/llvm/ADT/SmallVector.h"           // from @llvm-project
+#include "mlir/include/mlir/Dialect/Func/IR/FuncOps.h"   // from @llvm-project
+#include "mlir/include/mlir/Dialect/Tensor/IR/Tensor.h"  // from @llvm-project
+#include "mlir/include/mlir/IR/Builders.h"               // from @llvm-project
+#include "mlir/include/mlir/IR/BuiltinAttributes.h"      // from @llvm-project
+#include "mlir/include/mlir/IR/BuiltinOps.h"             // from @llvm-project
+#include "mlir/include/mlir/IR/BuiltinTypes.h"           // from @llvm-project
+#include "mlir/include/mlir/Pass/PassManager.h"          // from @llvm-project
+#include "mlir/include/mlir/Transforms/Passes.h"         // from @llvm-project
+
+namespace mlir::heir::cheddar {
+
+#define GEN_PASS_DEF_CHEDDARCONFIGURECRYPTOCONTEXT
+#include "lib/Dialect/Cheddar/Transforms/ConfigureCryptoContext.h.inc"
+
+namespace {
+
+// scale-snu CHEDDAR's pinned BootParameter consumes eight levels in EvalMod:
+// ceil(log2(31 minimax coefficients)) + three double-angle steps. Its
+// BootContext requires Parameter::default_encryption_level_ to equal the
+// resulting SlotToCoeff start level.
+constexpr int64_t kBootstrapEvalModLevels = 8;
+constexpr int64_t kMinBootstrapSlots = 256;
+
+// Build setup and key-generation functions in destination-passing tensor form:
+//   %p   = cheddar.make_parameter ...
+//   %ctx = cheddar.create_context %p, %ctx_init
+//   return %ctx
+//
+//   %ui0 = cheddar.create_user_interface %ctx, %ui_init
+//   %ui1 = cheddar.prepare_rot_key %ui0 {distance, maxLevel}   // per distance
+//   return %ctx, %uiN
+// Params come from the CKKS scheme attrs (logN/scale/Q/P); the rotation
+// distances come from the shared RotationAnalysis (the same way the lattigo and
+// openfhe backends discover which keys to generate). The two tensor results
+// become owning context/user_interface out-params during Cheddar
+// bufferization, and the cheddar-to-emitc boundary re-types them to owning
+// smart-pointer references.
+// When the program bootstraps, the generated configure builds a BootContext
+// (and runs the one-time bootstrap precompute + rotation-key request) instead
+// of a plain Context: the entry then takes a `!cheddar.boot_context`.
+// `bootstrapNumSlots` is the number of slots used to prepare the bootstrap;
+// `numCtsLevels` / `numStcLevels` are the CtS/StC level budgets (a
+// depth/rotations trade-off, cf. OpenFHE's level-budget-encode/decode),
+// threaded in as pass options.
+void buildConfigureFuncs(ModuleOp moduleOp, func::FuncOp entry, int64_t logN,
+                         int64_t logScale, DenseI64ArrayAttr Q,
+                         DenseI64ArrayAttr P,
+                         ArrayRef<std::pair<int64_t, int64_t>> rotationKeys,
+                         bool bootstraps, int64_t bootstrapNumSlots,
+                         int64_t numCtsLevels, int64_t numStcLevels,
+                         int64_t defaultEncLevel, int64_t denseHammingWeight,
+                         int64_t sparseHammingWeight, int64_t logMessageRatio) {
+  MLIRContext* ctx = moduleOp.getContext();
+  // EvalMod message headroom passed to CHEDDAR's BootParameter. This is the
+  // reserved bits for the MESSAGE magnitude (~log2(max|m|)+margin), NOT a
+  // function of the modulus chain: CHEDDAR scales the level-0 message UP by
+  // (log2(q0/scale) - log_message_ratio) bits before EvalMod, so the message
+  // fills the accurate part of the fixed sine (sin 2*pi*x) minimax. Too LARGE a
+  // ratio under-scales the message into the inaccurate low end of the sine ->
+  // the bootstrap stops being identity and silently corrupts its output (which
+  // then detonates a downstream Chebyshev eval). The old
+  // firstModBits-logScale-2 formula tied the headroom to the chain and gave ~13
+  // (log_scaleup_ ~= 2, a 256x under-scale). For the normalized activations
+  // these programs bootstrap
+  // (|m| ~ O(1), the sign/ReLU inputs), CHEDDAR's default headroom of 5 is the
+  // right magnitude (log_scaleup_ ~= 10). Override via the `log-message-ratio`
+  // option for a program with a larger message bound.
+  int64_t effLogMessageRatio = logMessageRatio;
+  if (bootstraps && effLogMessageRatio < 0) {
+    effLogMessageRatio = 5;
+  }
+
+  OpBuilder builder(ctx);
+  builder.setInsertionPointToEnd(moduleOp.getBody());
+  Location loc = entry.getLoc();
+
+  // Bootstrapping programs hand back an owning BootContext; others a Context.
+  Type ctxElt = bootstraps ? Type(BootContextType::get(ctx))
+                           : Type(ContextType::get(ctx));
+  auto ctxTensor = RankedTensorType::get({}, ctxElt);
+  auto uiTensor = RankedTensorType::get({}, UserInterfaceType::get(ctx));
+  auto roleAttr = builder.getDictionaryAttr({builder.getNamedAttr(
+      kClientHelperFuncName, builder.getStringAttr(entry.getSymName()))});
+
+  std::string setupName = (entry.getSymName() + "__setup").str();
+  auto setupType = FunctionType::get(ctx, {}, {ctxTensor});
+  auto setupFunc = func::FuncOp::create(builder, loc, setupName, setupType);
+  setupFunc.setPublic();
+  setupFunc->setAttr(kClientSetupFuncAttrName, roleAttr);
+
+  Block* bodyBlock = setupFunc.addEntryBlock();
+  builder.setInsertionPointToStart(bodyBlock);
+
+  auto i64 = [&](int64_t v) { return builder.getI64IntegerAttr(v); };
+  // Bootstrapping pins default_encryption_level below the chain top and sets
+  // the secret-key hamming weights; non-boot leaves these null (emitter
+  // defaults).
+  IntegerAttr defaultEncAttr =
+      bootstraps ? i64(defaultEncLevel) : IntegerAttr();
+  IntegerAttr denseHwAttr =
+      bootstraps ? i64(denseHammingWeight) : IntegerAttr();
+  IntegerAttr sparseHwAttr =
+      bootstraps ? i64(sparseHammingWeight) : IntegerAttr();
+  Value params =
+      MakeParameterOp::create(builder, loc, ParameterType::get(ctx), i64(logN),
+                              i64(logScale), Q, P, defaultEncAttr, denseHwAttr,
+                              sparseHwAttr)
+          .getParams();
+  // Shape-only DPS destinations. Cheddar bufferization connects these to the
+  // caller-provided result destinations before One-Shot Bufferize.
+  Value ctxInit = tensor::EmptyOp::create(builder, loc, ctxTensor.getShape(),
+                                          ctxTensor.getElementType());
+  Value context =
+      bootstraps
+          ? CreateBootContextOp::create(
+                builder, loc, TypeRange{ctxTensor}, params, i64(numCtsLevels),
+                i64(numStcLevels), i64(effLogMessageRatio), ctxInit)
+                ->getResult(0)
+          : CreateContextOp::create(builder, loc, TypeRange{ctxTensor},
+                                    ValueRange{params, ctxInit})
+                ->getResult(0);
+  func::ReturnOp::create(builder, loc, context);
+
+  builder.setInsertionPointToEnd(moduleOp.getBody());
+  std::string keygenName = (entry.getSymName() + "__keygen").str();
+  auto keygenType = FunctionType::get(ctx, {ctxTensor}, {ctxTensor, uiTensor});
+  auto keygenFunc = func::FuncOp::create(builder, loc, keygenName, keygenType);
+  keygenFunc.setPublic();
+  keygenFunc->setAttr(kClientKeygenFuncAttrName, roleAttr);
+  bodyBlock = keygenFunc.addEntryBlock();
+  builder.setInsertionPointToStart(bodyBlock);
+  context = keygenFunc.getArgument(0);
+  Value uiInit = tensor::EmptyOp::create(builder, loc, uiTensor.getShape(),
+                                         uiTensor.getElementType());
+  Value ui = CreateUserInterfaceOp::create(builder, loc, TypeRange{uiTensor},
+                                           ValueRange{context, uiInit})
+                 ->getResult(0);
+  for (auto [distance, level] : rotationKeys)
+    ui = PrepareRotKeyOp::create(builder, loc, TypeRange{uiTensor}, ui,
+                                 i64(distance), i64(level))
+             ->getResult(0);
+  if (bootstraps) {
+    auto prepare =
+        PrepareBootstrapOp::create(builder, loc, TypeRange{ctxTensor, uiTensor},
+                                   context, ui, i64(bootstrapNumSlots));
+    context = prepare->getResult(0);
+    ui = prepare->getResult(1);
+  }
+  func::ReturnOp::create(builder, loc, ValueRange{context, ui});
+
+  // Keep the combined setup and key-generation entry point.
+  builder.setInsertionPointToEnd(moduleOp.getBody());
+  auto configureType = FunctionType::get(ctx, {}, {ctxTensor, uiTensor});
+  std::string configureName = (entry.getSymName() + "__configure").str();
+  auto configureFunc =
+      func::FuncOp::create(builder, loc, configureName, configureType);
+  configureFunc.setPublic();
+  bodyBlock = configureFunc.addEntryBlock();
+  builder.setInsertionPointToStart(bodyBlock);
+  auto setupCall = func::CallOp::create(builder, loc, setupFunc, ValueRange{});
+  auto keygenCall =
+      func::CallOp::create(builder, loc, keygenFunc, setupCall.getResult(0));
+  func::ReturnOp::create(builder, loc, keygenCall.getResults());
+}
+
+}  // namespace
+
+struct CheddarConfigureCryptoContext
+    : public impl::CheddarConfigureCryptoContextBase<
+          CheddarConfigureCryptoContext> {
+  using CheddarConfigureCryptoContextBase::CheddarConfigureCryptoContextBase;
+
+  void runOnOperation() override {
+    auto moduleOp = cast<ModuleOp>(getOperation());
+    MLIRContext* ctx = &getContext();
+
+    // RotationAnalysis requires -sccp to have propagated constants so the
+    // rotation indices are statically detectable (mirrors the lattigo/openfhe
+    // configure passes).
+    OpPassManager pipeline("builtin.module");
+    pipeline.addPass(createSCCPPass());
+    pipeline.addPass(createCanonicalizerPass());
+    if (failed(runPipeline(pipeline, moduleOp))) {
+      signalPassFailure();
+      return;
+    }
+
+    auto schemeParamAttr = moduleOp->getAttrOfType<ckks::SchemeParamAttr>(
+        ckks::CKKSDialect::kSchemeParamAttrName);
+    if (!schemeParamAttr) return;
+
+    DenseI64ArrayAttr Q = schemeParamAttr.getQ();
+    DenseI64ArrayAttr P = schemeParamAttr.getP();
+    if (!Q || Q.size() == 0 || !P || P.size() == 0) {
+      moduleOp.emitError(
+          "CHEDDAR context configuration requires non-empty CKKS Q and P "
+          "modulus chains");
+      signalPassFailure();
+      return;
+    }
+
+    auto entry = detectEntryFunction(moduleOp, entryFunction);
+    if (!entry) {
+      signalPassFailure();
+      return;
+    }
+    for (StringRef suffix : {"__setup", "__keygen", "__configure"}) {
+      std::string functionName = (entry.getSymName() + suffix).str();
+      if (moduleOp.lookupSymbol<func::FuncOp>(functionName)) {
+        entry.emitOpError()
+            << "configuration function @" << functionName << " already exists";
+        signalPassFailure();
+        return;
+      }
+    }
+
+    RotationAnalysis rotationAnalysis;
+    if (failed(rotationAnalysis.run(moduleOp))) {
+      entry.emitOpError("failed to compute static rotation indices");
+      signalPassFailure();
+      return;
+    }
+    bool bootstraps = false;
+    moduleOp.walk([&](BootOp) { bootstraps = true; });
+    int64_t bootstrapNumSlots = 0;
+    if (bootstraps) {
+      auto slotsAttr =
+          moduleOp->getAttrOfType<IntegerAttr>(kRequestedSlotCountAttrName);
+      if (!slotsAttr) {
+        entry.emitOpError(
+            "bootstrapping program is missing the scheme.requested_slot_count "
+            "module attribute needed to configure the boot context");
+        signalPassFailure();
+        return;
+      }
+      // EvalSpecialFFT requires at least 256 slots. BootContext supports
+      // bootstrapping a smaller ciphertext with a larger prepared transform.
+      bootstrapNumSlots = std::max(slotsAttr.getInt(), kMinBootstrapSlots);
+    }
+
+    int64_t logN = schemeParamAttr.getLogN();
+    int64_t logDefaultScale = schemeParamAttr.getLogDefaultScale();
+    int64_t bootNumCts = numCtsLevels;
+    int64_t bootNumStc = numStcLevels;
+    int64_t defaultEncLevel = static_cast<int64_t>(Q.size()) - 1;
+    int64_t denseHammingWeight = 0;
+    int64_t sparseHammingWeight = 0;
+    if (bootstraps) {
+      if (auto attr =
+              moduleOp->getAttrOfType<IntegerAttr>("cheddar.boot.num_cts"))
+        bootNumCts = attr.getInt();
+      if (auto attr =
+              moduleOp->getAttrOfType<IntegerAttr>("cheddar.boot.num_stc"))
+        bootNumStc = attr.getInt();
+      if (bootNumCts < 0 || bootNumStc < 0) {
+        entry.emitOpError(
+            "CHEDDAR bootstrap CtS and StC level counts must be non-negative");
+        signalPassFailure();
+        return;
+      }
+      defaultEncLevel -= bootNumCts + kBootstrapEvalModLevels;
+      int64_t bootstrapEndLevel = defaultEncLevel - bootNumStc;
+      if (defaultEncLevel < 0 || bootstrapEndLevel < 0) {
+        entry.emitOpError()
+            << "CHEDDAR bootstrap modulus chain is too short: " << Q.size()
+            << " Q primes cannot cover " << bootNumCts << " CtS + "
+            << kBootstrapEvalModLevels << " EvalMod + " << bootNumStc
+            << " StC levels";
+        signalPassFailure();
+        return;
+      }
+      denseHammingWeight = int64_t{1} << (logN - 1);
+      sparseHammingWeight = 32;
+    }
+
+    SmallVector<std::pair<int64_t, int64_t>> rotationKeys;
+    if (prepareRotationKeysAtUseLevels) {
+      WalkResult result = moduleOp.walk([&](RotationOpInterface rotationOp) {
+        auto level = rotationOp->getAttrOfType<IntegerAttr>("level");
+        if (!level) {
+          rotationOp.emitOpError(
+              "requires a level attribute when preparing rotation keys at "
+              "operation use levels");
+          return WalkResult::interrupt();
+        }
+        for (int64_t distance :
+             rotationAnalysis.getRotationIndices(rotationOp)) {
+          rotationKeys.emplace_back(distance, level.getInt());
+        }
+        return WalkResult::advance();
+      });
+      if (result.wasInterrupted()) {
+        signalPassFailure();
+        return;
+      }
+    } else {
+      int64_t rotationKeyLevel =
+          bootstraps ? defaultEncLevel : static_cast<int64_t>(Q.size()) - 1;
+      for (int64_t distance : rotationAnalysis.getRotationIndices())
+        rotationKeys.emplace_back(distance, rotationKeyLevel);
+    }
+    llvm::sort(rotationKeys, [](const auto& lhs, const auto& rhs) {
+      if (lhs.first != rhs.first) return lhs.first < rhs.first;
+      return lhs.second > rhs.second;
+    });
+    rotationKeys.erase(std::unique(rotationKeys.begin(), rotationKeys.end()),
+                       rotationKeys.end());
+
+    moduleOp->setAttr("cheddar.logN",
+                      IntegerAttr::get(IntegerType::get(ctx, 64), logN));
+    moduleOp->setAttr(
+        "cheddar.logDefaultScale",
+        IntegerAttr::get(IntegerType::get(ctx, 64), logDefaultScale));
+    moduleOp->setAttr("cheddar.Q", Q);
+    moduleOp->setAttr("cheddar.P", P);
+    buildConfigureFuncs(moduleOp, entry, logN, logDefaultScale, Q, P,
+                        rotationKeys, bootstraps, bootstrapNumSlots, bootNumCts,
+                        bootNumStc, defaultEncLevel, denseHammingWeight,
+                        sparseHammingWeight, logMessageRatio);
+
+    moduleOp->removeAttr(ckks::CKKSDialect::kSchemeParamAttrName);
+    moduleOp->removeAttr("scheme.ckks");
+  }
+};
+
+}  // namespace mlir::heir::cheddar

--- a/lib/Dialect/Cheddar/Transforms/ConfigureCryptoContext.h
+++ b/lib/Dialect/Cheddar/Transforms/ConfigureCryptoContext.h
@@ -1,0 +1,16 @@
+#ifndef LIB_DIALECT_CHEDDAR_TRANSFORMS_CONFIGURECRYPTOCONTEXT_H_
+#define LIB_DIALECT_CHEDDAR_TRANSFORMS_CONFIGURECRYPTOCONTEXT_H_
+
+#include "mlir/include/mlir/Pass/Pass.h"  // from @llvm-project
+
+namespace mlir::heir::cheddar {
+
+#define GEN_PASS_DECL
+#include "lib/Dialect/Cheddar/Transforms/ConfigureCryptoContext.h.inc"
+
+#define GEN_PASS_REGISTRATION
+#include "lib/Dialect/Cheddar/Transforms/ConfigureCryptoContext.h.inc"
+
+}  // namespace mlir::heir::cheddar
+
+#endif  // LIB_DIALECT_CHEDDAR_TRANSFORMS_CONFIGURECRYPTOCONTEXT_H_

--- a/lib/Dialect/Cheddar/Transforms/ConfigureCryptoContext.td
+++ b/lib/Dialect/Cheddar/Transforms/ConfigureCryptoContext.td
@@ -1,0 +1,44 @@
+#ifndef LIB_DIALECT_CHEDDAR_TRANSFORMS_CONFIGURECRYPTOCONTEXT_TD_
+#define LIB_DIALECT_CHEDDAR_TRANSFORMS_CONFIGURECRYPTOCONTEXT_TD_
+
+include "mlir/Pass/PassBase.td"
+
+def CheddarConfigureCryptoContext : Pass<"cheddar-configure-crypto-context"> {
+  let summary = "Configure CHEDDAR crypto context from scheme parameters.";
+
+  let description = [{
+    This pass reads the `ckks.schemeParam` module attribute and re-exposes the
+    CHEDDAR-relevant parameters (`cheddar.logN`, `cheddar.logDefaultScale`,
+    `cheddar.Q`, `cheddar.P`) as module attributes, then removes the CKKS
+    module attributes.
+
+    It also generates a `<entry>__configure` function that builds the CHEDDAR
+    `Parameter` from the modulus chain, creates the `Context` and
+    `UserInterface`, and prepares a rotation key for every distinct rotation
+    distance used by the program (`cheddar.hrot` / `cheddar.hrot_add`). The
+    `prepare-rotation-keys-at-use-levels` option instead prepares every
+    distance at each operation level where it is used. The context and
+    user_interface are handed back to the caller through owning
+    out-params (`std::shared_ptr<Context<word>>&` /
+    `std::unique_ptr<UserInterface<word>>&`), matching the lattigo backend's
+    `__configure` convention.
+
+    After this pass, the module no longer depends on the CKKS dialect.
+  }];
+
+  let options = [
+    Option<"entryFunction", "entry-function", "std::string", "", "Entry function to configure (auto-detected if empty)">,
+    Option<"numCtsLevels", "num-cts-levels", "int", /*default=*/"3", "Bootstrap CoeffToSlot (CtS) level budget (cf. OpenFHE level-budget-encode); only used when the program bootstraps">,
+    Option<"numStcLevels", "num-stc-levels", "int", /*default=*/"3", "Bootstrap SlotToCoeff (StC) level budget (cf. OpenFHE level-budget-decode); only used when the program bootstraps">,
+    Option<"logMessageRatio", "log-message-ratio", "int", /*default=*/"-1", "Bootstrap message headroom passed to CHEDDAR's BootParameter (governs EvalMod precision). -1 uses CHEDDAR's default headroom of 5; only used when the program bootstraps">,
+    Option<"prepareRotationKeysAtUseLevels", "prepare-rotation-keys-at-use-levels", "bool", /*default=*/"false", "Prepare each rotation key at the level of the operation that uses it instead of once at the maximum level">,
+  ];
+
+  let dependentDialects = [
+    "mlir::heir::cheddar::CheddarDialect",
+    "mlir::func::FuncDialect",
+    "mlir::tensor::TensorDialect",
+  ];
+}
+
+#endif  // LIB_DIALECT_CHEDDAR_TRANSFORMS_CONFIGURECRYPTOCONTEXT_TD_

--- a/lib/Transforms/GenerateParam/GenerateParamCKKS.cpp
+++ b/lib/Transforms/GenerateParam/GenerateParamCKKS.cpp
@@ -49,6 +49,16 @@ bool containsBootstrap(Operation* op) {
   });
   return result.wasInterrupted();
 }
+
+// scale-snu/cheddar's BootContext uses one explicit chain containing both the
+// compute levels and the bootstrap circuit: CoeffToSlot, eight EvalMod levels,
+// and SlotToCoeff. The bootstrap returns to the original compute maximum, so
+// these levels extend the generated chain without changing HEIR's level model.
+constexpr int kCheddarBootNumCts = 4;
+constexpr int kCheddarBootNumStc = 2;
+constexpr int kCheddarBootEvalModLevels = 8;
+constexpr int kCheddarBootOverhead =
+    kCheddarBootNumCts + kCheddarBootNumStc + kCheddarBootEvalModLevels;
 }  // namespace
 
 struct GenerateParamCKKS : impl::GenerateParamCKKSBase<GenerateParamCKKS> {
@@ -148,32 +158,46 @@ struct GenerateParamCKKS : impl::GenerateParamCKKSBase<GenerateParamCKKS> {
     // below. Widening it would desync the packed layouts from the ciphertexts.
     int64_t requestedSlotCount = minSlotCount;
 
-    // for lattigo, defaults to extended encryption technique
-    if (moduleIsLattigo(getOperation())) {
-      encryptionTechniqueExtended = true;
-      LDBG() << "For lattigo, fixing extended encryption technique";
+    bool cheddarTarget = moduleIsCheddar(getOperation());
+    bool hasBootstrap = containsBootstrap(getOperation());
 
-      // Lattigo bootstrapping requires LogN >= 14, i.e., ringDim >= 16384.
-      // Since ringDim is computed from minSlotCount (minRingDim = 2 *
-      // minSlotCount), we bump minSlotCount to 8192 if bootstrapping is
-      // present.
-      if (containsBootstrap(getOperation())) {
+    // Lattigo and scale-snu/cheddar use the extended-encryption CKKS
+    // parameter path.
+    if (moduleIsLattigo(getOperation()) || cheddarTarget) {
+      encryptionTechniqueExtended = true;
+      LDBG() << "For lattigo/cheddar, fixing extended encryption technique";
+
+      // The supported Lattigo and scale-snu/cheddar bootstrap configurations
+      // require LogN >= 14. Since ringDim is twice minSlotCount, enforce the
+      // corresponding 8192-slot floor.
+      if (hasBootstrap) {
         if (minSlotCount < 8192) {
-          LDBG() << "Lattigo bootstrapping detected, bumping minSlotCount from "
+          LDBG() << "Bootstrapping detected, bumping minSlotCount from "
                  << minSlotCount << " to 8192";
           minSlotCount = 8192;
         }
       }
     }
 
+    int computeMaxLevel = maxLevel.value_or(0);
+    bool cheddarBootstrap = cheddarTarget && hasBootstrap;
+    int generatedMaxLevel =
+        computeMaxLevel + (cheddarBootstrap ? kCheddarBootOverhead : 0);
+
     auto schemeParam = ckks::SchemeParam::getConcreteSchemeParam(
-        firstModBits, scalingModBits, maxLevel.value_or(0), minSlotCount,
+        firstModBits, scalingModBits, generatedMaxLevel, minSlotCount,
         usePublicKey, encryptionTechniqueExtended, reducedError);
 
     LDBG() << "Scheme Param:\n" << schemeParam;
 
     auto* context = &getContext();
     OpBuilder builder(context);
+    if (cheddarBootstrap) {
+      getOperation()->setAttr("cheddar.boot.num_cts",
+                              builder.getI64IntegerAttr(kCheddarBootNumCts));
+      getOperation()->setAttr("cheddar.boot.num_stc",
+                              builder.getI64IntegerAttr(kCheddarBootNumStc));
+    }
     getOperation()->setAttr(kRequestedSlotCountAttrName,
                             builder.getI64IntegerAttr(requestedSlotCount));
     getOperation()->setAttr(

--- a/tests/Conversions/CheddarToEmitC/cheddar_to_emitc.mlir
+++ b/tests/Conversions/CheddarToEmitC/cheddar_to_emitc.mlir
@@ -31,6 +31,25 @@ memref.global "private" constant @zero_splat : memref<4x4xf32> = dense<0.000000e
 // CHECK: emitc.global static @negative_zero_splat : !emitc.array<4xf32> = dense<-0.000000e+00>
 memref.global "private" constant @negative_zero_splat : memref<4xf32> = dense<-0.000000e+00>
 
+// CHECK: func.func @configure
+// CHECK-SAME: !emitc.opaque<"std::shared_ptr<Context<word>>&">
+// CHECK-SAME: !emitc.opaque<"std::unique_ptr<UserInterface<word>>&">
+// CHECK: emitc.verbatim "static Parameter<word> cheddar_param
+// CHECK-SAME: std::vector<word>{1ULL, 2ULL, 3ULL}
+// CHECK-SAME: std::vector<word>{4ULL, 5ULL}
+// CHECK: emitc.verbatim "{} = Context<word>::Create({});"
+// CHECK: emitc.verbatim "{} = std::make_unique<UserInterface<word>>({});"
+// CHECK: emitc.verbatim "{}->PrepareRotationKey(3, 2);"
+func.func @configure() -> (tensor<!context>, tensor<!user_interface>) {
+  %p = cheddar.make_parameter {logN = 14 : i64, logScale = 45 : i64, mainPrimes = array<i64: 1, 2, 3>, auxPrimes = array<i64: 4, 5>} : !parameter
+  %context_dest = tensor.empty() : tensor<!context>
+  %context = cheddar.create_context %p, %context_dest : (!parameter, tensor<!context>) -> tensor<!context>
+  %ui_dest = tensor.empty() : tensor<!user_interface>
+  %ui = cheddar.create_user_interface %context, %ui_dest : (tensor<!context>, tensor<!user_interface>) -> tensor<!user_interface>
+  %prepared = cheddar.prepare_rot_key %ui {distance = 3 : i64, maxLevel = 2 : i64} : (tensor<!user_interface>) -> tensor<!user_interface>
+  return %context, %prepared : tensor<!context>, tensor<!user_interface>
+}
+
 // A two-op chain: each op is `ctx->Method(out, a, b)`. The first op's result is
 // an intermediate local (`emitc.variable`); the second writes the function
 // out-param. Inputs are `const Ciphertext<word>&`, the out-param is mutable.
@@ -151,7 +170,7 @@ func.func @dec_chain(%enc: !encoder, %ui: !user_interface, %ct: tensor<!cipherte
 // CHECK: emitc.verbatim "{}->HRot({}, {}, {}->GetRotationKey(5), 5);"
 func.func @hrot_static(%ctx: !context, %ui: !user_interface, %ct: tensor<!ciphertext>) -> tensor<!ciphertext> {
   %d0 = tensor.empty() : tensor<!ciphertext>
-  %r = cheddar.hrot %ctx, %ui, %ct, %d0 {static_distance = 5 : i64} : (!context, !user_interface, tensor<!ciphertext>, tensor<!ciphertext>) -> tensor<!ciphertext>
+  %r = cheddar.hrot %ctx, %ui, %ct, %d0 {level = 4 : i64, static_distance = 5 : i64} : (!context, !user_interface, tensor<!ciphertext>, tensor<!ciphertext>) -> tensor<!ciphertext>
   return %r : tensor<!ciphertext>
 }
 
@@ -160,7 +179,7 @@ func.func @hrot_static(%ctx: !context, %ui: !user_interface, %ct: tensor<!cipher
 // CHECK-SAME: %arg3, %arg3
 func.func @hrot_dyn(%ctx: !context, %ui: !user_interface, %ct: tensor<!ciphertext>, %d: index) -> tensor<!ciphertext> {
   %d0 = tensor.empty() : tensor<!ciphertext>
-  %r = cheddar.hrot %ctx, %ui, %ct, %d0, %d : (!context, !user_interface, tensor<!ciphertext>, tensor<!ciphertext>, index) -> tensor<!ciphertext>
+  %r = cheddar.hrot %ctx, %ui, %ct, %d0, %d {level = 4 : i64} : (!context, !user_interface, tensor<!ciphertext>, tensor<!ciphertext>, index) -> tensor<!ciphertext>
   return %r : tensor<!ciphertext>
 }
 

--- a/tests/Conversions/CheddarToEmitC/compile/BUILD
+++ b/tests/Conversions/CheddarToEmitC/compile/BUILD
@@ -122,3 +122,67 @@ build_test(
     target_compatible_with = requires_cheddar(),
     targets = [":kernels_real_compiled"],
 )
+
+heir_opt(
+    name = "setup_emitc",
+    src = "setup.mlir",
+    generated_filename = "setup_emitc.mlir",
+    pass_flags = [
+        "--cheddar-configure-crypto-context=entry-function=kernel",
+        "--cheddar-bufferize",
+        "--fold-memref-alias-ops",
+        "--cse",
+        "--canonicalize",
+        "--drop-equivalent-buffer-results",
+        "--canonicalize",
+        "--convert-to-emitc=filter-dialects=cheddar,arith,scf",
+        "--cheddar-emitc-boundary",
+        "--reconcile-unrealized-casts",
+    ],
+)
+
+heir_translate(
+    name = "setup_cpp_raw",
+    src = ":setup_emitc.mlir",
+    generated_filename = "setup_raw.cc",
+    pass_flags = ["--mlir-to-cpp"],
+)
+
+genrule(
+    name = "setup_real_lib_src",
+    srcs = [":setup_raw.cc"],
+    outs = ["setup_real_lib.cc"],
+    cmd = """cat > $@ <<'PRELUDE_EOF'
+// AUTO-GENERATED: do not edit. See tests/Conversions/CheddarToEmitC/compile/BUILD.
+#include <array>
+#include <complex>
+#include <cstdint>
+#include <initializer_list>
+#include <memory>
+#include <utility>
+#include <vector>
+#include "UserInterface.h"
+#include "core/Context.h"
+#include "core/Encode.h"
+#include "core/Parameter.h"
+#include "extension/BootContext.h"
+#include "extension/EvalPoly.h"
+using namespace cheddar;
+using word = uint64_t;
+PRELUDE_EOF
+cat $(location :setup_raw.cc) >> $@
+""",
+)
+
+cc_library(
+    name = "setup_real_compiled",
+    srcs = [":setup_real_lib_src"],
+    target_compatible_with = requires_cheddar(),
+    deps = ["@cheddar"],
+)
+
+build_test(
+    name = "real_setup_compile_test",
+    target_compatible_with = requires_cheddar(),
+    targets = [":setup_real_compiled"],
+)

--- a/tests/Conversions/CheddarToEmitC/compile/cheddar_stub.h
+++ b/tests/Conversions/CheddarToEmitC/compile/cheddar_stub.h
@@ -15,10 +15,8 @@
 //     non-const reference.                              (core/Context.h:377)
 //   * UserInterface::Get*Key() / GetEvkMap() return `const&`. (UserInterface.h)
 //
-// Kept deliberately narrow: the "setup/getter" surface (create_context,
-// create_user_interface, get_encoder, encode/decode) is *not* modelled here
-// because that part of the emitter has independent, pre-existing mismatches
-// against the real API and needs its own design pass.
+// Kept deliberately narrow: setup is covered by conversion and opt-in real
+// CHEDDAR compile tests. Getter ops remain unsupported by this lowering.
 
 #ifndef TESTS_CONVERSIONS_CHEDDARTOEMITC_COMPILE_CHEDDAR_STUB_H_
 #define TESTS_CONVERSIONS_CHEDDARTOEMITC_COMPILE_CHEDDAR_STUB_H_

--- a/tests/Conversions/CheddarToEmitC/compile/kernels.mlir
+++ b/tests/Conversions/CheddarToEmitC/compile/kernels.mlir
@@ -110,10 +110,10 @@ func.func @rotations(%ctx: !context, %ui: !cheddar.user_interface,
                      %a: tensor<!ciphertext>, %b: tensor<!ciphertext>)
     -> tensor<!ciphertext> {
   %d0 = tensor.empty() : tensor<!ciphertext>
-  %0 = cheddar.hrot %ctx, %ui, %a, %d0 {static_distance = 5 : i64}
+  %0 = cheddar.hrot %ctx, %ui, %a, %d0 {level = 4 : i64, static_distance = 5 : i64}
       : (!context, !cheddar.user_interface, tensor<!ciphertext>, tensor<!ciphertext>) -> tensor<!ciphertext>
   %d1 = tensor.empty() : tensor<!ciphertext>
-  %1 = cheddar.hrot_add %ctx, %ui, %0, %b, %d1 {distance = 7 : i64}
+  %1 = cheddar.hrot_add %ctx, %ui, %0, %b, %d1 {distance = 7 : i64, level = 4 : i64}
       : (!context, !cheddar.user_interface, tensor<!ciphertext>, tensor<!ciphertext>, tensor<!ciphertext>) -> tensor<!ciphertext>
   %d2 = tensor.empty() : tensor<!ciphertext>
   %2 = cheddar.hconj %ctx, %ui, %1, %d2

--- a/tests/Conversions/CheddarToEmitC/compile/setup.mlir
+++ b/tests/Conversions/CheddarToEmitC/compile/setup.mlir
@@ -1,0 +1,17 @@
+!boot_context = !cheddar.boot_context
+!ciphertext = !cheddar.ciphertext
+!evk_map = !cheddar.evk_map
+
+module attributes {
+  cheddar.boot.num_cts = 4 : i64,
+  cheddar.boot.num_stc = 3 : i64,
+  ckks.schemeParam = #ckks.scheme_param<logN = 16, Q = [1125899908022273, 1099515691009, 1099523555329, 1099525128193, 1099526176769, 1099529060353, 1099535220737, 1099536138241, 1099537580033, 1099538104321, 1099540725761, 1099540856833, 1099543085057, 36028797019488257, 36028797023420417, 36028797024206849, 36028797025124353, 36028797032202241, 36028797033644033, 36028797037576193, 36028797048324097, 36028797048586241, 36028797049896961, 36028797051863041, 36028797053698049, 36028797054222337], P = [72057594038321153, 72057594040680449, 72057594042646529, 72057594047889409, 72057594057195521, 72057594058375169, 72057594058899457], logDefaultScale = 40>,
+  scheme.actual_slot_count = 1024 : i64,
+  scheme.requested_slot_count = 1024 : i64
+} {
+  func.func @kernel(%ctx: !boot_context, %ct: tensor<!ciphertext>, %evk: !evk_map) -> tensor<!ciphertext> {
+    %dest = tensor.empty() : tensor<!ciphertext>
+    %result = cheddar.boot %ctx, %ct, %evk, %dest : (!boot_context, tensor<!ciphertext>, !evk_map, tensor<!ciphertext>) -> tensor<!ciphertext>
+    return %result : tensor<!ciphertext>
+  }
+}

--- a/tests/Conversions/CheddarToEmitC/unsupported_getters.mlir
+++ b/tests/Conversions/CheddarToEmitC/unsupported_getters.mlir
@@ -28,3 +28,14 @@ func.func @get_encoder(%ctx: !cheddar.context) -> !cheddar.encoder {
   %e = cheddar.get_encoder %ctx : (!cheddar.context) -> !cheddar.encoder
   return %e : !cheddar.encoder
 }
+
+// -----
+
+// The lowering uses one function-local static Parameter so the Context can
+// safely retain its reference after the configure function returns.
+// expected-error @below {{cheddar-to-emitc supports at most one cheddar.make_parameter per function}}
+func.func @duplicate_parameter() {
+  %p0 = cheddar.make_parameter {logN = 14 : i64, logScale = 45 : i64, mainPrimes = array<i64: 1, 2>, auxPrimes = array<i64: 3>} : !cheddar.parameter
+  %p1 = cheddar.make_parameter {logN = 14 : i64, logScale = 45 : i64, mainPrimes = array<i64: 1, 2>, auxPrimes = array<i64: 3>} : !cheddar.parameter
+  return
+}

--- a/tests/Dialect/Cheddar/IR/roundtrip.mlir
+++ b/tests/Dialect/Cheddar/IR/roundtrip.mlir
@@ -306,7 +306,7 @@ func.func @test_hrot_static(
     %out: tensor<!cheddar.ciphertext>) -> tensor<!cheddar.ciphertext> {
   // CHECK: cheddar.hrot
   // CHECK-SAME: static_distance = 5
-  %result = cheddar.hrot %ctx, %ui, %ct, %out {static_distance = 5 : i64} : (!cheddar.context, !cheddar.user_interface, tensor<!cheddar.ciphertext>, tensor<!cheddar.ciphertext>) -> tensor<!cheddar.ciphertext>
+  %result = cheddar.hrot %ctx, %ui, %ct, %out {level = 8 : i64, static_distance = 5 : i64} : (!cheddar.context, !cheddar.user_interface, tensor<!cheddar.ciphertext>, tensor<!cheddar.ciphertext>) -> tensor<!cheddar.ciphertext>
   return %result : tensor<!cheddar.ciphertext>
 }
 
@@ -318,7 +318,7 @@ func.func @test_hrot_dynamic(
     %out: tensor<!cheddar.ciphertext>,
     %dist: index) -> tensor<!cheddar.ciphertext> {
   // CHECK: cheddar.hrot
-  %result = cheddar.hrot %ctx, %ui, %ct, %out, %dist : (!cheddar.context, !cheddar.user_interface, tensor<!cheddar.ciphertext>, tensor<!cheddar.ciphertext>, index) -> tensor<!cheddar.ciphertext>
+  %result = cheddar.hrot %ctx, %ui, %ct, %out, %dist {level = 7 : i64} : (!cheddar.context, !cheddar.user_interface, tensor<!cheddar.ciphertext>, tensor<!cheddar.ciphertext>, index) -> tensor<!cheddar.ciphertext>
   return %result : tensor<!cheddar.ciphertext>
 }
 
@@ -331,7 +331,7 @@ func.func @test_hrot_add(
     %out: tensor<!cheddar.ciphertext>) -> tensor<!cheddar.ciphertext> {
   // CHECK: cheddar.hrot_add
   // CHECK-SAME: distance = 3
-  %result = cheddar.hrot_add %ctx, %ui, %ct0, %ct1, %out {distance = 3 : i64} : (!cheddar.context, !cheddar.user_interface, tensor<!cheddar.ciphertext>, tensor<!cheddar.ciphertext>, tensor<!cheddar.ciphertext>) -> tensor<!cheddar.ciphertext>
+  %result = cheddar.hrot_add %ctx, %ui, %ct0, %ct1, %out {distance = 3 : i64, level = 6 : i64} : (!cheddar.context, !cheddar.user_interface, tensor<!cheddar.ciphertext>, tensor<!cheddar.ciphertext>, tensor<!cheddar.ciphertext>) -> tensor<!cheddar.ciphertext>
   return %result : tensor<!cheddar.ciphertext>
 }
 

--- a/tests/Dialect/Cheddar/Transforms/bufferize.mlir
+++ b/tests/Dialect/Cheddar/Transforms/bufferize.mlir
@@ -106,7 +106,7 @@ func.func @rescale_alias_hint(%ctx: !cheddar.context, %lhs: tensor<!cheddar.ciph
 func.func @hrot_add_in_place(%ctx: !cheddar.context, %ui: !cheddar.user_interface, %lhs: tensor<!cheddar.ciphertext>, %rhs: tensor<!cheddar.ciphertext>) -> tensor<!cheddar.ciphertext> {
   %empty = tensor.empty() : tensor<!cheddar.ciphertext>
   %input = cheddar.add %ctx, %lhs, %rhs, %empty : (!cheddar.context, tensor<!cheddar.ciphertext>, tensor<!cheddar.ciphertext>, tensor<!cheddar.ciphertext>) -> tensor<!cheddar.ciphertext>
-  %output = cheddar.hrot_add %ctx, %ui, %input, %input, %input {distance = 2 : i64} : (!cheddar.context, !cheddar.user_interface, tensor<!cheddar.ciphertext>, tensor<!cheddar.ciphertext>, tensor<!cheddar.ciphertext>) -> tensor<!cheddar.ciphertext>
+  %output = cheddar.hrot_add %ctx, %ui, %input, %input, %input {distance = 2 : i64, level = 4 : i64} : (!cheddar.context, !cheddar.user_interface, tensor<!cheddar.ciphertext>, tensor<!cheddar.ciphertext>, tensor<!cheddar.ciphertext>) -> tensor<!cheddar.ciphertext>
   return %output : tensor<!cheddar.ciphertext>
 }
 

--- a/tests/Dialect/Cheddar/Transforms/configure_crypto_context.mlir
+++ b/tests/Dialect/Cheddar/Transforms/configure_crypto_context.mlir
@@ -1,0 +1,54 @@
+// RUN: heir-opt --cheddar-configure-crypto-context=entry-function=main %s | FileCheck %s
+// RUN: heir-opt --cheddar-configure-crypto-context="entry-function=main prepare-rotation-keys-at-use-levels=true" %s | FileCheck %s --check-prefix=USE-LEVELS
+
+!ciphertext = !cheddar.ciphertext
+!context = !cheddar.context
+!ui = !cheddar.user_interface
+
+module attributes {ckks.schemeParam = #ckks.scheme_param<logN = 13, Q = [36028797018652673, 1125899907366913, 1125899907760129], P = [1152921504606994433], logDefaultScale = 45>} {
+  func.func @main(%ctx: !context, %ui: !ui, %ct: tensor<!ciphertext>) -> tensor<!ciphertext> {
+    %d0 = bufferization.alloc_tensor() : tensor<!ciphertext>
+    %rot = cheddar.hrot %ctx, %ui, %ct, %d0 {level = 1 : i64, static_distance = 7 : i64} : (!context, !ui, tensor<!ciphertext>, tensor<!ciphertext>) -> tensor<!ciphertext>
+    %d1 = bufferization.alloc_tensor() : tensor<!ciphertext>
+    %result = cheddar.hrot_add %ctx, %ui, %rot, %ct, %d1 {distance = 2 : i64, level = 0 : i64} : (!context, !ui, tensor<!ciphertext>, tensor<!ciphertext>, tensor<!ciphertext>) -> tensor<!ciphertext>
+    %d2 = bufferization.alloc_tensor() : tensor<!ciphertext>
+    %result2 = cheddar.hrot_add %ctx, %ui, %result, %ct, %d2 {distance = 7 : i64, level = 0 : i64} : (!context, !ui, tensor<!ciphertext>, tensor<!ciphertext>, tensor<!ciphertext>) -> tensor<!ciphertext>
+    return %result2 : tensor<!ciphertext>
+  }
+}
+
+// CHECK: module attributes
+// CHECK-SAME: cheddar.P = array<i64: 1152921504606994433>
+// CHECK-SAME: cheddar.Q = array<i64: 36028797018652673, 1125899907366913, 1125899907760129>
+// CHECK-SAME: cheddar.logDefaultScale = 45 : i64
+// CHECK-SAME: cheddar.logN = 13 : i64
+// CHECK-NOT: ckks.schemeParam
+// CHECK: func.func @main__setup
+// CHECK-SAME: client.setup_func = {func_name = "main"}
+// CHECK: cheddar.make_parameter
+// CHECK: cheddar.create_context
+// CHECK: func.func @main__keygen
+// CHECK-SAME: client.keygen_func = {func_name = "main"}
+// CHECK: cheddar.create_user_interface
+// CHECK: cheddar.prepare_rot_key
+// CHECK-SAME: distance = 2
+// CHECK-SAME: maxLevel = 2
+// CHECK: cheddar.prepare_rot_key
+// CHECK-SAME: distance = 7
+// CHECK-SAME: maxLevel = 2
+// CHECK-NOT: cheddar.prepare_rot_key
+// CHECK: return %{{.*}}, %{{.*}} : tensor<!context>, tensor<!user_interface>
+// CHECK: func.func @main__configure
+// CHECK: call @main__setup
+// CHECK: call @main__keygen
+
+// USE-LEVELS: func.func @main__keygen
+// USE-LEVELS: cheddar.prepare_rot_key
+// USE-LEVELS-SAME: distance = 2
+// USE-LEVELS-SAME: maxLevel = 0
+// USE-LEVELS: cheddar.prepare_rot_key
+// USE-LEVELS-SAME: distance = 7
+// USE-LEVELS-SAME: maxLevel = 1
+// USE-LEVELS: cheddar.prepare_rot_key
+// USE-LEVELS-SAME: distance = 7
+// USE-LEVELS-SAME: maxLevel = 0

--- a/tests/Dialect/Cheddar/Transforms/configure_crypto_context_bootstrap.mlir
+++ b/tests/Dialect/Cheddar/Transforms/configure_crypto_context_bootstrap.mlir
@@ -1,0 +1,61 @@
+// RUN: heir-opt --cheddar-configure-crypto-context=entry-function=main %s | FileCheck %s --check-prefix=CONFIG
+// RUN: heir-opt --cheddar-configure-crypto-context=entry-function=main --cheddar-bufferize --fold-memref-alias-ops --canonicalize --convert-to-emitc=filter-dialects=cheddar,arith,scf --cheddar-emitc-boundary --reconcile-unrealized-casts %s | FileCheck %s --check-prefix=EMITC
+
+!boot_context = !cheddar.boot_context
+!ciphertext = !cheddar.ciphertext
+!evk_map = !cheddar.evk_map
+!ui = !cheddar.user_interface
+
+module attributes {
+  cheddar.boot.num_cts = 4 : i64,
+  cheddar.boot.num_stc = 3 : i64,
+  ckks.schemeParam = #ckks.scheme_param<logN = 16, Q = [1125899908022273, 1099515691009, 1099523555329, 1099525128193, 1099526176769, 1099529060353, 1099535220737, 1099536138241, 1099537580033, 1099538104321, 1099540725761, 1099540856833, 1099543085057, 36028797019488257, 36028797023420417, 36028797024206849, 36028797025124353, 36028797032202241, 36028797033644033, 36028797037576193, 36028797048324097, 36028797048586241, 36028797049896961, 36028797051863041, 36028797053698049, 36028797054222337], P = [72057594038321153, 72057594040680449, 72057594042646529, 72057594047889409, 72057594057195521, 72057594058375169, 72057594058899457], logDefaultScale = 40>,
+  scheme.actual_slot_count = 32768 : i64,
+  scheme.requested_slot_count = 8 : i64
+} {
+  func.func @main(%ctx: !boot_context, %ui: !ui, %ct: tensor<!ciphertext>, %evk: !evk_map) -> tensor<!ciphertext> {
+    %rotDest = bufferization.alloc_tensor() : tensor<!ciphertext>
+    %rotated = cheddar.hrot %ctx, %ui, %ct, %rotDest {level = 13 : i64, static_distance = 7 : i64} : (!boot_context, !ui, tensor<!ciphertext>, tensor<!ciphertext>) -> tensor<!ciphertext>
+    %dest = bufferization.alloc_tensor() : tensor<!ciphertext>
+    %result = cheddar.boot %ctx, %rotated, %evk, %dest : (!boot_context, tensor<!ciphertext>, !evk_map, tensor<!ciphertext>) -> tensor<!ciphertext>
+    return %result : tensor<!ciphertext>
+  }
+}
+
+// CONFIG: func.func @main__setup
+// CONFIG: cheddar.make_parameter
+// CONFIG-SAME: defaultEncryptionLevel = 13
+// CONFIG-SAME: denseHammingWeight = 32768
+// CONFIG-SAME: sparseHammingWeight = 32
+// CONFIG: cheddar.create_boot_context
+// CONFIG-SAME: logMessageRatio = 5
+// CONFIG-SAME: numCtsLevels = 4
+// CONFIG-SAME: numStcLevels = 3
+// CONFIG: func.func @main__keygen
+// CONFIG: cheddar.create_user_interface
+// CONFIG: cheddar.prepare_rot_key
+// CONFIG-SAME: distance = 7
+// CONFIG-SAME: maxLevel = 13
+// CONFIG: cheddar.prepare_bootstrap
+// CONFIG-SAME: numSlots = 256
+// CONFIG: func.func @main__configure
+// CONFIG: call @main__setup
+// CONFIG: call @main__keygen
+
+// EMITC: func.func @main__setup
+// EMITC-SAME: !emitc.opaque<"std::shared_ptr<BootContext<word>>&">
+// EMITC: emitc.verbatim "static Parameter<word> cheddar_param
+// EMITC: emitc.verbatim "cheddar_param.SetDenseHammingWeight(32768);"
+// EMITC: emitc.verbatim "cheddar_param.SetSparseHammingWeight(32);"
+// EMITC: emitc.verbatim "{} = BootContext<word>::Create({}, BootParameter({}.max_level_, 4, 3, 5));"
+// EMITC: func.func @main__keygen
+// EMITC-SAME: !emitc.opaque<"const std::shared_ptr<BootContext<word>>&">
+// EMITC-SAME: !emitc.opaque<"std::unique_ptr<UserInterface<word>>&">
+// EMITC: emitc.verbatim "{}->PrepareRotationKey(7, 13);"
+// EMITC: emitc.verbatim "{}->PrepareEvalMod();"
+// EMITC: emitc.verbatim "{}->PrepareEvalSpecialFFT(256, BootVariant::kImaginaryRemoving);"
+// EMITC: emitc.verbatim "EvkRequest boot_evk_req;"
+// EMITC: emitc.verbatim "{}->PrepareRotationKey(boot_evk_req);"
+// EMITC: func.func @main__configure
+// EMITC: emitc.call_opaque "main__setup"
+// EMITC: emitc.call_opaque "main__keygen"

--- a/tests/Dialect/Cheddar/Transforms/configure_crypto_context_bootstrap_invalid.mlir
+++ b/tests/Dialect/Cheddar/Transforms/configure_crypto_context_bootstrap_invalid.mlir
@@ -1,0 +1,18 @@
+// RUN: not heir-opt --cheddar-configure-crypto-context=entry-function=main %s 2>&1 | FileCheck %s
+
+!boot_context = !cheddar.boot_context
+!ciphertext = !cheddar.ciphertext
+!evk_map = !cheddar.evk_map
+
+module attributes {
+  ckks.schemeParam = #ckks.scheme_param<logN = 13, Q = [36028797018652673, 1125899907366913, 1125899907760129], P = [1152921504606994433], logDefaultScale = 45>,
+  scheme.actual_slot_count = 4096 : i64,
+  scheme.requested_slot_count = 4 : i64
+} {
+  // CHECK: error: 'func.func' op CHEDDAR bootstrap modulus chain is too short: 3 Q primes cannot cover 3 CtS + 8 EvalMod + 3 StC levels
+  func.func @main(%ctx: !boot_context, %ct: tensor<!ciphertext>, %evk: !evk_map) -> tensor<!ciphertext> {
+    %dest = bufferization.alloc_tensor() : tensor<!ciphertext>
+    %result = cheddar.boot %ctx, %ct, %evk, %dest : (!boot_context, tensor<!ciphertext>, !evk_map, tensor<!ciphertext>) -> tensor<!ciphertext>
+    return %result : tensor<!ciphertext>
+  }
+}

--- a/tests/Dialect/Cheddar/Transforms/configure_crypto_context_invalid.mlir
+++ b/tests/Dialect/Cheddar/Transforms/configure_crypto_context_invalid.mlir
@@ -1,0 +1,15 @@
+// RUN: not heir-opt --cheddar-configure-crypto-context=entry-function=main %s 2>&1 | FileCheck %s
+
+!boot_context = !cheddar.boot_context
+!ciphertext = !cheddar.ciphertext
+!evk_map = !cheddar.evk_map
+
+module attributes {ckks.schemeParam = #ckks.scheme_param<logN = 13, Q = [36028797018652673, 1125899907366913], P = [1152921504606994433], logDefaultScale = 45>} {
+  func.func @main(%ctx: !boot_context, %ct: tensor<!ciphertext>, %evk: !evk_map) -> tensor<!ciphertext> {
+    %dest = bufferization.alloc_tensor() : tensor<!ciphertext>
+    %result = cheddar.boot %ctx, %ct, %evk, %dest : (!boot_context, tensor<!ciphertext>, !evk_map, tensor<!ciphertext>) -> tensor<!ciphertext>
+    return %result : tensor<!ciphertext>
+  }
+}
+
+// CHECK: error: 'func.func' op bootstrapping program is missing the scheme.requested_slot_count module attribute

--- a/tests/Examples/cheddar/bootstrap/BUILD
+++ b/tests/Examples/cheddar/bootstrap/BUILD
@@ -1,0 +1,82 @@
+load("@heir//bazel/cheddar:config.bzl", "requires_cheddar")
+load("@heir//tools:heir-opt.bzl", "heir_opt")
+load("@heir//tools:heir-translate.bzl", "heir_translate")
+load("@rules_cc//cc:cc_library.bzl", "cc_library")
+load("@rules_cc//cc:cc_test.bzl", "cc_test")
+
+package(
+    default_applicable_licenses = ["@heir//:license"],
+    default_visibility = ["//visibility:public"],
+)
+
+# End-to-end: generate the real scale-snu BootContext setup, encrypt at level 0,
+# refresh with cheddar.boot (-> BootContext::Boot), decrypt, and check both the
+# refreshed level and boot(x) ~= x. The MLIR carries CHEDDAR's curated
+# bootparam_40_64bit modulus chain because the bootstrap needs substantially
+# more depth than an ordinary arithmetic program.
+heir_opt(
+    name = "bootstrap_emitc",
+    src = "bootstrap.mlir",
+    generated_filename = "bootstrap_emitc.mlir",
+    pass_flags = [
+        "--cheddar-configure-crypto-context=entry-function=boot",
+        "--cheddar-to-emitc",
+    ],
+)
+
+heir_translate(
+    name = "bootstrap_cpp_raw",
+    src = ":bootstrap_emitc.mlir",
+    generated_filename = "bootstrap_raw.cc",
+    pass_flags = ["--mlir-to-cpp"],
+)
+
+genrule(
+    name = "bootstrap_lib_src",
+    srcs = [":bootstrap_raw.cc"],
+    outs = ["bootstrap_lib.cc"],
+    cmd = """cat > $@ <<'PRELUDE_EOF'
+// AUTO-GENERATED: do not edit. See tests/Examples/cheddar/bootstrap/BUILD.
+#include <array>
+#include <complex>
+#include <cstddef>
+#include <cstdint>
+#include <utility>
+#include <vector>
+#include "core/Context.h"
+#include "core/Encode.h"
+#include "core/EvkRequest.h"
+#include "core/Parameter.h"
+#include "extension/BootContext.h"
+#include "UserInterface.h"
+using namespace cheddar;
+using word = uint64_t;
+using Complex = std::complex<double>;
+PRELUDE_EOF
+cat $(location :bootstrap_raw.cc) >> $@
+""",
+)
+
+cc_library(
+    name = "bootstrap_lib",
+    srcs = [":bootstrap_lib_src"],
+    target_compatible_with = requires_cheddar(),
+    deps = ["@cheddar"],
+)
+
+cc_test(
+    name = "bootstrap_test",
+    timeout = "long",
+    srcs = ["bootstrap_test.cpp"],
+    linkstatic = False,
+    tags = [
+        "exclusive",
+        "notap",
+    ],
+    target_compatible_with = requires_cheddar(),
+    deps = [
+        ":bootstrap_lib",
+        "@cheddar",
+        "@googletest//:gtest_main",
+    ],
+)

--- a/tests/Examples/cheddar/bootstrap/bootstrap.mlir
+++ b/tests/Examples/cheddar/bootstrap/bootstrap.mlir
@@ -1,0 +1,85 @@
+// A real CHEDDAR GPU bootstrap at the cheddar level: encrypt a secret 8-vector
+// at level 0 (the bottom), refresh its noise budget with cheddar.boot, then
+// decrypt -- so the result is (approximately) the input. Full-module e2e input
+// (client encrypt/decrypt helpers + the boot compute).
+//
+// This Cheddar-level IR is curated rather than pipeline-generated, mirroring
+// the lattigo bootstrap example (tests/Examples/lattigo/ckks/bootstrapping).
+// The harness drives CHEDDAR's well-known
+// bootparam_40_64bit param set (logN=16, 26-prime chain, scale 2^40,
+// num_cts_levels=4, num_stc_levels=3) and this IR only carries the runtime-
+// relevant literals: the level-0 encode at scale GetScale(0) = 2^40 (clean at the
+// bottom, so no scale bake needed) and the boot/encrypt/decrypt ops. The harness
+// supplies the boot's evk_map from ui->GetEvkMap() after AddRequiredRotations.
+//
+// cheddar.boot takes a !cheddar.boot_context and lowers to `ctx->Boot(res, in,
+// evk_map)` on a BootContext<word>*; the harness passes the BootContext and
+// prepared evaluation-key map it built.
+!ciphertext = !cheddar.ciphertext
+!context = !cheddar.context
+!boot_context = !cheddar.boot_context
+!encoder = !cheddar.encoder
+!eval_key = !cheddar.eval_key
+!evk_map = !cheddar.evk_map
+!plaintext = !cheddar.plaintext
+!user_interface = !cheddar.user_interface
+#layout = #tensor_ext.layout<"{ [i0] -> [ct, slot] : ct = 0 and (-i0 + slot) mod 8 = 0 and 0 <= i0 <= 7 and 0 <= slot <= 7 }">
+#original_type = #tensor_ext.original_type<originalType = tensor<8xf32>, layout = #layout>
+module attributes {
+  backend.cheddar,
+  cheddar.boot.num_cts = 4 : i64,
+  cheddar.boot.num_stc = 3 : i64,
+  ckks.schemeParam = #ckks.scheme_param<logN = 16, Q = [1125899908022273, 1099515691009, 1099523555329, 1099525128193, 1099526176769, 1099529060353, 1099535220737, 1099536138241, 1099537580033, 1099538104321, 1099540725761, 1099540856833, 1099543085057, 36028797019488257, 36028797023420417, 36028797024206849, 36028797025124353, 36028797032202241, 36028797033644033, 36028797037576193, 36028797048324097, 36028797048586241, 36028797049896961, 36028797051863041, 36028797053698049, 36028797054222337], P = [72057594038321153, 72057594040680449, 72057594042646529, 72057594047889409, 72057594057195521, 72057594058375169, 72057594058899457], logDefaultScale = 40>,
+  scheme.actual_slot_count = 1024 : i64,
+  scheme.requested_slot_count = 8 : i64
+} {
+  func.func @boot(%ctx: !boot_context, %encoder: !encoder, %ui: !user_interface, %evk: !eval_key, %evk_map: !evk_map, %arg0: tensor<1x!ciphertext> {tensor_ext.original_type = #original_type}) -> (tensor<1x!ciphertext> {tensor_ext.original_type = #original_type}) {
+    %c0 = arith.constant 0 : index
+    %extracted = tensor.extract_slice %arg0[0] [1] [1] : tensor<1x!ciphertext> to tensor<!ciphertext>
+    %dps_1 = tensor.empty() : tensor<!ciphertext>
+    %ct = cheddar.boot %ctx, %extracted, %evk_map, %dps_1 : (!boot_context, tensor<!ciphertext>, !evk_map, tensor<!ciphertext>) -> tensor<!ciphertext>
+    %0 = tensor.empty() : tensor<1x!ciphertext>
+    %inserted = tensor.insert_slice %ct into %0[0] [1] [1] : tensor<!ciphertext> into tensor<1x!ciphertext>
+    return %inserted : tensor<1x!ciphertext>
+  }
+  func.func @boot__encrypt__arg0(%ctx: !context, %encoder: !encoder, %ui: !user_interface, %evk: !eval_key, %arg0: tensor<8xf32>, %ui_0: !user_interface) -> tensor<1x!ciphertext> attributes {client.enc_func = {func_name = "boot", index = 0 : i64}} {
+    %c0 = arith.constant 0 : index
+    %cst = arith.constant dense<0.000000e+00> : tensor<1x8xf32>
+    %c0_i32 = arith.constant 0 : i32
+    %c1_i32 = arith.constant 1 : i32
+    %c8_i32 = arith.constant 8 : i32
+    %0 = scf.for %arg1 = %c0_i32 to %c8_i32 step %c1_i32 iter_args(%arg2 = %cst) -> (tensor<1x8xf32>)  : i32 {
+      %1 = arith.index_cast %arg1 : i32 to index
+      %extracted = tensor.extract %arg0[%1] : tensor<8xf32>
+      %inserted = tensor.insert %extracted into %arg2[%c0, %1] : tensor<1x8xf32>
+      scf.yield %inserted : tensor<1x8xf32>
+    }
+    %extracted_slice = tensor.extract_slice %0[0, 0] [1, 8] [1, 1] : tensor<1x8xf32> to tensor<8xf32>
+    %dps_2 = tensor.empty() : tensor<!plaintext>
+    %pt = cheddar.encode %encoder, %extracted_slice, %dps_2 {level = 0 : i64} : (!encoder, tensor<8xf32>, tensor<!plaintext>) -> tensor<!plaintext>
+    %dps_3 = tensor.empty() : tensor<!ciphertext>
+    %ct = cheddar.encrypt %ui, %pt, %dps_3 : (!user_interface, tensor<!plaintext>, tensor<!ciphertext>) -> tensor<!ciphertext>
+    %fe_4 = tensor.empty() : tensor<1x!ciphertext>
+    %from_elements = tensor.insert_slice %ct into %fe_4[0] [1] [1] : tensor<!ciphertext> into tensor<1x!ciphertext>
+    return %from_elements : tensor<1x!ciphertext>
+  }
+  func.func @boot__decrypt__result0(%ctx: !context, %encoder: !encoder, %ui: !user_interface, %evk: !eval_key, %arg0: tensor<1x!ciphertext>, %ui_0: !user_interface) -> tensor<8xf32> attributes {client.dec_func = {func_name = "boot", index = 0 : i64}} {
+    %c0 = arith.constant 0 : index
+    %c8_i32 = arith.constant 8 : i32
+    %c1_i32 = arith.constant 1 : i32
+    %c0_i32 = arith.constant 0 : i32
+    %cst = arith.constant dense<0.000000e+00> : tensor<8xf32>
+    %extracted = tensor.extract_slice %arg0[0] [1] [1] : tensor<1x!ciphertext> to tensor<!ciphertext>
+    %dps_5 = tensor.empty() : tensor<!plaintext>
+    %pt = cheddar.decrypt %ui, %extracted, %dps_5 : (!user_interface, tensor<!ciphertext>, tensor<!plaintext>) -> tensor<!plaintext>
+    %0 = tensor.empty() : tensor<1x8xf32>
+    %1 = cheddar.decode %encoder, %pt, %0 : (!encoder, tensor<!plaintext>, tensor<1x8xf32>) -> tensor<1x8xf32>
+    %2 = scf.for %arg1 = %c0_i32 to %c8_i32 step %c1_i32 iter_args(%arg2 = %cst) -> (tensor<8xf32>)  : i32 {
+      %3 = arith.index_cast %arg1 : i32 to index
+      %extracted_1 = tensor.extract %1[%c0, %3] : tensor<1x8xf32>
+      %inserted = tensor.insert %extracted_1 into %arg2[%3] : tensor<8xf32>
+      scf.yield %inserted : tensor<8xf32>
+    }
+    return %2 : tensor<8xf32>
+  }
+}

--- a/tests/Examples/cheddar/bootstrap/bootstrap_test.cpp
+++ b/tests/Examples/cheddar/bootstrap/bootstrap_test.cpp
@@ -1,0 +1,93 @@
+// End-to-end GPU run of a real CHEDDAR bootstrap via the cheddar backend. The
+// generated module builds and prepares a BootContext from CHEDDAR's curated
+// bootparam_40_64bit parameter set, then the harness calls the generated
+// encrypt/boot/decrypt helpers and checks that bootstrapping refreshes the
+// level while preserving the message (boot(x) ~= x).
+
+#include <gtest/gtest.h>
+
+#include <algorithm>
+#include <array>
+#include <cmath>
+#include <complex>
+#include <cstdint>
+#include <cstdio>
+#include <memory>
+#include <random>
+#include <vector>
+
+#include "UserInterface.h"
+#include "core/Context.h"
+#include "core/Encode.h"
+#include "core/EvkRequest.h"
+#include "core/Parameter.h"
+#include "extension/BootContext.h"
+
+using word = uint64_t;
+using Ct = cheddar::Ciphertext<word>;
+using Evk = cheddar::EvaluationKey<word>;
+using UI = cheddar::UserInterface<word>;
+using EvkMap = cheddar::EvkMap<word>;
+
+// Generated entry points (see tests/Examples/cheddar/bootstrap/BUILD).
+void boot__configure(std::shared_ptr<cheddar::BootContext<word>>& boot_ctx,
+                     std::unique_ptr<UI>& ui);
+void boot__encrypt__arg0(cheddar::Context<word>* ctx,
+                         const cheddar::Encoder<word>& encoder, UI* ui,
+                         const Evk& evk, float a[8], UI* ui2,
+                         std::array<Ct, 1>& out);
+void boot(cheddar::BootContext<word>* ctx,
+          const cheddar::Encoder<word>& encoder, UI* ui, const Evk& evk,
+          const EvkMap& evk_map, const std::array<Ct, 1>& in,
+          std::array<Ct, 1>& out);
+void boot__decrypt__result0(cheddar::Context<word>* ctx,
+                            const cheddar::Encoder<word>& encoder, UI* ui,
+                            const Evk& evk, const std::array<Ct, 1>& in,
+                            UI* ui2, float* out);
+
+namespace {
+constexpr int kN = 8;
+}  // namespace
+
+TEST(CheddarBootstrapE2E, GpuRun) {
+  std::mt19937 gen(123);
+  std::uniform_real_distribution<double> dist(-0.5, 0.5);
+  static float input[kN];
+  for (int i = 0; i < kN; ++i) input[i] = static_cast<float>(dist(gen));
+
+  std::shared_ptr<cheddar::BootContext<word>> boot_ctx;
+  std::unique_ptr<UI> ui;
+  boot__configure(boot_ctx, ui);
+  ASSERT_NE(boot_ctx, nullptr);
+  ASSERT_NE(ui, nullptr);
+  EXPECT_EQ(boot_ctx->param_.default_encryption_level_, 13);
+  EXPECT_EQ(boot_ctx->boot_param_.GetEndLevel(), 10);
+  const EvkMap& evk_map = ui->GetEvkMap();
+  const Evk& evk = ui->GetMultiplicationKey();
+
+  std::array<Ct, 1> cin, cout;
+  boot__encrypt__arg0(boot_ctx.get(), boot_ctx->encoder_, ui.get(), evk, input,
+                      ui.get(), cin);
+  boot(boot_ctx.get(), boot_ctx->encoder_, ui.get(), evk, evk_map, cin, cout);
+  EXPECT_EQ(cin[0].GetNumSlots(), kN);
+  EXPECT_EQ(cout[0].GetNumSlots(), kN);
+  EXPECT_EQ(boot_ctx->param_.NPToLevel(cin[0].GetNP()), 0);
+  EXPECT_EQ(boot_ctx->param_.NPToLevel(cout[0].GetNP()),
+            boot_ctx->boot_param_.GetEndLevel());
+  EXPECT_EQ(boot_ctx->param_.NPToLevel(cout[0].GetNP()), 10);
+  static float result[kN];
+  boot__decrypt__result0(boot_ctx.get(), boot_ctx->encoder_, ui.get(), evk,
+                         cout, ui.get(), result);
+
+  double max_abs = 0;
+  for (int i = 0; i < kN; ++i) {
+    double error = std::abs(static_cast<double>(result[i]) - input[i]);
+    ASSERT_TRUE(std::isfinite(error)) << "non-finite result at slot " << i;
+    max_abs = std::max(max_abs, error);
+  }
+  std::printf("bootstrap: max|d|=%.6e (e.g. fhe[0]=%.6f in[0]=%.6f)\n", max_abs,
+              result[0], input[0]);
+  // Bootstrapping is approximate; expect the message preserved to CKKS boot
+  // precision (observed max|d| ~7e-7 for this param set).
+  EXPECT_LT(max_abs, 1e-4);
+}

--- a/tests/Examples/cheddar/configure_smoke/BUILD
+++ b/tests/Examples/cheddar/configure_smoke/BUILD
@@ -1,0 +1,76 @@
+load("@heir//bazel/cheddar:config.bzl", "requires_cheddar")
+load("@heir//tools:heir-opt.bzl", "heir_opt")
+load("@heir//tools:heir-translate.bzl", "heir_translate")
+load("@rules_cc//cc:cc_library.bzl", "cc_library")
+load("@rules_cc//cc:cc_test.bzl", "cc_test")
+
+package(
+    default_applicable_licenses = ["@heir//:license"],
+    default_visibility = ["//visibility:public"],
+)
+
+heir_opt(
+    name = "configure_smoke_emitc",
+    src = "configure_smoke.mlir",
+    generated_filename = "configure_smoke_emitc.mlir",
+    pass_flags = [
+        "--cheddar-configure-crypto-context=entry-function=rotate",
+        "--cheddar-to-emitc",
+    ],
+)
+
+heir_translate(
+    name = "configure_smoke_cpp_raw",
+    src = ":configure_smoke_emitc.mlir",
+    generated_filename = "configure_smoke_raw.cc",
+    pass_flags = ["--mlir-to-cpp"],
+)
+
+genrule(
+    name = "configure_smoke_lib_src",
+    srcs = [":configure_smoke_raw.cc"],
+    outs = ["configure_smoke_lib.cc"],
+    cmd = """cat > $@ <<'PRELUDE_EOF'
+// AUTO-GENERATED: do not edit. See tests/Examples/cheddar/configure_smoke/BUILD.
+#include <array>
+#include <complex>
+#include <cstddef>
+#include <cstdint>
+#include <memory>
+#include <utility>
+#include <vector>
+#include "UserInterface.h"
+#include "core/Context.h"
+#include "core/Encode.h"
+#include "core/Parameter.h"
+using namespace cheddar;
+using word = uint64_t;
+using Complex = std::complex<double>;
+PRELUDE_EOF
+cat $(location :configure_smoke_raw.cc) >> $@
+""",
+)
+
+cc_library(
+    name = "configure_smoke_lib",
+    srcs = [":configure_smoke_lib_src"],
+    target_compatible_with = requires_cheddar(),
+    deps = ["@cheddar"],
+)
+
+cc_test(
+    name = "configure_smoke_test",
+    timeout = "long",
+    srcs = ["configure_smoke_test.cpp"],
+    linkstatic = False,
+    tags = [
+        "exclusive",
+        "notap",
+    ],
+    target_compatible_with = requires_cheddar(),
+    deps = [
+        ":configure_smoke_lib",
+        "@cheddar",
+        "@googletest//:gtest_main",
+    ],
+)

--- a/tests/Examples/cheddar/configure_smoke/configure_smoke.mlir
+++ b/tests/Examples/cheddar/configure_smoke/configure_smoke.mlir
@@ -1,0 +1,16 @@
+!ciphertext = !cheddar.ciphertext
+!context = !cheddar.context
+!ui = !cheddar.user_interface
+
+module attributes {
+  ckks.schemeParam = #ckks.scheme_param<logN = 13, Q = [36028797018652673, 1125899907366913, 1125899907760129], P = [1152921504606994433], logDefaultScale = 45>,
+  scheme.actual_slot_count = 4096 : i64
+} {
+  func.func @rotate(%ctx: !context, %ui: !ui, %ct: tensor<!ciphertext>) -> tensor<!ciphertext> {
+    %d0 = tensor.empty() : tensor<!ciphertext>
+    %rot = cheddar.hrot %ctx, %ui, %ct, %d0 {level = 2 : i64, static_distance = 7 : i64} : (!context, !ui, tensor<!ciphertext>, tensor<!ciphertext>) -> tensor<!ciphertext>
+    %d1 = tensor.empty() : tensor<!ciphertext>
+    %result = cheddar.hrot_add %ctx, %ui, %rot, %ct, %d1 {distance = 2 : i64, level = 2 : i64} : (!context, !ui, tensor<!ciphertext>, tensor<!ciphertext>, tensor<!ciphertext>) -> tensor<!ciphertext>
+    return %result : tensor<!ciphertext>
+  }
+}

--- a/tests/Examples/cheddar/configure_smoke/configure_smoke_test.cpp
+++ b/tests/Examples/cheddar/configure_smoke/configure_smoke_test.cpp
@@ -1,0 +1,77 @@
+#include <gtest/gtest.h>
+
+#include <algorithm>
+#include <cmath>
+#include <complex>
+#include <cstdint>
+#include <memory>
+#include <vector>
+
+#include "UserInterface.h"
+#include "core/Context.h"
+#include "core/Encode.h"
+
+using word = uint64_t;
+using Ct = cheddar::Ciphertext<word>;
+using Pt = cheddar::Plaintext<word>;
+using UI = cheddar::UserInterface<word>;
+
+void rotate__configure(std::shared_ptr<cheddar::Context<word>>& ctx,
+                       std::unique_ptr<UI>& ui);
+void rotate(cheddar::Context<word>* ctx, UI* ui, const Ct& input, Ct& output);
+
+TEST(CheddarConfigureSmoke, GeneratedSetupAndRotationRun) {
+  std::shared_ptr<cheddar::Context<word>> ctx;
+  std::unique_ptr<UI> ui;
+  rotate__configure(ctx, ui);
+
+  ASSERT_NE(ctx, nullptr);
+  ASSERT_NE(ui, nullptr);
+  EXPECT_NO_THROW(ui->GetRotationKey(2));
+  EXPECT_NO_THROW(ui->GetRotationKey(7));
+
+  constexpr int kSlots = 4096;
+  std::vector<cheddar::Complex> message;
+  message.reserve(kSlots);
+  for (int i = 0; i < kSlots; ++i)
+    message.emplace_back(static_cast<double>((i * 17) % 101) / 101.0,
+                         static_cast<double>((i * 29) % 89) / 178.0);
+  Pt plaintext;
+  ctx->encoder_.Encode(plaintext, /*level=*/2,
+                       ctx->param_.GetScale(/*level=*/2), message);
+  Ct input;
+  ui->Encrypt(input, plaintext);
+
+  Ct output;
+  rotate(ctx.get(), ui.get(), input, output);
+
+  // Compare the emitted call sequence against the real scale-snu operations.
+  // A nonconstant complex message makes rotation direction and distance
+  // observable, unlike the previous all-ones input.
+  Ct rotated_reference;
+  ctx->HRot(rotated_reference, input, ui->GetRotationKey(7), 7);
+  Ct reference;
+  ctx->HRotAdd(reference, rotated_reference, input, ui->GetRotationKey(2), 2);
+
+  Pt decrypted;
+  ui->Decrypt(decrypted, output);
+  std::vector<cheddar::Complex> decoded;
+  ctx->encoder_.Decode(decoded, decrypted);
+  ASSERT_EQ(decoded.size(), kSlots);
+
+  Pt decrypted_reference;
+  ui->Decrypt(decrypted_reference, reference);
+  std::vector<cheddar::Complex> decoded_reference;
+  ctx->encoder_.Decode(decoded_reference, decrypted_reference);
+  ASSERT_EQ(decoded_reference.size(), kSlots);
+
+  double max_abs_error = 0.0;
+  for (int i = 0; i < kSlots; ++i) {
+    ASSERT_TRUE(std::isfinite(decoded[i].real()));
+    ASSERT_TRUE(std::isfinite(decoded[i].imag()));
+    double error = std::abs(decoded[i] - decoded_reference[i]);
+    ASSERT_TRUE(std::isfinite(error)) << "non-finite error at slot " << i;
+    max_abs_error = std::max(max_abs_error, error);
+  }
+  EXPECT_LT(max_abs_error, 1e-2);
+}

--- a/tests/Transforms/generate_param_ckks/cheddar_bootstrap.mlir
+++ b/tests/Transforms/generate_param_ckks/cheddar_bootstrap.mlir
@@ -1,0 +1,18 @@
+// RUN: heir-opt --generate-param-ckks="first-mod-bits=55 scaling-mod-bits=45 min-slot-count=8" %s | FileCheck %s
+
+// A Cheddar bootstrap extends the generated Q chain with its CtS, EvalMod,
+// and StC levels and records the split consumed by context configuration.
+
+// CHECK: module attributes {
+// CHECK-SAME: backend.cheddar
+// CHECK-SAME: cheddar.boot.num_cts = 4 : i64
+// CHECK-SAME: cheddar.boot.num_stc = 2 : i64
+// CHECK-SAME: ckks.schemeParam = #ckks.scheme_param<
+// CHECK-SAME: encryptionTechnique = extended
+// CHECK-SAME: scheme.requested_slot_count = 8 : i64
+module attributes {backend.cheddar, scheme.ckks} {
+  func.func @bootstrap(%input: f32) -> f32 {
+    %result = mgmt.bootstrap %input : f32
+    return %result : f32
+  }
+}

--- a/tools/BUILD
+++ b/tools/BUILD
@@ -53,6 +53,7 @@ cc_binary(
         "@heir//lib/Dialect/Cheddar/IR:Dialect",
         "@heir//lib/Dialect/Cheddar/Transforms",
         "@heir//lib/Dialect/Cheddar/Transforms:BufferizableOpInterfaceImpl",
+        "@heir//lib/Dialect/Cheddar/Transforms:ConfigureCryptoContext",
         "@heir//lib/Dialect/Comb/IR:Dialect",
         "@heir//lib/Dialect/Debug/IR:Dialect",
         "@heir//lib/Dialect/Debug/Transforms",

--- a/tools/heir-opt.cpp
+++ b/tools/heir-opt.cpp
@@ -21,6 +21,7 @@
 #include "lib/Dialect/CKKS/Transforms/Passes.h"
 #include "lib/Dialect/Cheddar/IR/CheddarDialect.h"
 #include "lib/Dialect/Cheddar/Transforms/BufferizableOpInterfaceImpl.h"
+#include "lib/Dialect/Cheddar/Transforms/ConfigureCryptoContext.h"
 #include "lib/Dialect/Cheddar/Transforms/Passes.h"
 #include "lib/Dialect/Comb/IR/CombDialect.h"
 #include "lib/Dialect/Debug/IR/DebugDialect.h"
@@ -392,6 +393,7 @@ int main(int argc, char** argv) {
   // Custom passes in HEIR
   registerEmitCInterfacePass();
   registerCheddarToEmitCPasses();
+  cheddar::registerCheddarConfigureCryptoContextPasses();
   cggi::registerCGGIPasses();
   debug::registerDebugPasses();
   ckks::registerCKKSPasses();


### PR DESCRIPTION
Generate CHEDDAR parameters, contexts, user interfaces, rotation keys, and bootstrap setup from scheme attributes using scale-snu APIs directly.

Compile generated setup against real CHEDDAR and exercise generated configuration in GPU smoke and bootstrap tests, including invalid bootstrap-level validation.