### PR TITLE
cheddar: add crypto context configuration

### DIFF
--- a/lib/Conversions/CheddarToEmitC/CheddarToEmitC.cpp
+++ b/lib/Conversions/CheddarToEmitC/CheddarToEmitC.cpp
@@ -1,5 +1,6 @@
 #include "lib/Conversions/CheddarToEmitC/CheddarToEmitC.h"
 
+#include <cstdint>
 #include <cstdio>
 #include <functional>
 #include <optional>
@@ -329,6 +330,26 @@ bool diagnoseUnsupportedGetters(Operation* root) {
       found = true;
     }
   });
+  root->walk([&](func::FuncOp func) {
+    unsigned parameters = 0;
+    unsigned bootstraps = 0;
+    func.walk([&](Operation* op) {
+      parameters += isa<cheddar::MakeParameterOp>(op);
+      bootstraps += isa<cheddar::PrepareBootstrapOp>(op);
+    });
+    if (parameters > 1) {
+      func.emitError(
+          "cheddar-to-emitc supports at most one "
+          "cheddar.make_parameter per function");
+      found = true;
+    }
+    if (bootstraps > 1) {
+      func.emitError(
+          "cheddar-to-emitc supports at most one "
+          "cheddar.prepare_bootstrap per function");
+      found = true;
+    }
+  });
   return found;
 }
 
@@ -367,6 +388,143 @@ struct OutParamDpsPattern : public OpConversionPattern<Op> {
 
   std::string method;
   std::function<std::string(Op)> extra;
+};
+
+template <typename Op>
+struct ConvertSetupAssign : public OpConversionPattern<Op> {
+  ConvertSetupAssign(const TypeConverter& tc, MLIRContext* ctx,
+                     StringRef rhsCallee)
+      : OpConversionPattern<Op>(tc, ctx), rhsCallee(rhsCallee.str()) {}
+
+  LogicalResult matchAndRewrite(
+      Op op, typename Op::Adaptor adaptor,
+      ConversionPatternRewriter& rewriter) const override {
+    auto operands = adaptor.getOperands();
+    VerbatimOp::create(rewriter, op.getLoc(), "{} = " + rhsCallee + "({});",
+                       ValueRange{operands[1], operands[0]});
+    rewriter.eraseOp(op);
+    return success();
+  }
+
+  std::string rhsCallee;
+};
+
+struct ConvertMakeParameter
+    : public OpConversionPattern<cheddar::MakeParameterOp> {
+  using OpConversionPattern::OpConversionPattern;
+  LogicalResult matchAndRewrite(
+      cheddar::MakeParameterOp op, OpAdaptor /*adaptor*/,
+      ConversionPatternRewriter& rewriter) const override {
+    Type resultType = typeConverter->convertType(op.getResult().getType());
+    ArrayRef<int64_t> mainPrimes = op.getMainPrimes();
+    int64_t defaultLevel = op.getDefaultEncryptionLevel()
+                               ? op.getDefaultEncryptionLevelAttr().getInt()
+                               : static_cast<int64_t>(mainPrimes.size()) - 1;
+
+    std::string levels = "std::vector<std::pair<int, int>>{";
+    for (size_t i = 0; i < mainPrimes.size(); ++i) {
+      if (i) levels += ", ";
+      levels += "{" + std::to_string(i + 1) + ", 0}";
+    }
+    levels += "}";
+    auto primes = [](ArrayRef<int64_t> values) {
+      std::string result = "std::vector<word>{";
+      for (size_t i = 0; i < values.size(); ++i) {
+        if (i) result += ", ";
+        result += std::to_string(static_cast<uint64_t>(values[i])) + "ULL";
+      }
+      return result + "}";
+    };
+    std::string scale = "static_cast<double>(static_cast<word>(1) << " +
+                        std::to_string(op.getLogScale().getInt()) + ")";
+    std::string args = std::to_string(op.getLogN().getInt()) + ", " + scale +
+                       ", " + std::to_string(defaultLevel) + ", " + levels +
+                       ", " + primes(mainPrimes) + ", " +
+                       primes(op.getAuxPrimes());
+
+    StringRef name = "cheddar_param";
+    VerbatimOp::create(
+        rewriter, op.getLoc(),
+        ("static Parameter<word> " + name + "(" + args + ");").str(),
+        ValueRange{});
+    if (auto weight = op.getDenseHammingWeightAttr())
+      VerbatimOp::create(
+          rewriter, op.getLoc(),
+          (name + ".SetDenseHammingWeight(" + intLit(weight) + ");").str(),
+          ValueRange{});
+    if (auto weight = op.getSparseHammingWeightAttr())
+      VerbatimOp::create(
+          rewriter, op.getLoc(),
+          (name + ".SetSparseHammingWeight(" + intLit(weight) + ");").str(),
+          ValueRange{});
+    auto literal =
+        emitc::LiteralOp::create(rewriter, op.getLoc(), resultType, name);
+    rewriter.replaceOp(op, literal.getResult());
+    return success();
+  }
+};
+
+struct ConvertPrepareRotKey
+    : public OpConversionPattern<cheddar::PrepareRotKeyOp> {
+  using OpConversionPattern::OpConversionPattern;
+  LogicalResult matchAndRewrite(
+      cheddar::PrepareRotKeyOp op, OpAdaptor adaptor,
+      ConversionPatternRewriter& rewriter) const override {
+    VerbatimOp::create(rewriter, op.getLoc(),
+                       "{}->PrepareRotationKey(" +
+                           intLit(op.getDistanceAttr()) + ", " +
+                           intLit(op.getMaxLevelAttr()) + ");",
+                       ValueRange{adaptor.getUi()});
+    rewriter.eraseOp(op);
+    return success();
+  }
+};
+
+struct ConvertCreateBootContext
+    : public OpConversionPattern<cheddar::CreateBootContextOp> {
+  using OpConversionPattern::OpConversionPattern;
+  LogicalResult matchAndRewrite(
+      cheddar::CreateBootContextOp op, OpAdaptor adaptor,
+      ConversionPatternRewriter& rewriter) const override {
+    std::string ratio;
+    if (auto attr = op.getLogMessageRatioAttr()) ratio = ", " + intLit(attr);
+    VerbatimOp::create(
+        rewriter, op.getLoc(),
+        "{} = BootContext<word>::Create({}, BootParameter({}.max_level_, " +
+            std::to_string(op.getNumCtsLevels().getInt()) + ", " +
+            std::to_string(op.getNumStcLevels().getInt()) + ratio + "));",
+        ValueRange{adaptor.getOutput(), adaptor.getParams(),
+                   adaptor.getParams()});
+    rewriter.eraseOp(op);
+    return success();
+  }
+};
+
+struct ConvertPrepareBootstrap
+    : public OpConversionPattern<cheddar::PrepareBootstrapOp> {
+  using OpConversionPattern::OpConversionPattern;
+  LogicalResult matchAndRewrite(
+      cheddar::PrepareBootstrapOp op, OpAdaptor adaptor,
+      ConversionPatternRewriter& rewriter) const override {
+    std::string slots = std::to_string(op.getNumSlots().getInt());
+    Value context = adaptor.getCtx();
+    VerbatimOp::create(rewriter, op.getLoc(), "{}->PrepareEvalMod();",
+                       ValueRange{context});
+    VerbatimOp::create(rewriter, op.getLoc(),
+                       "{}->PrepareEvalSpecialFFT(" + slots +
+                           ", cheddar::BootVariant::kImaginaryRemoving);",
+                       ValueRange{context});
+    VerbatimOp::create(rewriter, op.getLoc(), "EvkRequest boot_evk_req;",
+                       ValueRange{});
+    VerbatimOp::create(rewriter, op.getLoc(),
+                       "{}->AddRequiredRotations(boot_evk_req, " + slots + ");",
+                       ValueRange{context});
+    VerbatimOp::create(rewriter, op.getLoc(),
+                       "{}->PrepareRotationKey(boot_evk_req);",
+                       ValueRange{adaptor.getUi()});
+    rewriter.eraseOp(op);
+    return success();
+  }
 };
 
 // cheddar.encode: fill a std::vector<Complex> from the float message buffer,
@@ -1362,9 +1520,15 @@ struct CheddarToEmitCDialectInterface : public ConvertToEmitCPatternInterface {
     patterns.add<ConvertCiphertextCopy>(typeConverter, ctx, /*benefit=*/3);
 
     patterns
-        .add<ConvertEncode, ConvertEncodeConstant, ConvertDecode, ConvertHRot,
-             ConvertHRotAdd, ConvertHConj, ConvertHConjAdd, ConvertEvalPoly>(
-            typeConverter, ctx);
+        .add<ConvertMakeParameter, ConvertPrepareRotKey,
+             ConvertCreateBootContext, ConvertPrepareBootstrap, ConvertEncode,
+             ConvertEncodeConstant, ConvertDecode, ConvertHRot, ConvertHRotAdd,
+             ConvertHConj, ConvertHConjAdd, ConvertEvalPoly>(typeConverter,
+                                                             ctx);
+    patterns.add<ConvertSetupAssign<cheddar::CreateContextOp>>(
+        typeConverter, ctx, "Context<word>::Create");
+    patterns.add<ConvertSetupAssign<cheddar::CreateUserInterfaceOp>>(
+        typeConverter, ctx, "std::make_unique<UserInterface<word>>");
 
     auto addDps = [&](StringRef name, auto opTag,
                       std::function<std::string(decltype(opTag))> extra =

--- a/lib/Dialect/Cheddar/Transforms/BUILD
+++ b/lib/Dialect/Cheddar/Transforms/BUILD
@@ -50,6 +50,33 @@ cc_library(
     ],
 )
 
+cc_library(
+    name = "ConfigureCryptoContext",
+    srcs = ["ConfigureCryptoContext.cpp"],
+    hdrs = ["ConfigureCryptoContext.h"],
+    deps = [
+        ":configure_crypto_context_inc_gen",
+        "@heir//lib/Analysis/RotationAnalysis",
+        "@heir//lib/Dialect:ModuleAttributes",
+        "@heir//lib/Dialect/CKKS/IR:Dialect",
+        "@heir//lib/Dialect/Cheddar/IR:Dialect",
+        "@heir//lib/Utils:TransformUtils",
+        "@llvm-project//llvm:Support",
+        "@llvm-project//mlir:FuncDialect",
+        "@llvm-project//mlir:IR",
+        "@llvm-project//mlir:Pass",
+        "@llvm-project//mlir:TensorDialect",
+        "@llvm-project//mlir:Transforms",
+    ],
+)
+
+add_heir_transforms(
+    generated_target_name = "configure_crypto_context_inc_gen",
+    header_filename = "ConfigureCryptoContext.h.inc",
+    pass_name = "CheddarConfigureCryptoContext",
+    td_file = "ConfigureCryptoContext.td",
+)
+
 add_heir_transforms(
     header_filename = "Passes.h.inc",
     pass_name = "Cheddar",

--- a/lib/Dialect/Cheddar/Transforms/ConfigureCryptoContext.cpp
+++ b/lib/Dialect/Cheddar/Transforms/ConfigureCryptoContext.cpp
@@ -1,0 +1,278 @@
+#include "lib/Dialect/Cheddar/Transforms/ConfigureCryptoContext.h"
+
+#include <algorithm>
+#include <string>
+
+#include "lib/Analysis/RotationAnalysis/RotationAnalysis.h"
+#include "lib/Dialect/CKKS/IR/CKKSAttributes.h"
+#include "lib/Dialect/CKKS/IR/CKKSDialect.h"
+#include "lib/Dialect/Cheddar/IR/CheddarOps.h"
+#include "lib/Dialect/Cheddar/IR/CheddarTypes.h"
+#include "lib/Dialect/ModuleAttributes.h"
+#include "lib/Utils/TransformUtils.h"
+#include "llvm/include/llvm/ADT/SmallVector.h"           // from @llvm-project
+#include "mlir/include/mlir/Dialect/Func/IR/FuncOps.h"   // from @llvm-project
+#include "mlir/include/mlir/Dialect/Tensor/IR/Tensor.h"  // from @llvm-project
+#include "mlir/include/mlir/IR/Builders.h"               // from @llvm-project
+#include "mlir/include/mlir/IR/BuiltinAttributes.h"      // from @llvm-project
+#include "mlir/include/mlir/IR/BuiltinOps.h"             // from @llvm-project
+#include "mlir/include/mlir/IR/BuiltinTypes.h"           // from @llvm-project
+#include "mlir/include/mlir/Pass/PassManager.h"          // from @llvm-project
+#include "mlir/include/mlir/Transforms/Passes.h"         // from @llvm-project
+
+namespace mlir::heir::cheddar {
+
+#define GEN_PASS_DEF_CHEDDARCONFIGURECRYPTOCONTEXT
+#include "lib/Dialect/Cheddar/Transforms/ConfigureCryptoContext.h.inc"
+
+namespace {
+
+// scale-snu CHEDDAR's pinned BootParameter consumes eight levels in EvalMod:
+// ceil(log2(31 minimax coefficients)) + three double-angle steps. Its
+// BootContext requires Parameter::default_encryption_level_ to equal the
+// resulting SlotToCoeff start level.
+constexpr int64_t kBootstrapEvalModLevels = 8;
+
+// Build a `<entry>__configure() -> (context, user_interface)` function in
+// destination-passing tensor form:
+//   %p   = cheddar.make_parameter ...
+//   %ctx = cheddar.create_context %p, %ctx_init
+//   %ui0 = cheddar.create_user_interface %ctx, %ui_init
+//   %ui1 = cheddar.prepare_rot_key %ui0 {distance, maxLevel}   // per distance
+//   return %ctx, %uiN
+// Params come from the CKKS scheme attrs (logN/scale/Q/P); the rotation
+// distances come from the shared RotationAnalysis (the same way the lattigo and
+// openfhe backends discover which keys to generate). The two tensor results
+// become owning context/user_interface out-params during Cheddar
+// bufferization, and the cheddar-to-emitc boundary re-types them to owning
+// smart-pointer references.
+// When the program bootstraps, the generated configure builds a BootContext
+// (and runs the one-time bootstrap precompute + rotation-key request) instead
+// of a plain Context: the entry then takes a `!cheddar.boot_context`.
+// `numSlots` is the slot count the (full-slot) bootstrap refreshes;
+// `numCtsLevels` / `numStcLevels` are the CtS/StC level budgets (a
+// depth/rotations trade-off, cf. OpenFHE's level-budget-encode/decode),
+// threaded in as pass options.
+void buildConfigureFunc(ModuleOp moduleOp, func::FuncOp entry, int64_t logN,
+                        int64_t logScale, DenseI64ArrayAttr Q,
+                        DenseI64ArrayAttr P, ArrayRef<int64_t> rotationIndices,
+                        bool bootstraps, int64_t numSlots, int64_t numCtsLevels,
+                        int64_t numStcLevels, int64_t defaultEncLevel,
+                        int64_t denseHammingWeight, int64_t sparseHammingWeight,
+                        int64_t logMessageRatio) {
+  MLIRContext* ctx = moduleOp.getContext();
+  int64_t maxLevel = Q.size() - 1;
+  int64_t rotationKeyLevel = bootstraps ? defaultEncLevel : maxLevel;
+  // EvalMod message headroom passed to CHEDDAR's BootParameter. This is the
+  // reserved bits for the MESSAGE magnitude (~log2(max|m|)+margin), NOT a
+  // function of the modulus chain: CHEDDAR scales the level-0 message UP by
+  // (log2(q0/scale) - log_message_ratio) bits before EvalMod, so the message
+  // fills the accurate part of the fixed sine (sin 2*pi*x) minimax. Too LARGE a
+  // ratio under-scales the message into the inaccurate low end of the sine ->
+  // the bootstrap stops being identity and silently corrupts its output (which
+  // then detonates a downstream Chebyshev eval). The old
+  // firstModBits-logScale-2 formula tied the headroom to the chain and gave ~13
+  // (log_scaleup_ ~= 2, a 256x under-scale). For the normalized activations
+  // these models bootstrap
+  // (|m| ~ O(1), the sign/ReLU inputs), CHEDDAR's default headroom of 5 is the
+  // right magnitude (log_scaleup_ ~= 10). Override via the `log-message-ratio`
+  // option for a model with a larger message bound.
+  int64_t effLogMessageRatio = logMessageRatio;
+  if (bootstraps && effLogMessageRatio < 0) {
+    effLogMessageRatio = 5;
+  }
+
+  OpBuilder builder(ctx);
+  builder.setInsertionPointToEnd(moduleOp.getBody());
+  Location loc = entry.getLoc();
+
+  // Bootstrapping programs hand back an owning BootContext; others a Context.
+  Type ctxElt = bootstraps ? Type(BootContextType::get(ctx))
+                           : Type(ContextType::get(ctx));
+  auto ctxTensor = RankedTensorType::get({}, ctxElt);
+  auto uiTensor = RankedTensorType::get({}, UserInterfaceType::get(ctx));
+  auto funcType = FunctionType::get(ctx, {}, {ctxTensor, uiTensor});
+  // Discovered by name convention (`<entry>__configure`), like the lattigo
+  // backend -- no marker attribute needed.
+  std::string name = (entry.getSymName() + "__configure").str();
+  auto configFunc = func::FuncOp::create(builder, loc, name, funcType);
+  configFunc.setPublic();
+
+  Block* bodyBlock = configFunc.addEntryBlock();
+  builder.setInsertionPointToStart(bodyBlock);
+
+  auto i64 = [&](int64_t v) { return builder.getI64IntegerAttr(v); };
+  // Bootstrapping pins default_encryption_level below the chain top and sets
+  // the secret-key hamming weights; non-boot leaves these null (emitter
+  // defaults).
+  IntegerAttr defaultEncAttr =
+      bootstraps ? i64(defaultEncLevel) : IntegerAttr();
+  IntegerAttr denseHwAttr =
+      bootstraps ? i64(denseHammingWeight) : IntegerAttr();
+  IntegerAttr sparseHwAttr =
+      bootstraps ? i64(sparseHammingWeight) : IntegerAttr();
+  Value params =
+      MakeParameterOp::create(builder, loc, ParameterType::get(ctx), i64(logN),
+                              i64(logScale), Q, P, defaultEncAttr, denseHwAttr,
+                              sparseHwAttr)
+          .getParams();
+  // Shape-only DPS destinations. Cheddar bufferization connects these to the
+  // caller-provided result destinations before One-Shot Bufferize.
+  Value ctxInit = tensor::EmptyOp::create(builder, loc, ctxTensor.getShape(),
+                                          ctxTensor.getElementType());
+  Value context =
+      bootstraps
+          ? CreateBootContextOp::create(
+                builder, loc, TypeRange{ctxTensor}, params, i64(numCtsLevels),
+                i64(numStcLevels), i64(effLogMessageRatio), ctxInit)
+                ->getResult(0)
+          : CreateContextOp::create(builder, loc, TypeRange{ctxTensor},
+                                    ValueRange{params, ctxInit})
+                ->getResult(0);
+  Value uiInit = tensor::EmptyOp::create(builder, loc, uiTensor.getShape(),
+                                         uiTensor.getElementType());
+  Value ui = CreateUserInterfaceOp::create(builder, loc, TypeRange{uiTensor},
+                                           ValueRange{context, uiInit})
+                 ->getResult(0);
+  for (int64_t d : rotationIndices)
+    ui = PrepareRotKeyOp::create(builder, loc, TypeRange{uiTensor}, ui, i64(d),
+                                 i64(rotationKeyLevel))
+             ->getResult(0);
+  if (bootstraps) {
+    auto prepare =
+        PrepareBootstrapOp::create(builder, loc, TypeRange{ctxTensor, uiTensor},
+                                   context, ui, i64(numSlots));
+    context = prepare->getResult(0);
+    ui = prepare->getResult(1);
+  }
+  func::ReturnOp::create(builder, loc, ValueRange{context, ui});
+}
+
+}  // namespace
+
+struct CheddarConfigureCryptoContext
+    : public impl::CheddarConfigureCryptoContextBase<
+          CheddarConfigureCryptoContext> {
+  using CheddarConfigureCryptoContextBase::CheddarConfigureCryptoContextBase;
+
+  void runOnOperation() override {
+    auto moduleOp = cast<ModuleOp>(getOperation());
+    MLIRContext* ctx = &getContext();
+
+    // RotationAnalysis requires -sccp to have propagated constants so the
+    // rotation indices are statically detectable (mirrors the lattigo/openfhe
+    // configure passes).
+    OpPassManager pipeline("builtin.module");
+    pipeline.addPass(createSCCPPass());
+    pipeline.addPass(createCanonicalizerPass());
+    if (failed(runPipeline(pipeline, moduleOp))) {
+      signalPassFailure();
+      return;
+    }
+
+    auto schemeParamAttr = moduleOp->getAttrOfType<ckks::SchemeParamAttr>(
+        ckks::CKKSDialect::kSchemeParamAttrName);
+    if (!schemeParamAttr) return;
+
+    DenseI64ArrayAttr Q = schemeParamAttr.getQ();
+    DenseI64ArrayAttr P = schemeParamAttr.getP();
+    if (!Q || Q.size() == 0 || !P || P.size() == 0) {
+      moduleOp.emitError(
+          "CHEDDAR context configuration requires non-empty CKKS Q and P "
+          "modulus chains");
+      signalPassFailure();
+      return;
+    }
+
+    auto entry = detectEntryFunction(moduleOp, entryFunction);
+    if (!entry) {
+      signalPassFailure();
+      return;
+    }
+    std::string configureName = (entry.getSymName() + "__configure").str();
+    if (moduleOp.lookupSymbol<func::FuncOp>(configureName)) {
+      entry.emitOpError() << "configuration function @" << configureName
+                          << " already exists";
+      signalPassFailure();
+      return;
+    }
+
+    RotationAnalysis rotationAnalysis;
+    if (failed(rotationAnalysis.run(moduleOp))) {
+      entry.emitOpError("failed to compute static rotation indices");
+      signalPassFailure();
+      return;
+    }
+    const auto& indexSet = rotationAnalysis.getRotationIndices();
+    SmallVector<int64_t> rotationIndices(indexSet.begin(), indexSet.end());
+    llvm::sort(rotationIndices);
+
+    bool bootstraps = false;
+    moduleOp.walk([&](BootOp) { bootstraps = true; });
+    int64_t numSlots = 0;
+    if (bootstraps) {
+      auto slotsAttr =
+          moduleOp->getAttrOfType<IntegerAttr>(kActualSlotCountAttrName);
+      if (!slotsAttr) {
+        entry.emitOpError(
+            "bootstrapping program is missing the scheme.actual_slot_count "
+            "module attribute needed to configure the boot context");
+        signalPassFailure();
+        return;
+      }
+      numSlots = slotsAttr.getInt();
+    }
+
+    int64_t logN = schemeParamAttr.getLogN();
+    int64_t logDefaultScale = schemeParamAttr.getLogDefaultScale();
+    int64_t bootNumCts = numCtsLevels;
+    int64_t bootNumStc = numStcLevels;
+    int64_t defaultEncLevel = static_cast<int64_t>(Q.size()) - 1;
+    int64_t denseHammingWeight = 0;
+    int64_t sparseHammingWeight = 0;
+    if (bootstraps) {
+      if (auto attr =
+              moduleOp->getAttrOfType<IntegerAttr>("cheddar.boot.num_cts"))
+        bootNumCts = attr.getInt();
+      if (auto attr =
+              moduleOp->getAttrOfType<IntegerAttr>("cheddar.boot.num_stc"))
+        bootNumStc = attr.getInt();
+      if (bootNumCts < 0 || bootNumStc < 0) {
+        entry.emitOpError(
+            "CHEDDAR bootstrap CtS and StC level counts must be non-negative");
+        signalPassFailure();
+        return;
+      }
+      defaultEncLevel -= bootNumCts + kBootstrapEvalModLevels;
+      int64_t bootstrapEndLevel = defaultEncLevel - bootNumStc;
+      if (defaultEncLevel < 0 || bootstrapEndLevel < 0) {
+        entry.emitOpError()
+            << "CHEDDAR bootstrap modulus chain is too short: " << Q.size()
+            << " Q primes cannot cover " << bootNumCts << " CtS + "
+            << kBootstrapEvalModLevels << " EvalMod + " << bootNumStc
+            << " StC levels";
+        signalPassFailure();
+        return;
+      }
+      denseHammingWeight = int64_t{1} << (logN - 1);
+      sparseHammingWeight = 32;
+    }
+
+    moduleOp->setAttr("cheddar.logN",
+                      IntegerAttr::get(IntegerType::get(ctx, 64), logN));
+    moduleOp->setAttr(
+        "cheddar.logDefaultScale",
+        IntegerAttr::get(IntegerType::get(ctx, 64), logDefaultScale));
+    moduleOp->setAttr("cheddar.Q", Q);
+    moduleOp->setAttr("cheddar.P", P);
+    buildConfigureFunc(moduleOp, entry, logN, logDefaultScale, Q, P,
+                       rotationIndices, bootstraps, numSlots, bootNumCts,
+                       bootNumStc, defaultEncLevel, denseHammingWeight,
+                       sparseHammingWeight, logMessageRatio);
+
+    moduleOp->removeAttr(ckks::CKKSDialect::kSchemeParamAttrName);
+    moduleOp->removeAttr("scheme.ckks");
+  }
+};
+
+}  // namespace mlir::heir::cheddar

--- a/lib/Dialect/Cheddar/Transforms/ConfigureCryptoContext.h
+++ b/lib/Dialect/Cheddar/Transforms/ConfigureCryptoContext.h
@@ -1,0 +1,16 @@
+#ifndef LIB_DIALECT_CHEDDAR_TRANSFORMS_CONFIGURECRYPTOCONTEXT_H_
+#define LIB_DIALECT_CHEDDAR_TRANSFORMS_CONFIGURECRYPTOCONTEXT_H_
+
+#include "mlir/include/mlir/Pass/Pass.h"  // from @llvm-project
+
+namespace mlir::heir::cheddar {
+
+#define GEN_PASS_DECL
+#include "lib/Dialect/Cheddar/Transforms/ConfigureCryptoContext.h.inc"
+
+#define GEN_PASS_REGISTRATION
+#include "lib/Dialect/Cheddar/Transforms/ConfigureCryptoContext.h.inc"
+
+}  // namespace mlir::heir::cheddar
+
+#endif  // LIB_DIALECT_CHEDDAR_TRANSFORMS_CONFIGURECRYPTOCONTEXT_H_

--- a/lib/Dialect/Cheddar/Transforms/ConfigureCryptoContext.td
+++ b/lib/Dialect/Cheddar/Transforms/ConfigureCryptoContext.td
@@ -1,0 +1,41 @@
+#ifndef LIB_DIALECT_CHEDDAR_TRANSFORMS_CONFIGURECRYPTOCONTEXT_TD_
+#define LIB_DIALECT_CHEDDAR_TRANSFORMS_CONFIGURECRYPTOCONTEXT_TD_
+
+include "mlir/Pass/PassBase.td"
+
+def CheddarConfigureCryptoContext : Pass<"cheddar-configure-crypto-context"> {
+  let summary = "Configure CHEDDAR crypto context from scheme parameters.";
+
+  let description = [{
+    This pass reads the `ckks.schemeParam` module attribute and re-exposes the
+    CHEDDAR-relevant parameters (`cheddar.logN`, `cheddar.logDefaultScale`,
+    `cheddar.Q`, `cheddar.P`) as module attributes, then removes the CKKS
+    module attributes.
+
+    It also generates a `<entry>__configure` function that builds the CHEDDAR
+    `Parameter` from the modulus chain, creates the `Context` and
+    `UserInterface`, and prepares a rotation key for every distinct rotation
+    distance used by the program (`cheddar.hrot` / `cheddar.hrot_add`). The
+    context and user_interface are handed back to the caller through owning
+    out-params (`std::shared_ptr<Context<word>>&` /
+    `std::unique_ptr<UserInterface<word>>&`), matching the lattigo backend's
+    `__configure` convention.
+
+    After this pass, the module no longer depends on the CKKS dialect.
+  }];
+
+  let options = [
+    Option<"entryFunction", "entry-function", "std::string", "", "Entry function to configure (auto-detected if empty)">,
+    Option<"numCtsLevels", "num-cts-levels", "int", /*default=*/"3", "Bootstrap CoeffToSlot (CtS) level budget (cf. OpenFHE level-budget-encode); only used when the program bootstraps">,
+    Option<"numStcLevels", "num-stc-levels", "int", /*default=*/"3", "Bootstrap SlotToCoeff (StC) level budget (cf. OpenFHE level-budget-decode); only used when the program bootstraps">,
+    Option<"logMessageRatio", "log-message-ratio", "int", /*default=*/"-1", "Bootstrap message headroom passed to CHEDDAR's BootParameter (governs EvalMod precision). -1 uses CHEDDAR's default headroom of 5; only used when the program bootstraps">,
+  ];
+
+  let dependentDialects = [
+    "mlir::heir::cheddar::CheddarDialect",
+    "mlir::func::FuncDialect",
+    "mlir::tensor::TensorDialect",
+  ];
+}
+
+#endif  // LIB_DIALECT_CHEDDAR_TRANSFORMS_CONFIGURECRYPTOCONTEXT_TD_

--- a/tests/Conversions/CheddarToEmitC/cheddar_to_emitc.mlir
+++ b/tests/Conversions/CheddarToEmitC/cheddar_to_emitc.mlir
@@ -19,6 +19,25 @@
 !parameter = !cheddar.parameter
 !boot_context = !cheddar.boot_context
 
+// CHECK: func.func @configure
+// CHECK-SAME: !emitc.opaque<"std::shared_ptr<Context<word>>&">
+// CHECK-SAME: !emitc.opaque<"std::unique_ptr<UserInterface<word>>&">
+// CHECK: emitc.verbatim "static Parameter<word> cheddar_param
+// CHECK-SAME: std::vector<word>{1ULL, 2ULL, 3ULL}
+// CHECK-SAME: std::vector<word>{4ULL, 5ULL}
+// CHECK: emitc.verbatim "{} = Context<word>::Create({});"
+// CHECK: emitc.verbatim "{} = std::make_unique<UserInterface<word>>({});"
+// CHECK: emitc.verbatim "{}->PrepareRotationKey(3, 2);"
+func.func @configure() -> (tensor<!context>, tensor<!user_interface>) {
+  %p = cheddar.make_parameter {logN = 14 : i64, logScale = 45 : i64, mainPrimes = array<i64: 1, 2, 3>, auxPrimes = array<i64: 4, 5>} : !parameter
+  %context_dest = tensor.empty() : tensor<!context>
+  %context = cheddar.create_context %p, %context_dest : (!parameter, tensor<!context>) -> tensor<!context>
+  %ui_dest = tensor.empty() : tensor<!user_interface>
+  %ui = cheddar.create_user_interface %context, %ui_dest : (tensor<!context>, tensor<!user_interface>) -> tensor<!user_interface>
+  %prepared = cheddar.prepare_rot_key %ui {distance = 3 : i64, maxLevel = 2 : i64} : (tensor<!user_interface>) -> tensor<!user_interface>
+  return %context, %prepared : tensor<!context>, tensor<!user_interface>
+}
+
 // A two-op chain: each op is `ctx->Method(out, a, b)`. The first op's result is
 // an intermediate local (`emitc.variable`); the second writes the function
 // out-param. Inputs are `const Ciphertext<word>&`, the out-param is mutable.

--- a/tests/Conversions/CheddarToEmitC/compile/BUILD
+++ b/tests/Conversions/CheddarToEmitC/compile/BUILD
@@ -122,3 +122,67 @@ build_test(
     target_compatible_with = requires_cheddar(),
     targets = [":kernels_real_compiled"],
 )
+
+heir_opt(
+    name = "setup_emitc",
+    src = "setup.mlir",
+    generated_filename = "setup_emitc.mlir",
+    pass_flags = [
+        "--cheddar-configure-crypto-context=entry-function=kernel",
+        "--cheddar-bufferize",
+        "--fold-memref-alias-ops",
+        "--cse",
+        "--canonicalize",
+        "--drop-equivalent-buffer-results",
+        "--canonicalize",
+        "--convert-to-emitc=filter-dialects=cheddar,arith,scf",
+        "--cheddar-emitc-boundary",
+        "--reconcile-unrealized-casts",
+    ],
+)
+
+heir_translate(
+    name = "setup_cpp_raw",
+    src = ":setup_emitc.mlir",
+    generated_filename = "setup_raw.cc",
+    pass_flags = ["--mlir-to-cpp"],
+)
+
+genrule(
+    name = "setup_real_lib_src",
+    srcs = [":setup_raw.cc"],
+    outs = ["setup_real_lib.cc"],
+    cmd = """cat > $@ <<'PRELUDE_EOF'
+// AUTO-GENERATED: do not edit. See tests/Conversions/CheddarToEmitC/compile/BUILD.
+#include <array>
+#include <complex>
+#include <cstdint>
+#include <initializer_list>
+#include <memory>
+#include <utility>
+#include <vector>
+#include "UserInterface.h"
+#include "core/Context.h"
+#include "core/Encode.h"
+#include "core/Parameter.h"
+#include "extension/BootContext.h"
+#include "extension/EvalPoly.h"
+using namespace cheddar;
+using word = uint64_t;
+PRELUDE_EOF
+cat $(location :setup_raw.cc) >> $@
+""",
+)
+
+cc_library(
+    name = "setup_real_compiled",
+    srcs = [":setup_real_lib_src"],
+    target_compatible_with = requires_cheddar(),
+    deps = ["@cheddar"],
+)
+
+build_test(
+    name = "real_setup_compile_test",
+    target_compatible_with = requires_cheddar(),
+    targets = [":setup_real_compiled"],
+)

--- a/tests/Conversions/CheddarToEmitC/compile/cheddar_stub.h
+++ b/tests/Conversions/CheddarToEmitC/compile/cheddar_stub.h
@@ -15,10 +15,8 @@
 //     non-const reference.                              (core/Context.h:377)
 //   * UserInterface::Get*Key() / GetEvkMap() return `const&`. (UserInterface.h)
 //
-// Kept deliberately narrow: the "setup/getter" surface (create_context,
-// create_user_interface, get_encoder, encode/decode) is *not* modelled here
-// because that part of the emitter has independent, pre-existing mismatches
-// against the real API and needs its own design pass.
+// Kept deliberately narrow: setup is covered by conversion and opt-in real
+// CHEDDAR compile tests. Getter ops remain unsupported by this lowering.
 
 #ifndef TESTS_CONVERSIONS_CHEDDARTOEMITC_COMPILE_CHEDDAR_STUB_H_
 #define TESTS_CONVERSIONS_CHEDDARTOEMITC_COMPILE_CHEDDAR_STUB_H_

--- a/tests/Conversions/CheddarToEmitC/compile/setup.mlir
+++ b/tests/Conversions/CheddarToEmitC/compile/setup.mlir
@@ -1,0 +1,16 @@
+!boot_context = !cheddar.boot_context
+!ciphertext = !cheddar.ciphertext
+!evk_map = !cheddar.evk_map
+
+module attributes {
+  cheddar.boot.num_cts = 4 : i64,
+  cheddar.boot.num_stc = 3 : i64,
+  ckks.schemeParam = #ckks.scheme_param<logN = 16, Q = [1125899908022273, 1099515691009, 1099523555329, 1099525128193, 1099526176769, 1099529060353, 1099535220737, 1099536138241, 1099537580033, 1099538104321, 1099540725761, 1099540856833, 1099543085057, 36028797019488257, 36028797023420417, 36028797024206849, 36028797025124353, 36028797032202241, 36028797033644033, 36028797037576193, 36028797048324097, 36028797048586241, 36028797049896961, 36028797051863041, 36028797053698049, 36028797054222337], P = [72057594038321153, 72057594040680449, 72057594042646529, 72057594047889409, 72057594057195521, 72057594058375169, 72057594058899457], logDefaultScale = 40>,
+  scheme.actual_slot_count = 1024 : i64
+} {
+  func.func @kernel(%ctx: !boot_context, %ct: tensor<!ciphertext>, %evk: !evk_map) -> tensor<!ciphertext> {
+    %dest = tensor.empty() : tensor<!ciphertext>
+    %result = cheddar.boot %ctx, %ct, %evk, %dest : (!boot_context, tensor<!ciphertext>, !evk_map, tensor<!ciphertext>) -> tensor<!ciphertext>
+    return %result : tensor<!ciphertext>
+  }
+}

--- a/tests/Conversions/CheddarToEmitC/unsupported_getters.mlir
+++ b/tests/Conversions/CheddarToEmitC/unsupported_getters.mlir
@@ -28,3 +28,14 @@ func.func @get_encoder(%ctx: !cheddar.context) -> !cheddar.encoder {
   %e = cheddar.get_encoder %ctx : (!cheddar.context) -> !cheddar.encoder
   return %e : !cheddar.encoder
 }
+
+// -----
+
+// The lowering uses one function-local static Parameter so the Context can
+// safely retain its reference after the configure function returns.
+// expected-error @below {{cheddar-to-emitc supports at most one cheddar.make_parameter per function}}
+func.func @duplicate_parameter() {
+  %p0 = cheddar.make_parameter {logN = 14 : i64, logScale = 45 : i64, mainPrimes = array<i64: 1, 2>, auxPrimes = array<i64: 3>} : !cheddar.parameter
+  %p1 = cheddar.make_parameter {logN = 14 : i64, logScale = 45 : i64, mainPrimes = array<i64: 1, 2>, auxPrimes = array<i64: 3>} : !cheddar.parameter
+  return
+}

--- a/tests/Dialect/Cheddar/Transforms/configure_crypto_context.mlir
+++ b/tests/Dialect/Cheddar/Transforms/configure_crypto_context.mlir
@@ -1,0 +1,32 @@
+// RUN: heir-opt --cheddar-configure-crypto-context=entry-function=main %s | FileCheck %s
+
+!ciphertext = !cheddar.ciphertext
+!context = !cheddar.context
+!ui = !cheddar.user_interface
+
+module attributes {ckks.schemeParam = #ckks.scheme_param<logN = 13, Q = [36028797018652673, 1125899907366913, 1125899907760129], P = [1152921504606994433], logDefaultScale = 45>} {
+  func.func @main(%ctx: !context, %ui: !ui, %ct: tensor<!ciphertext>) -> tensor<!ciphertext> {
+    %d0 = bufferization.alloc_tensor() : tensor<!ciphertext>
+    %rot = cheddar.hrot %ctx, %ui, %ct, %d0 {static_distance = 7 : i64} : (!context, !ui, tensor<!ciphertext>, tensor<!ciphertext>) -> tensor<!ciphertext>
+    %d1 = bufferization.alloc_tensor() : tensor<!ciphertext>
+    %result = cheddar.hrot_add %ctx, %ui, %rot, %ct, %d1 {distance = 2 : i64} : (!context, !ui, tensor<!ciphertext>, tensor<!ciphertext>, tensor<!ciphertext>) -> tensor<!ciphertext>
+    return %result : tensor<!ciphertext>
+  }
+}
+
+// CHECK: module attributes
+// CHECK-SAME: cheddar.P = array<i64: 1152921504606994433>
+// CHECK-SAME: cheddar.Q = array<i64: 36028797018652673, 1125899907366913, 1125899907760129>
+// CHECK-SAME: cheddar.logDefaultScale = 45 : i64
+// CHECK-SAME: cheddar.logN = 13 : i64
+// CHECK-NOT: ckks.schemeParam
+// CHECK: func.func @main__configure
+// CHECK: cheddar.make_parameter
+// CHECK: cheddar.create_context
+// CHECK: cheddar.create_user_interface
+// CHECK: cheddar.prepare_rot_key
+// CHECK-SAME: distance = 2
+// CHECK-SAME: maxLevel = 2
+// CHECK: cheddar.prepare_rot_key
+// CHECK-SAME: distance = 7
+// CHECK-SAME: maxLevel = 2

--- a/tests/Dialect/Cheddar/Transforms/configure_crypto_context_bootstrap.mlir
+++ b/tests/Dialect/Cheddar/Transforms/configure_crypto_context_bootstrap.mlir
@@ -1,0 +1,51 @@
+// RUN: heir-opt --cheddar-configure-crypto-context=entry-function=main %s | FileCheck %s --check-prefix=CONFIG
+// RUN: heir-opt --cheddar-configure-crypto-context=entry-function=main --cheddar-bufferize --fold-memref-alias-ops --canonicalize --convert-to-emitc=filter-dialects=cheddar,arith,scf --cheddar-emitc-boundary --reconcile-unrealized-casts %s | FileCheck %s --check-prefix=EMITC
+
+!boot_context = !cheddar.boot_context
+!ciphertext = !cheddar.ciphertext
+!evk_map = !cheddar.evk_map
+!ui = !cheddar.user_interface
+
+module attributes {
+  cheddar.boot.num_cts = 4 : i64,
+  cheddar.boot.num_stc = 3 : i64,
+  ckks.schemeParam = #ckks.scheme_param<logN = 16, Q = [1125899908022273, 1099515691009, 1099523555329, 1099525128193, 1099526176769, 1099529060353, 1099535220737, 1099536138241, 1099537580033, 1099538104321, 1099540725761, 1099540856833, 1099543085057, 36028797019488257, 36028797023420417, 36028797024206849, 36028797025124353, 36028797032202241, 36028797033644033, 36028797037576193, 36028797048324097, 36028797048586241, 36028797049896961, 36028797051863041, 36028797053698049, 36028797054222337], P = [72057594038321153, 72057594040680449, 72057594042646529, 72057594047889409, 72057594057195521, 72057594058375169, 72057594058899457], logDefaultScale = 40>,
+  scheme.actual_slot_count = 1024 : i64
+} {
+  func.func @main(%ctx: !boot_context, %ui: !ui, %ct: tensor<!ciphertext>, %evk: !evk_map) -> tensor<!ciphertext> {
+    %rotDest = bufferization.alloc_tensor() : tensor<!ciphertext>
+    %rotated = cheddar.hrot %ctx, %ui, %ct, %rotDest {static_distance = 7 : i64} : (!boot_context, !ui, tensor<!ciphertext>, tensor<!ciphertext>) -> tensor<!ciphertext>
+    %dest = bufferization.alloc_tensor() : tensor<!ciphertext>
+    %result = cheddar.boot %ctx, %rotated, %evk, %dest : (!boot_context, tensor<!ciphertext>, !evk_map, tensor<!ciphertext>) -> tensor<!ciphertext>
+    return %result : tensor<!ciphertext>
+  }
+}
+
+// CONFIG: func.func @main__configure
+// CONFIG: cheddar.make_parameter
+// CONFIG-SAME: defaultEncryptionLevel = 13
+// CONFIG-SAME: denseHammingWeight = 32768
+// CONFIG-SAME: sparseHammingWeight = 32
+// CONFIG: cheddar.create_boot_context
+// CONFIG-SAME: logMessageRatio = 5
+// CONFIG-SAME: numCtsLevels = 4
+// CONFIG-SAME: numStcLevels = 3
+// CONFIG: cheddar.create_user_interface
+// CONFIG: cheddar.prepare_rot_key
+// CONFIG-SAME: distance = 7
+// CONFIG-SAME: maxLevel = 13
+// CONFIG: cheddar.prepare_bootstrap
+// CONFIG-SAME: numSlots = 1024
+
+// EMITC: func.func @main__configure
+// EMITC-SAME: !emitc.opaque<"std::shared_ptr<BootContext<word>>&">
+// EMITC-SAME: !emitc.opaque<"std::unique_ptr<UserInterface<word>>&">
+// EMITC: emitc.verbatim "static Parameter<word> cheddar_param
+// EMITC: emitc.verbatim "cheddar_param.SetDenseHammingWeight(32768);"
+// EMITC: emitc.verbatim "cheddar_param.SetSparseHammingWeight(32);"
+// EMITC: emitc.verbatim "{} = BootContext<word>::Create({}, BootParameter({}.max_level_, 4, 3, 5));"
+// EMITC: emitc.verbatim "{}->PrepareRotationKey(7, 13);"
+// EMITC: emitc.verbatim "{}->PrepareEvalMod();"
+// EMITC: emitc.verbatim "{}->PrepareEvalSpecialFFT(1024, cheddar::BootVariant::kImaginaryRemoving);"
+// EMITC: emitc.verbatim "EvkRequest boot_evk_req;"
+// EMITC: emitc.verbatim "{}->PrepareRotationKey(boot_evk_req);"

--- a/tests/Dialect/Cheddar/Transforms/configure_crypto_context_bootstrap_invalid.mlir
+++ b/tests/Dialect/Cheddar/Transforms/configure_crypto_context_bootstrap_invalid.mlir
@@ -1,0 +1,17 @@
+// RUN: not heir-opt --cheddar-configure-crypto-context=entry-function=main %s 2>&1 | FileCheck %s
+
+!boot_context = !cheddar.boot_context
+!ciphertext = !cheddar.ciphertext
+!evk_map = !cheddar.evk_map
+
+module attributes {
+  ckks.schemeParam = #ckks.scheme_param<logN = 13, Q = [36028797018652673, 1125899907366913, 1125899907760129], P = [1152921504606994433], logDefaultScale = 45>,
+  scheme.actual_slot_count = 4 : i64
+} {
+  // CHECK: error: 'func.func' op CHEDDAR bootstrap modulus chain is too short: 3 Q primes cannot cover 3 CtS + 8 EvalMod + 3 StC levels
+  func.func @main(%ctx: !boot_context, %ct: tensor<!ciphertext>, %evk: !evk_map) -> tensor<!ciphertext> {
+    %dest = bufferization.alloc_tensor() : tensor<!ciphertext>
+    %result = cheddar.boot %ctx, %ct, %evk, %dest : (!boot_context, tensor<!ciphertext>, !evk_map, tensor<!ciphertext>) -> tensor<!ciphertext>
+    return %result : tensor<!ciphertext>
+  }
+}

--- a/tests/Dialect/Cheddar/Transforms/configure_crypto_context_invalid.mlir
+++ b/tests/Dialect/Cheddar/Transforms/configure_crypto_context_invalid.mlir
@@ -1,0 +1,15 @@
+// RUN: not heir-opt --cheddar-configure-crypto-context=entry-function=main %s 2>&1 | FileCheck %s
+
+!boot_context = !cheddar.boot_context
+!ciphertext = !cheddar.ciphertext
+!evk_map = !cheddar.evk_map
+
+module attributes {ckks.schemeParam = #ckks.scheme_param<logN = 13, Q = [36028797018652673, 1125899907366913], P = [1152921504606994433], logDefaultScale = 45>} {
+  func.func @main(%ctx: !boot_context, %ct: tensor<!ciphertext>, %evk: !evk_map) -> tensor<!ciphertext> {
+    %dest = bufferization.alloc_tensor() : tensor<!ciphertext>
+    %result = cheddar.boot %ctx, %ct, %evk, %dest : (!boot_context, tensor<!ciphertext>, !evk_map, tensor<!ciphertext>) -> tensor<!ciphertext>
+    return %result : tensor<!ciphertext>
+  }
+}
+
+// CHECK: error: 'func.func' op bootstrapping program is missing the scheme.actual_slot_count module attribute

--- a/tests/Examples/cheddar/bootstrap/bootstrap_test.cpp
+++ b/tests/Examples/cheddar/bootstrap/bootstrap_test.cpp
@@ -1,11 +1,8 @@
 // End-to-end GPU run of a real CHEDDAR bootstrap via the cheddar backend. The
-// lowered module's `boot` kernel takes a BootContext<word>* and calls
-// `ctx->Boot(...)`, so the harness builds a BootContext from CHEDDAR's curated
-// bootparam_40_64bit parameter set, runs the bootstrap preparation sequence
-// (PrepareEvalMod / PrepareEvalSpecialFFT / AddRequiredRotations -> rotation
-// keys), then calls the generated encrypt/boot/decrypt helpers and checks that
-// bootstrapping preserves the message (boot(x) ~= x). Mirrors CHEDDAR's own
-// Bootstrapping unit test, but driven through HEIR-emitted code.
+// generated module builds and prepares a BootContext from CHEDDAR's curated
+// bootparam_40_64bit parameter set, then the harness calls the generated
+// encrypt/boot/decrypt helpers and checks that bootstrapping refreshes the
+// level while preserving the message (boot(x) ~= x).
 
 #include <gtest/gtest.h>
 
@@ -17,7 +14,6 @@
 #include <cstdio>
 #include <memory>
 #include <random>
-#include <utility>
 #include <vector>
 
 #include "UserInterface.h"
@@ -34,6 +30,8 @@ using UI = cheddar::UserInterface<word>;
 using EvkMap = cheddar::EvkMap<word>;
 
 // Generated entry points (see tests/Examples/cheddar/bootstrap/BUILD).
+void boot__configure(std::shared_ptr<cheddar::BootContext<word>>& boot_ctx,
+                     std::unique_ptr<UI>& ui);
 void boot__encrypt__arg0(cheddar::Context<word>* ctx,
                          const cheddar::Encoder<word>& encoder, UI* ui,
                          const Evk& evk, float a[1024], UI* ui2,
@@ -49,40 +47,6 @@ void boot__decrypt__result0(cheddar::Context<word>* ctx,
 
 namespace {
 constexpr int kN = 1024;
-// The encoded message has 1024 slots (the Encode vector length), so the sparse
-// bootstrap operates on 1024 of the logN=16 context's 32768 slots.
-constexpr int kNumSlots = 1024;
-
-// CHEDDAR's bootparam_40_64bit parameter set (logN=16, scale 2^40, 26-prime
-// main chain, 7 auxiliary primes, num_cts_levels=4, num_stc_levels=3).
-cheddar::Parameter<word> MakeParam() {
-  std::vector<word> main_primes = {
-      1125899908022273ULL,  1099515691009ULL,     1099523555329ULL,
-      1099525128193ULL,     1099526176769ULL,     1099529060353ULL,
-      1099535220737ULL,     1099536138241ULL,     1099537580033ULL,
-      1099538104321ULL,     1099540725761ULL,     1099540856833ULL,
-      1099543085057ULL,     36028797019488257ULL, 36028797023420417ULL,
-      36028797024206849ULL, 36028797025124353ULL, 36028797032202241ULL,
-      36028797033644033ULL, 36028797037576193ULL, 36028797048324097ULL,
-      36028797048586241ULL, 36028797049896961ULL, 36028797051863041ULL,
-      36028797053698049ULL, 36028797054222337ULL};
-  std::vector<word> aux_primes = {72057594038321153ULL, 72057594040680449ULL,
-                                  72057594042646529ULL, 72057594047889409ULL,
-                                  72057594057195521ULL, 72057594058375169ULL,
-                                  72057594058899457ULL};
-  std::vector<word> ter_primes = {};
-  std::vector<std::pair<int, int>> level_config;
-  for (int i = 1; i <= 26; ++i) level_config.emplace_back(i, 0);
-  std::pair<int, int> additional_base = {0, 0};
-  cheddar::Parameter<word> p(/*log_degree=*/16,
-                             /*base_scale=*/static_cast<double>(1ULL << 40),
-                             /*default_encryption_level=*/13, level_config,
-                             main_primes, aux_primes, ter_primes,
-                             additional_base);
-  p.SetDenseHammingWeight(32768);
-  p.SetSparseHammingWeight(32);
-  return p;
-}
 }  // namespace
 
 TEST(CheddarBootstrapE2E, GpuRun) {
@@ -91,18 +55,13 @@ TEST(CheddarBootstrapE2E, GpuRun) {
   static float input[1024];
   for (int i = 0; i < kN; ++i) input[i] = static_cast<float>(dist(gen));
 
-  auto param = MakeParam();
-  auto boot_ctx = cheddar::BootContext<word>::Create(
-      param, cheddar::BootParameter(param.max_level_, /*num_cts_levels=*/4,
-                                    /*num_stc_levels=*/3));
-  auto ui = std::make_unique<UI>(boot_ctx);
-
-  // Bootstrap preparation (one-time precompute + rotation keys).
-  boot_ctx->PrepareEvalMod();
-  boot_ctx->PrepareEvalSpecialFFT(kNumSlots);
-  cheddar::EvkRequest req;
-  boot_ctx->AddRequiredRotations(req, kNumSlots);
-  ui->PrepareRotationKey(req);
+  std::shared_ptr<cheddar::BootContext<word>> boot_ctx;
+  std::unique_ptr<UI> ui;
+  boot__configure(boot_ctx, ui);
+  ASSERT_NE(boot_ctx, nullptr);
+  ASSERT_NE(ui, nullptr);
+  EXPECT_EQ(boot_ctx->param_.default_encryption_level_, 13);
+  EXPECT_EQ(boot_ctx->boot_param_.GetEndLevel(), 10);
   const EvkMap& evk_map = ui->GetEvkMap();
   const Evk& evk = ui->GetMultiplicationKey();
 

--- a/tests/Examples/cheddar/configure_smoke/BUILD
+++ b/tests/Examples/cheddar/configure_smoke/BUILD
@@ -9,17 +9,12 @@ package(
     default_visibility = ["//visibility:public"],
 )
 
-# End-to-end: generate the real scale-snu BootContext setup, encrypt at level 0,
-# refresh with cheddar.boot (-> BootContext::Boot), decrypt, and check both the
-# refreshed level and boot(x) ~= x. The MLIR carries CHEDDAR's curated
-# bootparam_40_64bit modulus chain because the bootstrap needs substantially
-# more depth than an ordinary arithmetic program.
 heir_opt(
-    name = "bootstrap_emitc",
-    src = "bootstrap.mlir",
-    generated_filename = "bootstrap_emitc.mlir",
+    name = "configure_smoke_emitc",
+    src = "configure_smoke.mlir",
+    generated_filename = "configure_smoke_emitc.mlir",
     pass_flags = [
-        "--cheddar-configure-crypto-context=entry-function=boot",
+        "--cheddar-configure-crypto-context=entry-function=rotate",
         "--cheddar-bufferize",
         "--fold-memref-alias-ops",
         "--cse",
@@ -34,49 +29,48 @@ heir_opt(
 )
 
 heir_translate(
-    name = "bootstrap_cpp_raw",
-    src = ":bootstrap_emitc.mlir",
-    generated_filename = "bootstrap_raw.cc",
+    name = "configure_smoke_cpp_raw",
+    src = ":configure_smoke_emitc.mlir",
+    generated_filename = "configure_smoke_raw.cc",
     pass_flags = ["--mlir-to-cpp"],
 )
 
 genrule(
-    name = "bootstrap_lib_src",
-    srcs = [":bootstrap_raw.cc"],
-    outs = ["bootstrap_lib.cc"],
+    name = "configure_smoke_lib_src",
+    srcs = [":configure_smoke_raw.cc"],
+    outs = ["configure_smoke_lib.cc"],
     cmd = """cat > $@ <<'PRELUDE_EOF'
-// AUTO-GENERATED: do not edit. See tests/Examples/cheddar/bootstrap/BUILD.
+// AUTO-GENERATED: do not edit. See tests/Examples/cheddar/configure_smoke/BUILD.
 #include <array>
 #include <complex>
 #include <cstddef>
 #include <cstdint>
+#include <memory>
 #include <utility>
 #include <vector>
+#include "UserInterface.h"
 #include "core/Context.h"
 #include "core/Encode.h"
-#include "core/EvkRequest.h"
 #include "core/Parameter.h"
-#include "extension/BootContext.h"
-#include "UserInterface.h"
 using namespace cheddar;
 using word = uint64_t;
 using Complex = std::complex<double>;
 PRELUDE_EOF
-cat $(location :bootstrap_raw.cc) >> $@
+cat $(location :configure_smoke_raw.cc) >> $@
 """,
 )
 
 cc_library(
-    name = "bootstrap_lib",
-    srcs = [":bootstrap_lib_src"],
+    name = "configure_smoke_lib",
+    srcs = [":configure_smoke_lib_src"],
     target_compatible_with = requires_cheddar(),
     deps = ["@cheddar"],
 )
 
 cc_test(
-    name = "bootstrap_test",
+    name = "configure_smoke_test",
     timeout = "long",
-    srcs = ["bootstrap_test.cpp"],
+    srcs = ["configure_smoke_test.cpp"],
     linkstatic = False,
     tags = [
         "exclusive",
@@ -84,7 +78,7 @@ cc_test(
     ],
     target_compatible_with = requires_cheddar(),
     deps = [
-        ":bootstrap_lib",
+        ":configure_smoke_lib",
         "@cheddar",
         "@googletest//:gtest_main",
     ],

--- a/tests/Examples/cheddar/configure_smoke/configure_smoke.mlir
+++ b/tests/Examples/cheddar/configure_smoke/configure_smoke.mlir
@@ -1,0 +1,16 @@
+!ciphertext = !cheddar.ciphertext
+!context = !cheddar.context
+!ui = !cheddar.user_interface
+
+module attributes {
+  ckks.schemeParam = #ckks.scheme_param<logN = 13, Q = [36028797018652673, 1125899907366913, 1125899907760129], P = [1152921504606994433], logDefaultScale = 45>,
+  scheme.actual_slot_count = 4096 : i64
+} {
+  func.func @rotate(%ctx: !context, %ui: !ui, %ct: tensor<!ciphertext>) -> tensor<!ciphertext> {
+    %d0 = tensor.empty() : tensor<!ciphertext>
+    %rot = cheddar.hrot %ctx, %ui, %ct, %d0 {static_distance = 7 : i64} : (!context, !ui, tensor<!ciphertext>, tensor<!ciphertext>) -> tensor<!ciphertext>
+    %d1 = tensor.empty() : tensor<!ciphertext>
+    %result = cheddar.hrot_add %ctx, %ui, %rot, %ct, %d1 {distance = 2 : i64} : (!context, !ui, tensor<!ciphertext>, tensor<!ciphertext>, tensor<!ciphertext>) -> tensor<!ciphertext>
+    return %result : tensor<!ciphertext>
+  }
+}

--- a/tests/Examples/cheddar/configure_smoke/configure_smoke_test.cpp
+++ b/tests/Examples/cheddar/configure_smoke/configure_smoke_test.cpp
@@ -1,0 +1,77 @@
+#include <gtest/gtest.h>
+
+#include <algorithm>
+#include <cmath>
+#include <complex>
+#include <cstdint>
+#include <memory>
+#include <vector>
+
+#include "UserInterface.h"
+#include "core/Context.h"
+#include "core/Encode.h"
+
+using word = uint64_t;
+using Ct = cheddar::Ciphertext<word>;
+using Pt = cheddar::Plaintext<word>;
+using UI = cheddar::UserInterface<word>;
+
+void rotate__configure(std::shared_ptr<cheddar::Context<word>>& ctx,
+                       std::unique_ptr<UI>& ui);
+void rotate(cheddar::Context<word>* ctx, UI* ui, const Ct& input, Ct& output);
+
+TEST(CheddarConfigureSmoke, GeneratedSetupAndRotationRun) {
+  std::shared_ptr<cheddar::Context<word>> ctx;
+  std::unique_ptr<UI> ui;
+  rotate__configure(ctx, ui);
+
+  ASSERT_NE(ctx, nullptr);
+  ASSERT_NE(ui, nullptr);
+  EXPECT_NO_THROW(ui->GetRotationKey(2));
+  EXPECT_NO_THROW(ui->GetRotationKey(7));
+
+  constexpr int kSlots = 4096;
+  std::vector<cheddar::Complex> message;
+  message.reserve(kSlots);
+  for (int i = 0; i < kSlots; ++i)
+    message.emplace_back(static_cast<double>((i * 17) % 101) / 101.0,
+                         static_cast<double>((i * 29) % 89) / 178.0);
+  Pt plaintext;
+  ctx->encoder_.Encode(plaintext, /*level=*/2,
+                       ctx->param_.GetScale(/*level=*/2), message);
+  Ct input;
+  ui->Encrypt(input, plaintext);
+
+  Ct output;
+  rotate(ctx.get(), ui.get(), input, output);
+
+  // Compare the emitted call sequence against the real scale-snu operations.
+  // A nonconstant complex message makes rotation direction and distance
+  // observable, unlike the previous all-ones input.
+  Ct rotated_reference;
+  ctx->HRot(rotated_reference, input, ui->GetRotationKey(7), 7);
+  Ct reference;
+  ctx->HRotAdd(reference, rotated_reference, input, ui->GetRotationKey(2), 2);
+
+  Pt decrypted;
+  ui->Decrypt(decrypted, output);
+  std::vector<cheddar::Complex> decoded;
+  ctx->encoder_.Decode(decoded, decrypted);
+  ASSERT_EQ(decoded.size(), kSlots);
+
+  Pt decrypted_reference;
+  ui->Decrypt(decrypted_reference, reference);
+  std::vector<cheddar::Complex> decoded_reference;
+  ctx->encoder_.Decode(decoded_reference, decrypted_reference);
+  ASSERT_EQ(decoded_reference.size(), kSlots);
+
+  double max_abs_error = 0.0;
+  for (int i = 0; i < kSlots; ++i) {
+    ASSERT_TRUE(std::isfinite(decoded[i].real()));
+    ASSERT_TRUE(std::isfinite(decoded[i].imag()));
+    double error = std::abs(decoded[i] - decoded_reference[i]);
+    ASSERT_TRUE(std::isfinite(error)) << "non-finite error at slot " << i;
+    max_abs_error = std::max(max_abs_error, error);
+  }
+  EXPECT_LT(max_abs_error, 1e-2);
+}

--- a/tools/BUILD
+++ b/tools/BUILD
@@ -52,6 +52,7 @@ cc_binary(
         "@heir//lib/Dialect/Cheddar/IR:Dialect",
         "@heir//lib/Dialect/Cheddar/Transforms",
         "@heir//lib/Dialect/Cheddar/Transforms:BufferizableOpInterfaceImpl",
+        "@heir//lib/Dialect/Cheddar/Transforms:ConfigureCryptoContext",
         "@heir//lib/Dialect/Comb/IR:Dialect",
         "@heir//lib/Dialect/Debug/IR:Dialect",
         "@heir//lib/Dialect/Debug/Transforms",

--- a/tools/heir-opt.cpp
+++ b/tools/heir-opt.cpp
@@ -21,6 +21,7 @@
 #include "lib/Dialect/Cheddar/IR/CheddarDialect.h"
 #include "lib/Dialect/Cheddar/Transforms/BufferizableOpInterfaceImpl.h"
 #include "lib/Dialect/Cheddar/Transforms/Passes.h"
+#include "lib/Dialect/Cheddar/Transforms/ConfigureCryptoContext.h"
 #include "lib/Dialect/Comb/IR/CombDialect.h"
 #include "lib/Dialect/Debug/IR/DebugDialect.h"
 #include "lib/Dialect/Debug/Transforms/Passes.h"
@@ -383,6 +384,7 @@ int main(int argc, char** argv) {
   // Custom passes in HEIR
   registerEmitCInterfacePass();
   registerCheddarToEmitCPasses();
+  cheddar::registerCheddarConfigureCryptoContextPasses();
   cggi::registerCGGIPasses();
   debug::registerDebugPasses();
   ckks::registerCKKSPasses();


### PR DESCRIPTION
Generate CHEDDAR parameters, contexts, user interfaces, rotation keys, and bootstrap setup from scheme attributes using scale-snu APIs directly.

Compile generated setup against real CHEDDAR and exercise generated configuration in GPU smoke and bootstrap tests, including invalid bootstrap-level validation.

---

<sub>Stack created with <a href="https://github.com/github/gh-stack">GitHub Stacks CLI</a> • <a href="https://gh.io/stacks-feedback">Give Feedback 💬</a></sub>