### PR TITLE
cheddar: add optional scale-snu CHEDDAR dependency

### DIFF
--- a/.bazelrc
+++ b/.bazelrc
@@ -65,6 +65,20 @@ build:linux --linkopt="-fuse-ld=lld"
 # target links with a C++ lib.
 build:linux --linkopt="-Wl,-no-pie"
 
+# CHEDDAR GPU FHE backend (opt-in, requires CUDA). CHEDDAR's CUDA sources are
+# compiled with the hermetic clang toolchain via rules_cuda.
+build:cheddar --//:enable_cheddar=1
+build:cheddar --extra_toolchains=@cuda//toolchain:all
+build:cheddar --@rules_cuda//cuda:compiler=clang
+# Compile CUDA with the hermetic clang from the configured cc_toolchain
+# (instead of rules_cuda's `which clang` fallback).
+build:cheddar --repo_env=CUDA_COMPILER_USE_CC_TOOLCHAIN=true
+build:cheddar --@rules_cuda//cuda:copts=-D_ALLOW_UNSUPPORTED_LIBCPP
+build:cheddar --@rules_cuda//cuda:copts=-D_LIBCPP_NO_ABI_TAG
+build:cheddar --@rules_cuda//cuda:copts=-D_VSTD=std
+build:cheddar --@rules_cuda//cuda:copts=-DSPDLOG_FMT_EXTERNAL
+build:cheddar --@rules_cuda//cuda:archs=sm_60,sm_61,sm_70,sm_75,sm_80,sm_86,sm_89,sm_90
+
 # macos specific options
 # openmp is not supported in apple clang
 build:macos --@openfhe//:enable_openmp=False

--- a/BUILD.bazel
+++ b/BUILD.bazel
@@ -50,6 +50,32 @@ config_setting(
     visibility = ["//visibility:public"],
 )
 
+# CHEDDAR GPU FHE backend (opt-in, requires CUDA).
+# Enable with `--config=cheddar`
+string_flag(
+    name = "enable_cheddar",
+    build_setting_default = "0",
+)
+
+config_setting(
+    name = "config_enable_cheddar",
+    flag_values = {
+        ":enable_cheddar": "1",
+    },
+    visibility = ["//visibility:public"],
+)
+
+config_setting(
+    name = "config_enable_cheddar_linux_x86_64",
+    constraint_values = [
+        "@platforms//cpu:x86_64",
+        "@platforms//os:linux",
+    ],
+    flag_values = {
+        ":enable_cheddar": "1",
+    },
+)
+
 # OpenFHE interpreter
 string_flag(
     name = "openfhe_enable_timing",

--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -45,6 +45,7 @@ bazel_dep(name = "bazel_skylib_gazelle_plugin", version = "1.8.2", dev_dependenc
 # implicitly depends upon the target '//:license'. How bizarre.
 bazel_dep(name = "rules_license", version = "1.0.0")
 bazel_dep(name = "platforms", version = "1.1.0")
+bazel_dep(name = "rules_cuda", version = "0.3.0")
 bazel_dep(name = "rules_go", version = "0.61.1")
 bazel_dep(name = "rules_python", version = "1.7.0")
 bazel_dep(name = "googletest", version = "1.17.0")
@@ -98,6 +99,29 @@ use_repo(
     llvm_extensions,
     "llvm-raw",
 )
+
+# CHEDDAR GPU FHE library (opt-in, requires CUDA).
+cheddar_extensions = use_extension("//bazel:extensions.bzl", "cheddar_deps")
+use_repo(cheddar_extensions, "cheddar", "libtommath", "rmm")
+
+# CHEDDAR's headers leak spdlog (via RMM) and nlohmann_json includes.
+bazel_dep(name = "nlohmann_json", version = "3.12.0.bcr.2")
+bazel_dep(name = "spdlog", version = "1.17.0")
+
+# CUDA for CHEDDAR
+cuda = use_extension("@rules_cuda//cuda:extensions.bzl", "toolchain")
+
+# NVIDIA publishes no macOS CUDA redistributable; on non-Linux hosts rules_cuda
+# resolves this to a disabled toolkit, which is fine because CHEDDAR targets are
+# Linux-x86_64 only. Do not add `components = [...]` here: that path indexes the
+# redist JSON by host platform and hard-fails on macOS.
+cuda.redist_json(
+    name = "cuda_redist",
+    sha256 = "8335301010b0023ee1ff61eb11e2600ca62002d76780de4089011ad77e0c7630",
+    version = "12.9.1",
+)
+cuda.toolkit(name = "cuda")
+use_repo(cuda, "cuda")
 
 # The subset of LLVM backend targets that should be compiled
 _LLVM_TARGETS = [

--- a/bazel/cheddar/BUILD
+++ b/bazel/cheddar/BUILD
@@ -1,0 +1,12 @@
+# This build file marks the directory as a Bazel subpackage.
+
+package(
+    default_applicable_licenses = ["@heir//:license"],
+    default_visibility = ["//visibility:public"],
+)
+
+exports_files([
+    "cheddar.BUILD",
+    "libtommath.BUILD",
+    "rmm.BUILD",
+])

--- a/bazel/cheddar/cheddar.BUILD
+++ b/bazel/cheddar/cheddar.BUILD
@@ -1,0 +1,80 @@
+load("@rules_cc//cc:defs.bzl", "cc_library")
+load("@rules_cuda//cuda:defs.bzl", "cuda_library")
+
+cuda_library(
+    name = "cheddar_cuda",
+    srcs = [
+        "src/UserInterface.cu",
+        "src/core/ElementWise.cu",
+        "src/core/ModSwitch.cu",
+        "src/core/NTT.cu",
+        "src/core/Parameter.cu",
+        "src/extension/Hoist.cu",
+    ],
+    hdrs = glob([
+        "include/**/*.h",
+        "include/**/*.cuh",
+    ]),
+    defines = [
+        "ENABLE_EXTENSION",
+        "SPDLOG_FMT_EXTERNAL",
+        "_ALLOW_UNSUPPORTED_LIBCPP",
+        "_LIBCPP_NO_ABI_TAG",
+        "_VSTD=std",
+    ],
+    includes = ["include"],
+    visibility = ["//visibility:public"],
+    deps = [
+        "@cuda//:cuda_headers",
+        "@cuda//:libcudacxx",
+        "@cuda//:thrust",
+        "@libtommath//:tommath",
+        "@rmm",
+        "@rules_cuda//cuda:runtime",
+    ],
+)
+
+cc_library(
+    name = "cheddar",
+    srcs = [
+        "src/core/BigInt_tommath.cpp",
+        "src/core/Container.cpp",
+        "src/core/Context.cpp",
+        "src/core/DeviceVector.cpp",
+        "src/core/Encode.cpp",
+        "src/core/EvkMap.cpp",
+        "src/core/EvkRequest.cpp",
+        "src/core/MemoryPool.cpp",
+        "src/core/MultiLevelCiphertext.cpp",
+        "src/core/NPInfo.cpp",
+        "src/extension/BootContext.cpp",
+        "src/extension/BootParameter.cpp",
+        "src/extension/EvalMod.cpp",
+        "src/extension/EvalPoly.cpp",
+        "src/extension/EvalSpecialFFT.cpp",
+        "src/extension/LinearTransform.cpp",
+        "src/extension/StripedMatrix.cpp",
+    ],
+    hdrs = glob([
+        "include/**/*.h",
+        "include/**/*.cuh",
+    ]),
+    defines = [
+        "ENABLE_EXTENSION",
+        "SPDLOG_FMT_EXTERNAL",
+        "_ALLOW_UNSUPPORTED_LIBCPP",
+        "_LIBCPP_NO_ABI_TAG",
+        "_VSTD=std",
+    ],
+    includes = ["include"],
+    visibility = ["//visibility:public"],
+    deps = [
+        ":cheddar_cuda",
+        "@cuda//:cuda_headers",
+        "@cuda//:libcudacxx",
+        "@cuda//:thrust",
+        "@libtommath//:tommath",
+        "@rmm",
+        "@rules_cuda//cuda:runtime",
+    ],
+)

--- a/bazel/cheddar/config.bzl
+++ b/bazel/cheddar/config.bzl
@@ -1,0 +1,19 @@
+"""Helpers for CHEDDAR's opt-in build configuration."""
+
+def if_cheddar_enabled(if_true, if_false = []):
+    """Selects a value based on whether CHEDDAR is enabled."""
+    return select({
+        "@heir//:config_enable_cheddar": if_true,
+        "//conditions:default": if_false,
+    })
+
+def requires_cheddar():
+    """Marks a target incompatible unless CHEDDAR is enabled on Linux x86."""
+    return select({
+        "@heir//:config_enable_cheddar_linux_x86_64": [],
+        "//conditions:default": ["@platforms//:incompatible"],
+    })
+
+def cheddar_deps(extra = []):
+    """Returns CHEDDAR library dependencies when enabled."""
+    return if_cheddar_enabled(["@cheddar//:cheddar"] + extra)

--- a/bazel/cheddar/libtommath.BUILD
+++ b/bazel/cheddar/libtommath.BUILD
@@ -1,0 +1,20 @@
+load("@rules_cc//cc:defs.bzl", "cc_library")
+
+cc_library(
+    name = "tommath",
+    srcs = glob(
+        ["*.c"],
+        allow_empty = True,
+        exclude = [
+            "demo/**",
+            "etc/**",
+            "mtest/**",
+        ],
+    ),
+    hdrs = glob(
+        ["*.h"],
+        allow_empty = True,
+    ),
+    includes = ["."],
+    visibility = ["//visibility:public"],
+)

--- a/bazel/cheddar/rmm.BUILD
+++ b/bazel/cheddar/rmm.BUILD
@@ -1,0 +1,22 @@
+load("@rules_cc//cc:defs.bzl", "cc_library")
+
+cc_library(
+    name = "rmm",
+    hdrs = glob(
+        [
+            "include/rmm/**/*.hpp",
+            "include/rmm/**/*.h",
+            "include/rmm/**/*.cuh",
+        ],
+        allow_empty = True,
+    ),
+    includes = ["include"],
+    visibility = ["//visibility:public"],
+    deps = [
+        "@cuda//:cuda_headers",
+        "@cuda//:libcudacxx",
+        "@cuda//:thrust",
+        "@rules_cuda//cuda:runtime",
+        "@spdlog",
+    ],
+)

--- a/bazel/extensions.bzl
+++ b/bazel/extensions.bzl
@@ -4,7 +4,7 @@ load("@bazel_tools//tools/build_defs/repo:git.bzl", "new_git_repository")
 
 def _llvm_deps_impl(_):
     """Implementation of the llvm_deps module extension."""
-    LLVM_COMMIT = "fdb39b1112a6db0343de169b79820768bd16c7d9"
+    LLVM_COMMIT = "ab547095ead5464dc024d66264d9b8a987f429f3"
 
     # Download LLVM/MLIR using a git repository
     new_git_repository(

--- a/bazel/extensions.bzl
+++ b/bazel/extensions.bzl
@@ -1,6 +1,8 @@
 """Module extensions for MLIR Tutorial dependencies."""
 
 load("@bazel_tools//tools/build_defs/repo:git.bzl", "new_git_repository")
+load("@bazel_tools//tools/build_defs/repo:http.bzl", "http_archive")
+load("@bazel_tools//tools/build_defs/repo:utils.bzl", "maybe")
 
 def _llvm_deps_impl(_):
     """Implementation of the llvm_deps module extension."""
@@ -27,3 +29,34 @@ def _llvm_deps_impl(_):
 llvm_deps = module_extension(
     implementation = _llvm_deps_impl,
 )
+
+CHEDDAR_COMMIT = "307b49cbe03e7f8f14bf31485f716c1090c9ec9d"
+
+def _cheddar_deps_impl(_):
+    maybe(
+        new_git_repository,
+        name = "cheddar",
+        build_file = "@heir//bazel/cheddar:cheddar.BUILD",
+        commit = CHEDDAR_COMMIT,
+        remote = "https://github.com/scale-snu/cheddar-fhe.git",
+        patches = ["@heir//patches:cheddar.patch"],
+        patch_args = ["-p1"],
+    )
+    maybe(
+        http_archive,
+        name = "rmm",
+        build_file = "@heir//bazel/cheddar:rmm.BUILD",
+        integrity = "sha256-XrU9m0N9g6ABhp9b720nKx1Q2bUk3xzugzvJG3V29ls=",
+        strip_prefix = "rmm-22.12.00",
+        urls = ["https://github.com/rapidsai/rmm/archive/refs/tags/v22.12.00.tar.gz"],
+    )
+    maybe(
+        http_archive,
+        name = "libtommath",
+        build_file = "@heir//bazel/cheddar:libtommath.BUILD",
+        integrity = "sha256-Bora9RVdKNSsl265XqDfHss2LyDXdyhxVMIqJP2zX6o=",
+        strip_prefix = "libtommath-1.2.1",
+        urls = ["https://github.com/libtom/libtommath/archive/refs/tags/v1.2.1.tar.gz"],
+    )
+
+cheddar_deps = module_extension(implementation = _cheddar_deps_impl)

--- a/patches/cheddar.patch
+++ b/patches/cheddar.patch
@@ -1,0 +1,138 @@
+diff --git a/include/common/PtrList.h b/include/common/PtrList.h
+index 4444444..5555555 100644
+--- a/include/common/PtrList.h
++++ b/include/common/PtrList.h
+@@ -11,7 +11,7 @@ template <typename word, int num_poly>
+ struct OutputPtrList {
+   word *ptrs_[num_poly];
+ 
+-  OutputPtrList() {
++  __host__ __device__ OutputPtrList() {
+     for (int i = 0; i < num_poly; i++) {
+       ptrs_[i] = nullptr;
+     }
+@@ -39,7 +39,7 @@ struct InputPtrList {
+   const word *ptrs_[num_poly];
+   int extra_ = 0;
+ 
+-  InputPtrList() {
++  __host__ __device__ InputPtrList() {
+     for (int i = 0; i < num_poly; i++) {
+       ptrs_[i] = nullptr;
+     }
+@@ -68,7 +68,7 @@ struct PermuteInputPtrList {
+   int extra_ = 0;
+   uint32_t galois_factor_ = 1;
+ 
+-  PermuteInputPtrList() {
++  __host__ __device__ PermuteInputPtrList() {
+     for (int i = 0; i < num_poly; i++) {
+       ptrs_[i] = nullptr;
+     }
+@@ -98,7 +98,7 @@ struct CPAccumInputPtrList {
+   const word *common_ptr_;
+   int common_extra_ = 0;
+ 
+-  CPAccumInputPtrList() {
++  __host__ __device__ CPAccumInputPtrList() {
+     for (int i = 0; i < num_poly; i++) {
+       ptrs_[i] = nullptr;
+     }
+diff --git a/include/core/Encode.h b/include/core/Encode.h
+index 2222222..3333333 100644
+--- a/include/core/Encode.h
++++ b/include/core/Encode.h
+@@ -46,6 +46,13 @@ class Encoder {
+    */
+   Encoder(const Parameter<word> &param, const NTTHandler<word> &ntt_handler);
+ 
++  /**
++   * @brief Canonical CKKS encode scale at the given level. Added for HEIR's
++   * cheddar backend: cheddar.encode emits encoder.GetScale(level) so plaintexts
++   * are encoded at the parameter set's exact per-level scale.
++   */
++  double GetScale(int level) const { return param_.GetScale(level); }
++
+   /**
+    * @brief Encode a message into a plaintext for a given level and scale.
+    * The message will be padded to the nearest power of 2.
+diff --git a/src/extension/EvalPoly.cpp b/src/extension/EvalPoly.cpp
+index 97bf07a..1f5e67b 100644
+--- a/src/extension/EvalPoly.cpp
++++ b/src/extension/EvalPoly.cpp
+@@ -504,8 +504,8 @@ void EvalPolyNode<word>::Compile(ConstContextPtr<word> context,
+     auto [_, split_scale] = basis_eval.GetBaseLevelAndScale(split_degree_);
+     double high_scale = working_scale / split_scale;
+     if (is_high_constant_) {
+-      context->encoder_.EncodeConstant(high_constant_, high_scale,
+-                                       working_level,
++      context->encoder_.EncodeConstant(high_constant_, working_level,
++                                       high_scale,
+                                        coefficients_[split_degree_]);
+     } else {
+       high_->Compile(context, basis_eval, working_level, high_scale, true);
+diff --git a/parameters/BUILD.bazel b/parameters/BUILD.bazel
+new file mode 100644
+index 0000000..6666666
+--- /dev/null
++++ b/parameters/BUILD.bazel
+@@ -0,0 +1,5 @@
++filegroup(
++    name = "param_files",
++    srcs = glob(["*.json"]),
++    visibility = ["//visibility:public"],
++)
+diff --git a/unittest/BUILD.bazel b/unittest/BUILD.bazel
+new file mode 100644
+index 0000000..7777777
+--- /dev/null
++++ b/unittest/BUILD.bazel
+@@ -0,0 +1,48 @@
++load("@rules_cc//cc:defs.bzl", "cc_test")
++
++cc_test(
++    name = "basic_test",
++    timeout = "eternal",
++    srcs = [
++        "BasicTest.cpp",
++        "Testbed.h",
++    ],
++    data = ["//parameters:param_files"],
++    defines = [
++        # Path relative to the runfiles cwd of the *main* (heir) workspace.
++        "PARAM_DIR=\\\"../+cheddar_deps+cheddar/parameters\\\"",
++        "_ALLOW_UNSUPPORTED_LIBCPP",
++        "_LIBCPP_NO_ABI_TAG",
++        "_VSTD=std",
++    ],
++    includes = ["."],
++    deps = [
++        "//:cheddar",
++        "@googletest//:gtest_main",
++        "@nlohmann_json//:json",
++    ],
++)
++
++cc_test(
++    name = "boot_test",
++    timeout = "eternal",
++    srcs = [
++        "Bootstrapping.cpp",
++        "Testbed.h",
++    ],
++    data = ["//parameters:param_files"],
++    defines = [
++        "ENABLE_EXTENSION",
++        # Path relative to the runfiles cwd of the *main* (heir) workspace.
++        "PARAM_DIR=\\\"../+cheddar_deps+cheddar/parameters\\\"",
++        "_ALLOW_UNSUPPORTED_LIBCPP",
++        "_LIBCPP_NO_ABI_TAG",
++        "_VSTD=std",
++    ],
++    includes = ["."],
++    deps = [
++        "//:cheddar",
++        "@googletest//:gtest_main",
++        "@nlohmann_json//:json",
++    ],
++)

--- a/patches/llvm.patch
+++ b/patches/llvm.patch
@@ -1,4 +1,404 @@
 Auto generated patch. Do not edit or delete it, even if empty.
+diff -ruN --strip-trailing-cr a/bolt/lib/Core/Relocation.cpp b/bolt/lib/Core/Relocation.cpp
+--- a/bolt/lib/Core/Relocation.cpp
++++ b/bolt/lib/Core/Relocation.cpp
+@@ -606,14 +606,6 @@
+   case ELF::R_AARCH64_TLSIE_LD64_GOTTPREL_LO12_NC:
+   case ELF::R_AARCH64_TLSLE_ADD_TPREL_HI12:
+   case ELF::R_AARCH64_TLSLE_ADD_TPREL_LO12_NC:
+-  case ELF::R_AARCH64_TLSLE_LDST8_TPREL_LO12:
+-  case ELF::R_AARCH64_TLSLE_LDST8_TPREL_LO12_NC:
+-  case ELF::R_AARCH64_TLSLE_LDST16_TPREL_LO12:
+-  case ELF::R_AARCH64_TLSLE_LDST16_TPREL_LO12_NC:
+-  case ELF::R_AARCH64_TLSLE_LDST32_TPREL_LO12:
+-  case ELF::R_AARCH64_TLSLE_LDST32_TPREL_LO12_NC:
+-  case ELF::R_AARCH64_TLSLE_LDST64_TPREL_LO12:
+-  case ELF::R_AARCH64_TLSLE_LDST64_TPREL_LO12_NC:
+   case ELF::R_AARCH64_TLSLE_MOVW_TPREL_G0:
+   case ELF::R_AARCH64_TLSLE_MOVW_TPREL_G0_NC:
+   case ELF::R_AARCH64_TLSDESC_LD64_LO12:
+diff -ruN --strip-trailing-cr a/bolt/test/AArch64/tls.c b/bolt/test/AArch64/tls.c
+--- a/bolt/test/AArch64/tls.c
++++ b/bolt/test/AArch64/tls.c
+@@ -5,8 +5,6 @@
+   int b;
+ } tbssstruct = {}, tdatastruct = {4, 2};
+ 
+-__thread int directaccess;
+-
+ extern __thread struct str extstruct;
+ 
+ extern void processAddr(volatile void *);
+@@ -20,9 +18,6 @@
+   processAddr(&tbssstruct.b);
+   processAddr(&tdatastruct.b);
+ 
+-  // R_AARCH64_TLSLE_LDST32_TPREL_LO12_NC for a direct access
+-  directaccess++;
+-
+   // The R_AARCH64_TLSIE_ADR_GOTTPREL_PAGE21 and
+   // R_AARCH64_TLSIE_LD64_GOTTPREL_LO12_NC relocations
+   processAddr(&extstruct.b);
+@@ -33,8 +28,6 @@
+ // RUN:   -Wl,--unresolved-symbols=ignore-all \
+ // RUN:   -fuse-ld=lld \
+ // RUN:   -nostdlib
+-// RUN: llvm-objdump -d -r --disassemble-symbols=main %t.exe \
+-// RUN:   | FileCheck %s --check-prefix=CHECK-DIRECT-ACCESS
+ // RUN: llvm-bolt %t.exe -o %t.bolt
+ // RUN: %clang %cflags -fPIC -pie %s -o %t_pie.exe -Wl,-q \
+ // RUN:   -Wl,--unresolved-symbols=ignore-all \
+@@ -47,11 +40,6 @@
+ // RUN: llvm-objdump -d -r --disassemble-symbols=main %t.so | FileCheck %s
+ // RUN: llvm-bolt %t.so -o %t.bolt.so
+ 
+-// CHECK-DIRECT-ACCESS: R_AARCH64_TLSLE_LDST32_TPREL_LO12_NC directaccess
+-// CHECK-DIRECT-ACCESS-NEXT: add {{.*}} #0x1
+-// CHECK-DIRECT-ACCESS-NEXT: str {{.*}}
+-// CHECK-DIRECT-ACCESS-NEXT: R_AARCH64_TLSLE_LDST32_TPREL_LO12_NC directaccess
+-
+ // Verify that unoptimized TLS access was generated for shared object.
+ // CHECK:      adrp    x0
+ // CHECK-NEXT: R_AARCH64_TLSDESC_ADR_PAGE21     tbssstruct
+diff -ruN --strip-trailing-cr a/lldb/include/lldb/Symbol/Symbol.h b/lldb/include/lldb/Symbol/Symbol.h
+--- a/lldb/include/lldb/Symbol/Symbol.h
++++ b/lldb/include/lldb/Symbol/Symbol.h
+@@ -53,11 +53,7 @@
+ 
+   Symbol(const Symbol &rhs);
+ 
+-  ~Symbol() {
+-    if (m_type != lldb::eSymbolTypeReExported &&
+-        m_type != lldb::eSymbolTypeInvalid)
+-      m_addr_or_reexport.GetAddressRange(*this).Clear();
+-  }
++  ~Symbol() { m_addr_or_reexport.Clear(*this); }
+ 
+   const Symbol &operator=(const Symbol &rhs);
+ 
+@@ -419,6 +415,13 @@
+     // impl to let the compiler know it's handled.
+     ~AddrRangeOrReExport() {}
+ 
++    void Clear(const Symbol &sym) {
++      if (sym.GetType() == lldb::eSymbolTypeReExported)
++        m_reexport_info.Clear();
++      else
++        m_addr_range.Clear();
++    }
++
+   private:
+     union {
+       // Contains the value, or the section offset address when the value is an
+diff -ruN --strip-trailing-cr a/lldb/source/API/SBThread.cpp b/lldb/source/API/SBThread.cpp
+--- a/lldb/source/API/SBThread.cpp
++++ b/lldb/source/API/SBThread.cpp
+@@ -465,7 +465,7 @@
+ 
+   // Release the run lock but keep the API lock.
+   TargetAPIMutex api_mutex = exe_ctx.AllowResume();
+-  std::lock_guard<TargetAPIMutex> guard(api_mutex, std::adopt_lock);
++  std::unique_lock<TargetAPIMutex> guard(api_mutex, std::adopt_lock);
+   if (process->GetTarget().GetDebugger().GetAsyncExecution())
+     return process->Resume();
+   return process->ResumeSynchronous(nullptr);
+diff -ruN --strip-trailing-cr a/lldb/unittests/Target/TargetAPIMutexTest.cpp b/lldb/unittests/Target/TargetAPIMutexTest.cpp
+--- a/lldb/unittests/Target/TargetAPIMutexTest.cpp
++++ b/lldb/unittests/Target/TargetAPIMutexTest.cpp
+@@ -120,6 +120,15 @@
+     EXPECT_FALSE(background_lock.try_lock());
+   });
+   t.join();
++
++  // Unlock the original locked mutex.
++  // Calling try_lock() resolves the underlying mutex and re-enters it on this
++  // thread (incrementing the recursive count), so we unlock twice to fully
++  // release both acquisitions.
++  TargetAPIMutex cleanup_lock(target_sp);
++  ASSERT_TRUE(cleanup_lock.try_lock());
++  cleanup_lock.unlock();
++  cleanup_lock.unlock();
+ }
+ 
+ TEST_F(TargetAPIMutexTargetTest, LockGuardReleasesOnScopeExit) {
+diff -ruN --strip-trailing-cr a/llvm/lib/CodeGen/SelectionDAG/DAGCombiner.cpp b/llvm/lib/CodeGen/SelectionDAG/DAGCombiner.cpp
+--- a/llvm/lib/CodeGen/SelectionDAG/DAGCombiner.cpp
++++ b/llvm/lib/CodeGen/SelectionDAG/DAGCombiner.cpp
+@@ -5937,6 +5937,8 @@
+                                 ISD::matchUnaryPredicate(
+                                     Y,
+                                     [&](auto *C) {
++                                      if (!C)
++                                        return true;
+                                       const APInt &YConst = C->getAsAPIntVal();
+                                       return (Opcode == ISD::ABDS)
+                                                  ? YConst.isSignedIntN(Bits)
+diff -ruN --strip-trailing-cr a/llvm/lib/Target/AArch64/AArch64ISelDAGToDAG.cpp b/llvm/lib/Target/AArch64/AArch64ISelDAGToDAG.cpp
+--- a/llvm/lib/Target/AArch64/AArch64ISelDAGToDAG.cpp
++++ b/llvm/lib/Target/AArch64/AArch64ISelDAGToDAG.cpp
+@@ -1254,18 +1254,6 @@
+   return true;
+ }
+ 
+-/// Check whether \p GAN is the low part of a TLS address computation, i.e. the
+-/// second operand of an ADDlow. The target flags on their own do not tell the
+-/// ELF local-exec (:tprel_lo12: and :tprel_lo12_nc:) cases apart from other
+-/// uses, so callers that depend on local-exec semantics have to check the
+-/// object format as well. Local dynamic never gets here because it does not
+-/// build an ADDlow.
+-static bool isTLSLo12(const GlobalAddressSDNode *GAN) {
+-  unsigned Flags = GAN->getTargetFlags();
+-  return (Flags & (AArch64II::MO_TLS | AArch64II::MO_FRAGMENT)) ==
+-         (AArch64II::MO_TLS | AArch64II::MO_PAGEOFF);
+-}
+-
+ /// Check if the immediate offset is valid as a scaled immediate.
+ static bool isValidAsScaledImmediate(int64_t Offset, unsigned Range,
+                                      unsigned Size) {
+@@ -1361,13 +1349,8 @@
+     if (!GAN)
+       return true;
+ 
+-    // Folding the low part of an ELF local-exec TLS address into a 128-bit
+-    // access needs R_AARCH64_TLSLE_LDST128_TPREL_LO12 or its NC variant, which
+-    // the GNU bfd linker does not support, so keep materialising the address
+-    // with an add.
+     if (GAN->getOffset() % Size == 0 &&
+-        GAN->getGlobal()->getPointerAlignment(DL) >= Size &&
+-        !(Size > 8 && Subtarget->isTargetELF() && isTLSLo12(GAN)))
++        GAN->getGlobal()->getPointerAlignment(DL) >= Size)
+       return true;
+   }
+ 
+diff -ruN --strip-trailing-cr a/llvm/lib/Target/AArch64/AArch64ISelLowering.cpp b/llvm/lib/Target/AArch64/AArch64ISelLowering.cpp
+--- a/llvm/lib/Target/AArch64/AArch64ISelLowering.cpp
++++ b/llvm/lib/Target/AArch64/AArch64ISelLowering.cpp
+@@ -11542,7 +11542,10 @@
+     // add   x0, x0, :tprel_lo12:a
+     SDValue Var = DAG.getTargetGlobalAddress(
+         GV, DL, PtrVT, 0, AArch64II::MO_TLS | AArch64II::MO_PAGEOFF);
+-    return DAG.getNode(AArch64ISD::ADDlow, DL, PtrVT, ThreadBase, Var);
++    return SDValue(DAG.getMachineNode(AArch64::ADDXri, DL, PtrVT, ThreadBase,
++                                      Var,
++                                      DAG.getTargetConstant(0, DL, MVT::i32)),
++                   0);
+   }
+ 
+   case 24: {
+@@ -11558,10 +11561,9 @@
+                                       HiVar,
+                                       DAG.getTargetConstant(0, DL, MVT::i32)),
+                    0);
+-    // Emit the low part as an ADDlow so that it can be folded into the
+-    // addressing mode of a following load or store, turning the add into a
+-    // :tprel_lo12_nc: relocation on the memory access itself.
+-    return DAG.getNode(AArch64ISD::ADDlow, DL, PtrVT, Addr, LoVar);
++    return SDValue(DAG.getMachineNode(AArch64::ADDXri, DL, PtrVT, Addr, LoVar,
++                                      DAG.getTargetConstant(0, DL, MVT::i32)),
++                   0);
+   }
+ 
+   case 32: {
+diff -ruN --strip-trailing-cr a/llvm/test/CodeGen/AArch64/abd-combine.ll b/llvm/test/CodeGen/AArch64/abd-combine.ll
+--- a/llvm/test/CodeGen/AArch64/abd-combine.ll
++++ b/llvm/test/CodeGen/AArch64/abd-combine.ll
+@@ -523,9 +523,26 @@
+   ret <1 x i64> %10
+ }
+ 
++; Poison elements in the constant operand pass a null ConstantSDNode to the
++; matchUnaryPredicate lambda in visitABD; make sure that does not crash.
++define <4 x i32> @abdu_const_poison(<4 x i8> %x) {
++; CHECK-LABEL: abdu_const_poison:
++; CHECK:       // %bb.0:
++; CHECK-NEXT:    mov w8, #8388736 // =0x800080
++; CHECK-NEXT:    bic v0.4h, #255, lsl #8
++; CHECK-NEXT:    fmov d1, x8
++; CHECK-NEXT:    uabdl v0.4s, v0.4h, v1.4h
++; CHECK-NEXT:    ret
++  %ext = zext <4 x i8> %x to <4 x i32>
++  %sub = sub <4 x i32> <i32 128, i32 128, i32 poison, i32 poison>, %ext
++  %abs = call <4 x i32> @llvm.abs.v4i32(<4 x i32> %sub, i1 false)
++  ret <4 x i32> %abs
++}
++
+ declare <8 x i8> @llvm.aarch64.neon.umax.v8i8(<8 x i8>, <8 x i8>)
+ declare <1 x i64> @llvm.aarch64.neon.saddlp.v1i64.v2i32(<2 x i32>)
+ declare <8 x i8> @llvm.aarch64.neon.uabd.v8i8(<8 x i8>, <8 x i8>)
+ declare <8 x i16> @llvm.aarch64.neon.uabd.v8i16(<8 x i16>, <8 x i16>)
+ declare <8 x i16> @llvm.aarch64.neon.sabd.v8i16(<8 x i16>, <8 x i16>)
+ declare <8 x i32> @llvm.abs.v8i32(<8 x i32>, i1)
++declare <4 x i32> @llvm.abs.v4i32(<4 x i32>, i1)
+diff -ruN --strip-trailing-cr a/llvm/test/CodeGen/AArch64/arm64-tls-local-exec.ll b/llvm/test/CodeGen/AArch64/arm64-tls-local-exec.ll
+--- a/llvm/test/CodeGen/AArch64/arm64-tls-local-exec.ll
++++ b/llvm/test/CodeGen/AArch64/arm64-tls-local-exec.ll
+@@ -27,24 +27,24 @@
+ ; RUN: llc -mtriple=arm64-none-linux-gnu -filetype=obj < %s -code-model=large | llvm-objdump -r - | FileCheck --check-prefix=CHECK-24-RELOC %s
+ 
+ @local_exec_var = thread_local(localexec) global i32 0
+-@local_exec_var64 = thread_local(localexec) global i64 0
+-@vec_local_exec_var = thread_local(localexec) global <2 x i64> zeroinitializer, align 16
+ 
+ define i32 @test_local_exec() {
+ ; CHECK-LABEL: test_local_exec:
+   %val = load i32, ptr @local_exec_var
+ 
+ ; CHECK-12: mrs x[[R1:[0-9]+]], TPIDR_EL0
+-; CHECK-12: ldr w0, [x[[R1]], :tprel_lo12:local_exec_var]
++; CHECK-12: add x[[R2:[0-9]+]], x[[R1]], :tprel_lo12:local_exec_var
++; CHECK-12: ldr w0, [x[[R2]]]
+ 
+-; CHECK-12-RELOC: R_AARCH64_TLSLE_LDST32_TPREL_LO12
++; CHECK-12-RELOC: R_AARCH64_TLSLE_ADD_TPREL_LO12
+ 
+ ; CHECK-24: mrs x[[R1:[0-9]+]], TPIDR_EL0
+ ; CHECK-24: add x[[R2:[0-9]+]], x[[R1]], :tprel_hi12:local_exec_var
+-; CHECK-24: ldr w0, [x[[R2]], :tprel_lo12_nc:local_exec_var]
++; CHECK-24: add x[[R3:[0-9]+]], x[[R2]], :tprel_lo12_nc:local_exec_var
++; CHECK-24: ldr w0, [x[[R3]]]
+ 
+ ; CHECK-24-RELOC: R_AARCH64_TLSLE_ADD_TPREL_HI12
+-; CHECK-24-RELOC: R_AARCH64_TLSLE_LDST32_TPREL_LO12_NC
++; CHECK-24-RELOC: R_AARCH64_TLSLE_ADD_TPREL_LO12_NC
+ 
+ ; CHECK-32: movz x[[R2:[0-9]+]], #:tprel_g1:local_exec_var
+ ; CHECK-32: mrs x[[R1:[0-9]+]], TPIDR_EL0
+@@ -66,24 +66,6 @@
+   ret i32 %val
+ }
+ 
+-define void @test_local_exec_store64(i64 %val) {
+-; CHECK-LABEL: test_local_exec_store64:
+-  store i64 %val, ptr @local_exec_var64
+-
+-; CHECK-12: mrs x[[R1:[0-9]+]], TPIDR_EL0
+-; CHECK-12: str x0, [x[[R1]], :tprel_lo12:local_exec_var64]
+-
+-; CHECK-12-RELOC: R_AARCH64_TLSLE_LDST64_TPREL_LO12
+-
+-; CHECK-24: mrs x[[R1:[0-9]+]], TPIDR_EL0
+-; CHECK-24: add x[[R2:[0-9]+]], x[[R1]], :tprel_hi12:local_exec_var64
+-; CHECK-24: str x0, [x[[R2]], :tprel_lo12_nc:local_exec_var64]
+-
+-; CHECK-24-RELOC: R_AARCH64_TLSLE_ADD_TPREL_HI12 local_exec_var64
+-; CHECK-24-RELOC-NEXT: R_AARCH64_TLSLE_LDST64_TPREL_LO12_NC local_exec_var64
+-  ret void
+-}
+-
+ define ptr @test_local_exec_addr() {
+ ; CHECK-LABEL: test_local_exec_addr:
+   ret ptr @local_exec_var
+@@ -122,26 +104,3 @@
+ ; CHECK-48-RELOC: R_AARCH64_TLSLE_MOVW_TPREL_G1_NC
+ ; CHECK-48-RELOC: R_AARCH64_TLSLE_MOVW_TPREL_G0_NC
+ }
+-
+-; A 128-bit access would need R_AARCH64_TLSLE_LDST128_TPREL_LO12 or its NC
+-; variant, which not every linker implements, so the low part stays in a
+-; separate add.
+-define <2 x i64> @test_local_exec_128bit() {
+-; CHECK-LABEL: test_local_exec_128bit:
+-  %val = load <2 x i64>, ptr @vec_local_exec_var
+-
+-; CHECK-12: mrs x[[R1:[0-9]+]], TPIDR_EL0
+-; CHECK-12: add x[[R2:[0-9]+]], x[[R1]], :tprel_lo12:vec_local_exec_var
+-; CHECK-12: ldr q0, [x[[R2]]]
+-
+-; CHECK-12-RELOC: R_AARCH64_TLSLE_ADD_TPREL_LO12 vec_local_exec_var
+-
+-; CHECK-24: mrs x[[R1:[0-9]+]], TPIDR_EL0
+-; CHECK-24: add x[[R2:[0-9]+]], x[[R1]], :tprel_hi12:vec_local_exec_var
+-; CHECK-24: add x[[R3:[0-9]+]], x[[R2]], :tprel_lo12_nc:vec_local_exec_var
+-; CHECK-24: ldr q0, [x[[R3]]]
+-
+-; CHECK-24-RELOC: R_AARCH64_TLSLE_ADD_TPREL_HI12 vec_local_exec_var
+-; CHECK-24-RELOC-NEXT: R_AARCH64_TLSLE_ADD_TPREL_LO12_NC vec_local_exec_var
+-  ret <2 x i64> %val
+-}
+diff -ruN --strip-trailing-cr a/llvm/test/CodeGen/AArch64/win-tls.ll b/llvm/test/CodeGen/AArch64/win-tls.ll
+--- a/llvm/test/CodeGen/AArch64/win-tls.ll
++++ b/llvm/test/CodeGen/AArch64/win-tls.ll
+@@ -3,7 +3,6 @@
+ @tlsVar = thread_local global i32 0
+ @tlsVar8 = thread_local global i8 0
+ @tlsVar64 = thread_local global i64 0
+-@tlsVar128 = thread_local global <2 x i64> zeroinitializer
+ 
+ define i32 @getVar() {
+   %1 = load i32, ptr @tlsVar
+@@ -29,11 +28,6 @@
+   ret i64 %1
+ }
+ 
+-define <2 x i64> @getVar128() {
+-  %1 = load <2 x i64>, ptr @tlsVar128
+-  ret <2 x i64> %1
+-}
+-
+ ; CHECK-LABEL: getVar
+ ; CHECK: adrp [[TLS_INDEX_ADDR:x[0-9]+]], _tls_index
+ ; CHECK: ldr [[TLS_POINTER:x[0-9]+]], [x18, #88]
+@@ -68,7 +62,3 @@
+ ; CHECK-LABEL: getVar64
+ ; CHECK: add [[TLS:x[0-9]+]], [[TLS]], :secrel_hi12:tlsVar64
+ ; CHECK: ldr x0, [[[TLS]], :secrel_lo12:tlsVar64]
+-
+-; CHECK-LABEL: getVar128
+-; CHECK: add [[TLS:x[0-9]+]], [[TLS]], :secrel_hi12:tlsVar128
+-; CHECK: ldr q0, [[[TLS]], :secrel_lo12:tlsVar128]
+diff -ruN --strip-trailing-cr a/utils/bazel/.bazelrc b/utils/bazel/.bazelrc
+--- a/utils/bazel/.bazelrc
++++ b/utils/bazel/.bazelrc
+@@ -222,6 +222,19 @@
+ build:hermetic-toolchain --copt=-Wno-modules-import-nested-redundant --host_copt=-Wno-modules-import-nested-redundant
+ 
+ ###############################################################################
++# Options for Emscripten WebAssembly builds.
++###############################################################################
++
++build:wasm --platforms=@emsdk//:platform_wasm
++# Match LLVM's single-threaded config and shut the runtime down when main returns.
++build:wasm --features=-use_pthreads,exit_runtime
++# Make the default CLI artifact use Node's host filesystem; browser builds override this to 0.
++build:wasm --linkopt=-sNODERAWFS=1
++
++# TODO: zstd unconditionally enables pthreads on non-Windows targets.
++build:wasm --@llvm-project//third-party:llvm_enable_zstd=false
++
++###############################################################################
+ # Options for continuous integration.
+ ###############################################################################
+ 
+diff -ruN --strip-trailing-cr a/utils/bazel/llvm-project-overlay/clang/BUILD.bazel b/utils/bazel/llvm-project-overlay/clang/BUILD.bazel
+--- a/utils/bazel/llvm-project-overlay/clang/BUILD.bazel
++++ b/utils/bazel/llvm-project-overlay/clang/BUILD.bazel
+@@ -1957,6 +1957,7 @@
+         ":parse",
+         ":sema",
+         ":serialization",
++        "//compiler-rt:emutls",
+         "//llvm:AllTargetsAsmParsers",
+         "//llvm:AllTargetsCodeGens",
+         "//llvm:Core",
+diff -ruN --strip-trailing-cr a/utils/bazel/llvm-project-overlay/compiler-rt/BUILD.bazel b/utils/bazel/llvm-project-overlay/compiler-rt/BUILD.bazel
+--- a/utils/bazel/llvm-project-overlay/compiler-rt/BUILD.bazel
++++ b/utils/bazel/llvm-project-overlay/compiler-rt/BUILD.bazel
+@@ -165,6 +165,15 @@
+     ],
+ )
+ 
++cc_library(
++    name = "emutls",
++    srcs = [
++        "lib/builtins/emutls.c",
++    ],
++    hdrs = glob(["lib/builtins/*.h"]),
++    linkstatic = True,
++)
++
+ filegroup(
+     name = "fuzzer_installed_hdrs",
+     srcs = glob(["include/fuzzer/*.h"]),
 diff -ruN --strip-trailing-cr a/utils/bazel/llvm-project-overlay/libc/BUILD.bazel b/utils/bazel/llvm-project-overlay/libc/BUILD.bazel
 --- a/utils/bazel/llvm-project-overlay/libc/BUILD.bazel
 +++ b/utils/bazel/llvm-project-overlay/libc/BUILD.bazel
@@ -21,23 +421,1084 @@ diff -ruN --strip-trailing-cr a/utils/bazel/llvm-project-overlay/libc/BUILD.baze
 diff -ruN --strip-trailing-cr a/utils/bazel/llvm-project-overlay/libc/test/libc_test_rules.bzl b/utils/bazel/llvm-project-overlay/libc/test/libc_test_rules.bzl
 --- a/utils/bazel/llvm-project-overlay/libc/test/libc_test_rules.bzl
 +++ b/utils/bazel/llvm-project-overlay/libc/test/libc_test_rules.bzl
-@@ -61,14 +61,19 @@
-     else:
-         deps = deps + ["//libc/test/UnitTest:LibcUnitTest"]
- 
-+    tags = kwargs.pop("tags", [])
-     if full_build:
+@@ -66,7 +66,7 @@
          copts = copts + _FULL_BUILD_COPTS
-+
-+        # Temporarily disable full_build tests (currently broken) to unblock CI.
-+        tags = tags + ["manual", "notap"]
+ 
+         # Temporarily disable full_build tests (currently broken) to unblock CI.
+-        tags = tags + ["manual", "notap"]
++        tags = tags + ["manual", "nobuildkite", "notap"]
      cc_test(
          name = name,
          local_defines = local_defines + _TEST_DEFINES + LIBC_CONFIGURE_OPTIONS,
-         deps = deps,
-         copts = copts + libc_common_copts(),
-         linkstatic = 1,
-+        tags = tags,
-         **kwargs
-     )
+diff -ruN --strip-trailing-cr a/utils/bazel/llvm-project-overlay/llvm/BUILD.bazel b/utils/bazel/llvm-project-overlay/llvm/BUILD.bazel
+--- a/utils/bazel/llvm-project-overlay/llvm/BUILD.bazel
++++ b/utils/bazel/llvm-project-overlay/llvm/BUILD.bazel
+@@ -456,6 +456,7 @@
+             "-pthread",
+             "-ldl",
+         ],
++        "@platforms//os:emscripten": [],
+         "//conditions:default": [
+             "-pthread",
+             "-ldl",
+@@ -1439,7 +1440,10 @@
+             "include/llvm/Analysis/Utils/*.h",
+         ],
+     ) + ["include/llvm-c/Analysis.h"],
+-    copts = llvm_copts + ["-ftrapping-math"],
++    copts = llvm_copts + select({
++        "@platforms//os:emscripten": [],
++        "//conditions:default": ["-ftrapping-math"],
++    }),
+     features = ["-parse_headers"],
+     textual_hdrs = glob([
+         "include/llvm/Analysis/*.def",
+@@ -4973,6 +4977,7 @@
+     # ll scripts rely on symbols from dependent
+     # libraries being resolvable.
+     linkopts = select({
++        "@platforms//os:emscripten": [],
+         "@platforms//os:macos": [],
+         "@platforms//os:windows": [],
+         "//conditions:default": [
+@@ -5548,6 +5553,7 @@
+     copts = llvm_copts,
+     # Make symbols from the standard library dynamically resolvable.
+     linkopts = select({
++        "@platforms//os:emscripten": [],
+         "@platforms//os:macos": [],
+         "@platforms//os:windows": [],
+         "//conditions:default": [
+diff -ruN --strip-trailing-cr a/utils/bazel/llvm-project-overlay/llvm/config.bzl b/utils/bazel/llvm-project-overlay/llvm/config.bzl
+--- a/utils/bazel/llvm-project-overlay/llvm/config.bzl
++++ b/utils/bazel/llvm-project-overlay/llvm/config.bzl
+@@ -46,7 +46,28 @@
+     "HAVE_UNISTD_H=1",
+ ]
  
++emscripten_defines = [
++    "LLVM_ON_UNIX=1",
++    r'LTDL_SHLIB_EXT=\".so\"',
++    r'LLVM_PLUGIN_EXT=\".so\"',
++    "LLVM_ENABLE_LLVM_EXPORT_ANNOTATIONS=1",
++    "LLVM_ENABLE_PLUGINS=0",
++    "LLVM_ENABLE_THREADS=0",
++    "HAVE_MALLINFO=1",
++    "HAVE_SETENV_R=1",
++    "HAVE_STRERROR_R=1",
++    "HAVE_SYSEXITS_H=1",
++    "HAVE_SYS_IOCTL_H=1",
++    "HAVE_UNISTD_H=1",
++]
++
++fenv_defines = [
++    "HAVE_DECL_FE_ALL_EXCEPT=1",
++    "HAVE_DECL_FE_INEXACT=1",
++]
++
+ backtrace_defines = select({
++    "@platforms//os:emscripten": [],
+     "@platforms//os:windows": [],
+     "@llvm//platforms/config:musl": [],
+     "//conditions:default": [
+@@ -60,14 +81,14 @@
+     "//conditions:default": [],
+ })
+ 
+-linux_defines = posix_defines + [
++linux_defines = posix_defines + fenv_defines + [
+     "_GNU_SOURCE",
+     "HAVE_GETAUXVAL=1",
+     "HAVE_SBRK=1",
+     "HAVE_STRUCT_STAT_ST_MTIM_TV_NSEC=1",
+ ]
+ 
+-macos_defines = posix_defines + [
++macos_defines = posix_defines + fenv_defines + [
+     "HAVE_MACH_MACH_H=1",
+     "HAVE_MALLOC_MALLOC_H=1",
+     "HAVE_MALLOC_ZONE_STATISTICS=1",
+@@ -89,12 +110,13 @@
+     # LLVM features
+     r'LTDL_SHLIB_EXT=\".dll\"',
+     r'LLVM_PLUGIN_EXT=\".dll\"',
+-]
++] + fenv_defines
+ 
+ # TODO: We should switch to platforms-based config settings to make this easier
+ # to express.
+ os_defines = select({
+-    "@platforms//os:freebsd": posix_defines,
++    "@platforms//os:emscripten": emscripten_defines,
++    "@platforms//os:freebsd": posix_defines + fenv_defines,
+     "@platforms//os:macos": macos_defines,
+     "@platforms//os:windows": win32_defines,
+     "//conditions:default": linux_defines,
+@@ -117,6 +139,7 @@
+     Label("//llvm:linux_ppc64le"): native_arch_defines("PowerPC", "powerpc64le-unknown-linux-gnu"),
+     Label("//llvm:linux_riscv64"): native_arch_defines("RISCV", "riscv64-unknown-linux-gnu"),
+     Label("//llvm:linux_s390x"): native_arch_defines("SystemZ", "systemz-unknown-linux_gnu"),
++    "@platforms//os:emscripten": native_arch_defines("WebAssembly", "wasm32-unknown-emscripten"),
+     "@platforms//os:windows": native_arch_defines("X86", "x86_64-pc-win32"),
+     "//conditions:default": native_arch_defines("X86", "x86_64-unknown-linux-gnu"),
+ }) + [
+diff -ruN --strip-trailing-cr a/utils/bazel/llvm-project-overlay/llvm/include/llvm/Config/config.h b/utils/bazel/llvm-project-overlay/llvm/include/llvm/Config/config.h
+--- a/utils/bazel/llvm-project-overlay/llvm/include/llvm/Config/config.h
++++ b/utils/bazel/llvm-project-overlay/llvm/include/llvm/Config/config.h
+@@ -56,11 +56,11 @@
+ 
+ /* Define to 1 if you have the declaration of `FE_ALL_EXCEPT', and to 0 if you
+    don't. */
+-#define HAVE_DECL_FE_ALL_EXCEPT 1
++/* HAVE_DECL_FE_ALL_EXCEPT defined in Bazel */
+ 
+ /* Define to 1 if you have the declaration of `FE_INEXACT', and to 0 if you
+    don't. */
+-#define HAVE_DECL_FE_INEXACT 1
++/* HAVE_DECL_FE_INEXACT defined in Bazel */
+ 
+ /* Define to 1 if you have the declaration of `strerror_s', and to 0 if you
+    don't. */
+diff -ruN --strip-trailing-cr a/utils/bazel/llvm-project-overlay/llvm/include/llvm/Config/llvm-config.h b/utils/bazel/llvm-project-overlay/llvm/include/llvm/Config/llvm-config.h
+--- a/utils/bazel/llvm-project-overlay/llvm/include/llvm/Config/llvm-config.h
++++ b/utils/bazel/llvm-project-overlay/llvm/include/llvm/Config/llvm-config.h
+@@ -28,7 +28,7 @@
+ /* LLVM_DEFAULT_TARGET_TRIPLE defined in Bazel */
+ 
+ /* Define if threads enabled */
+-#define LLVM_ENABLE_THREADS 1
++/* LLVM_ENABLE_THREADS defined in Bazel */
+ 
+ /* Has gcc/MSVC atomic intrinsics */
+ #define LLVM_HAS_ATOMICS 1
+diff -ruN --strip-trailing-cr a/utils/bazel/MODULE.bazel b/utils/bazel/MODULE.bazel
+--- a/utils/bazel/MODULE.bazel
++++ b/utils/bazel/MODULE.bazel
+@@ -30,6 +30,7 @@
+ bazel_dep(name = "libpfm", version = "4.13.0", repo_name = "pfm")
+ bazel_dep(name = "vulkan_headers", version = "1.4.349")
+ 
++bazel_dep(name = "emsdk", version = "6.0.2", dev_dependency = True)
+ bazel_dep(name = "llvm", version = "0.8.5", dev_dependency = True)
+ 
+ llvm_repos_extension = use_extension(":extensions.bzl", "llvm_repos_extension")
+diff -ruN --strip-trailing-cr a/utils/bazel/MODULE.bazel.lock b/utils/bazel/MODULE.bazel.lock
+--- a/utils/bazel/MODULE.bazel.lock
++++ b/utils/bazel/MODULE.bazel.lock
+@@ -81,6 +81,8 @@
+     "https://bcr.bazel.build/modules/buildozer/7.1.2/source.json": "c9028a501d2db85793a6996205c8de120944f50a0d570438fcae0457a5f9d1f8",
+     "https://bcr.bazel.build/modules/eigen/3.4.0.bcr.3/MODULE.bazel": "f6561baff0fc0035c9c1a9e2b0820de106cdb01b37bf5c81276860ccc863e5b2",
+     "https://bcr.bazel.build/modules/eigen/3.4.0.bcr.3/source.json": "a8611a2b5577929ad7e1f44ded19dab21a188125a74ac6192d21d283609f280f",
++    "https://bcr.bazel.build/modules/emsdk/6.0.2/MODULE.bazel": "4a3c4195e5f2e0056bc18bf9f8af631c4f720c3e8cea45cfb7247eacf02e27fe",
++    "https://bcr.bazel.build/modules/emsdk/6.0.2/source.json": "53111cbcb9f0971aa14da976bafbb937a1bc92a2580c8881890983cd2d289af0",
+     "https://bcr.bazel.build/modules/gawk/5.3.2.bcr.3/MODULE.bazel": "f1b7bb2dd53e8f2ef984b39485ec8a44e9076dda5c4b8efd2fb4c6a6e856a31d",
+     "https://bcr.bazel.build/modules/gawk/5.3.2.bcr.3/source.json": "ebe931bfe362e4b41e59ee00a528db6074157ff2ced92eb9e970acab2e1089c9",
+     "https://bcr.bazel.build/modules/gazelle/0.32.0/MODULE.bazel": "b499f58a5d0d3537f3cf5b76d8ada18242f64ec474d8391247438bf04f58c7b8",
+@@ -184,6 +186,7 @@
+     "https://bcr.bazel.build/modules/rules_cc/0.2.13/MODULE.bazel": "eecdd666eda6be16a8d9dc15e44b5c75133405e820f620a234acc4b1fdc5aa37",
+     "https://bcr.bazel.build/modules/rules_cc/0.2.14/MODULE.bazel": "353c99ed148887ee89c54a17d4100ae7e7e436593d104b668476019023b58df8",
+     "https://bcr.bazel.build/modules/rules_cc/0.2.15/MODULE.bazel": "6a0a4a75a57aa6dc888300d848053a58c6b12a29f89d4304e1c41448514ec6e8",
++    "https://bcr.bazel.build/modules/rules_cc/0.2.16/MODULE.bazel": "9242fa89f950c6ef7702801ab53922e99c69b02310c39fb6e62b2bd30df2a1d4",
+     "https://bcr.bazel.build/modules/rules_cc/0.2.17/MODULE.bazel": "1849602c86cb60da8613d2de887f9566a6d354a6df6d7009f9d04a14402f9a84",
+     "https://bcr.bazel.build/modules/rules_cc/0.2.18/MODULE.bazel": "4460ec36adc8f722a6a2a4ac9374cb91f2acebadaa93fc37966129afb3dece87",
+     "https://bcr.bazel.build/modules/rules_cc/0.2.19/MODULE.bazel": "d5e0f05b63273281a16654eb6b1a8742a75ec153ac8b4f0419949d6e401e46f0",
+@@ -242,6 +245,8 @@
+     "https://bcr.bazel.build/modules/rules_license/0.0.7/MODULE.bazel": "088fbeb0b6a419005b89cf93fe62d9517c0a2b8bb56af3244af65ecfe37e7d5d",
+     "https://bcr.bazel.build/modules/rules_license/1.0.0/MODULE.bazel": "a7fda60eefdf3d8c827262ba499957e4df06f659330bbe6cdbdb975b768bb65c",
+     "https://bcr.bazel.build/modules/rules_license/1.0.0/source.json": "a52c89e54cc311196e478f8382df91c15f7a2bfdf4c6cd0e2675cc2ff0b56efb",
++    "https://bcr.bazel.build/modules/rules_nodejs/6.7.3/MODULE.bazel": "c22a48b2a0dbf05a9dc5f83837bbc24c226c1f6e618de3c3a610044c9f336056",
++    "https://bcr.bazel.build/modules/rules_nodejs/6.7.3/source.json": "a3f966f4415a8a6545e560ee5449eac95cc633f96429d08e87c87775c72f5e09",
+     "https://bcr.bazel.build/modules/rules_pkg/0.7.0/MODULE.bazel": "df99f03fc7934a4737122518bb87e667e62d780b610910f0447665a7e2be62dc",
+     "https://bcr.bazel.build/modules/rules_pkg/1.0.1/MODULE.bazel": "5b1df97dbc29623bccdf2b0dcd0f5cb08e2f2c9050aab1092fd39a41e82686ff",
+     "https://bcr.bazel.build/modules/rules_pkg/1.0.1/source.json": "bd82e5d7b9ce2d31e380dd9f50c111d678c3bdaca190cb76b0e1c71b05e1ba8a",
+@@ -268,7 +273,8 @@
+     "https://bcr.bazel.build/modules/rules_python/1.6.0/MODULE.bazel": "7e04ad8f8d5bea40451cf80b1bd8262552aa73f841415d20db96b7241bd027d8",
+     "https://bcr.bazel.build/modules/rules_python/1.7.0/MODULE.bazel": "d01f995ecd137abf30238ad9ce97f8fc3ac57289c8b24bd0bf53324d937a14f8",
+     "https://bcr.bazel.build/modules/rules_python/1.8.0/MODULE.bazel": "c151c025dbcc93d8f62ab68ecc313c9176a868a0e6386981bf2a12aec77cbe7b",
+-    "https://bcr.bazel.build/modules/rules_python/1.8.0/source.json": "356397eed5b46971d8c585c92098d70495078a80bf18bebcb4209f44b495f3e6",
++    "https://bcr.bazel.build/modules/rules_python/1.8.4/MODULE.bazel": "33e3971e66161a3e955f7a0d411a8d1f291c4ce4c561851512466f3c77ff8ece",
++    "https://bcr.bazel.build/modules/rules_python/1.8.4/source.json": "9fbc0e57bae52cddcc3831d668bce87a47e0c655104a85098d4459dd9a3b0a10",
+     "https://bcr.bazel.build/modules/rules_robolectric/4.14.1.2/MODULE.bazel": "d44fec647d0aeb67b9f3b980cf68ba634976f3ae7ccd6c07d790b59b87a4f251",
+     "https://bcr.bazel.build/modules/rules_robolectric/4.14.1.2/source.json": "37c10335f2361c337c5c1f34ed36d2da70534c23088062b33a8bdaab68aa9dea",
+     "https://bcr.bazel.build/modules/rules_rust/0.69.0/MODULE.bazel": "4326fec48f2fef0d514de46346f7f77e200c82936dd08b91c9ef039fbdad5c10",
+@@ -348,9 +354,142 @@
+         ]
+       }
+     },
++    "@@emsdk+//:emscripten_cache.bzl%emscripten_cache": {
++      "general": {
++        "bzlTransitiveDigest": "GMscy7c4sDbvbf9dMSrtUvyJJBuxYpJBT/Lg+2ob6dk=",
++        "usagesDigest": "Id/C4z1d3MUlKZgmBOQiLi2E7NQZTGsd4WV2wSMzmo4=",
++        "recordedFileInputs": {},
++        "recordedDirentsInputs": {},
++        "envVariables": {},
++        "generatedRepoSpecs": {
++          "emscripten_cache": {
++            "repoRuleId": "@@emsdk+//:emscripten_cache.bzl%_emscripten_cache_repository",
++            "attributes": {
++              "configuration": [],
++              "targets": [],
++              "prebuilt_cache_url": "",
++              "prebuilt_cache_sha256": "",
++              "prebuilt_cache_strip_prefix": ""
++            }
++          }
++        },
++        "recordedRepoMappingEntries": []
++      }
++    },
++    "@@emsdk+//:emscripten_deps.bzl%emscripten_deps": {
++      "general": {
++        "bzlTransitiveDigest": "ZT33Pf8H8gJ/X4gT3oXVPzuAO0H2y1HtHMPOfILGV0M=",
++        "usagesDigest": "4SlUap0Npa9PDUrLoi0uZ7CRDp9h/YbWi0UuidttuWc=",
++        "recordedFileInputs": {},
++        "recordedDirentsInputs": {},
++        "envVariables": {},
++        "generatedRepoSpecs": {
++          "emscripten_bin_linux": {
++            "repoRuleId": "@@bazel_tools//tools/build_defs/repo:http.bzl%http_archive",
++            "attributes": {
++              "build_file_content": "\npackage(default_visibility = ['//visibility:public'])\n\nfilegroup(\n    name = \"all\",\n    srcs = glob([\"**\"]),\n)\n\nfilegroup(\n    name = \"includes\",\n    srcs = glob([\n        \"emscripten/cache/sysroot/include/c++/v1/**\",\n        \"emscripten/cache/sysroot/include/compat/**\",\n        \"emscripten/cache/sysroot/include/**\",\n        \"lib/clang/**/include/**\",\n    ]),\n)\n\nfilegroup(\n    name = \"builtin_cache\",\n    srcs = glob([\n        \"emscripten/cache/**\",\n    ]),\n)\n\nfilegroup(\n    name = \"emcc_common\",\n    srcs = [\n        \"emscripten/emcc.py\",\n        \"emscripten/embuilder.py\",\n        \"emscripten/emscripten-version.txt\",\n        \"emscripten/cache/sysroot_install.stamp\",\n        \"emscripten/src/settings.js\",\n        \"emscripten/src/settings_internal.js\",\n    ] + glob(\n        include = [\n            \"emscripten/third_party/**\",\n            \"emscripten/tools/**\",\n        ],\n        exclude = [\n            \"**/__pycache__/**\",\n        ],\n    ),\n)\n\nfilegroup(\n    name = \"compiler_files\",\n    srcs = [\n        \"bin/clang\",\n        \"bin/clang++\",\n        \":emcc_common\",\n        \":includes\",\n    ],\n)\n\nfilegroup(\n    name = \"linker_files\",\n    srcs = [\n        \"bin/clang\",\n        \"bin/llvm-ar\",\n        \"bin/llvm-dwarfdump\",\n        \"bin/llvm-nm\",\n        \"bin/llvm-objcopy\",\n        \"bin/wasm-ctor-eval\",\n        \"bin/wasm-emscripten-finalize\",\n        \"bin/wasm-ld\",\n        \"bin/wasm-metadce\",\n        \"bin/wasm-opt\",\n        \"bin/wasm-split\",\n        \"bin/wasm2js\",\n        \":emcc_common\",\n    ] + glob(\n        include = [\n            \"emscripten/cache/sysroot/lib/**\",\n            \"emscripten/node_modules/**\",\n            \"emscripten/src/**\",\n        ],\n    ),\n)\n\nfilegroup(\n    name = \"ar_files\",\n    srcs = [\n        \"bin/llvm-ar\",\n        \"emscripten/emar.py\",\n        \"emscripten/emscripten-version.txt\",\n        \"emscripten/src/settings.js\",\n        \"emscripten/src/settings_internal.js\",\n    ] + glob(\n        include = [\n            \"emscripten/tools/**\",\n        ],\n        exclude = [\n            \"**/__pycache__/**\",\n        ],\n    ),\n)\n",
++              "sha256": "d574428df9ecf00790e28636bdc47027432737c31621b18cdb418123afda4ac1",
++              "strip_prefix": "install",
++              "type": "tar.xz",
++              "url": "https://storage.googleapis.com/webassembly/emscripten-releases-builds/linux/004876f1984e18a9eb0736c5ca417ac86d386fb8/wasm-binaries.tar.xz"
++            }
++          },
++          "emscripten_bin_linux_arm64": {
++            "repoRuleId": "@@bazel_tools//tools/build_defs/repo:http.bzl%http_archive",
++            "attributes": {
++              "build_file_content": "\npackage(default_visibility = ['//visibility:public'])\n\nfilegroup(\n    name = \"all\",\n    srcs = glob([\"**\"]),\n)\n\nfilegroup(\n    name = \"includes\",\n    srcs = glob([\n        \"emscripten/cache/sysroot/include/c++/v1/**\",\n        \"emscripten/cache/sysroot/include/compat/**\",\n        \"emscripten/cache/sysroot/include/**\",\n        \"lib/clang/**/include/**\",\n    ]),\n)\n\nfilegroup(\n    name = \"builtin_cache\",\n    srcs = glob([\n        \"emscripten/cache/**\",\n    ]),\n)\n\nfilegroup(\n    name = \"emcc_common\",\n    srcs = [\n        \"emscripten/emcc.py\",\n        \"emscripten/embuilder.py\",\n        \"emscripten/emscripten-version.txt\",\n        \"emscripten/cache/sysroot_install.stamp\",\n        \"emscripten/src/settings.js\",\n        \"emscripten/src/settings_internal.js\",\n    ] + glob(\n        include = [\n            \"emscripten/third_party/**\",\n            \"emscripten/tools/**\",\n        ],\n        exclude = [\n            \"**/__pycache__/**\",\n        ],\n    ),\n)\n\nfilegroup(\n    name = \"compiler_files\",\n    srcs = [\n        \"bin/clang\",\n        \"bin/clang++\",\n        \":emcc_common\",\n        \":includes\",\n    ],\n)\n\nfilegroup(\n    name = \"linker_files\",\n    srcs = [\n        \"bin/clang\",\n        \"bin/llvm-ar\",\n        \"bin/llvm-dwarfdump\",\n        \"bin/llvm-nm\",\n        \"bin/llvm-objcopy\",\n        \"bin/wasm-ctor-eval\",\n        \"bin/wasm-emscripten-finalize\",\n        \"bin/wasm-ld\",\n        \"bin/wasm-metadce\",\n        \"bin/wasm-opt\",\n        \"bin/wasm-split\",\n        \"bin/wasm2js\",\n        \":emcc_common\",\n    ] + glob(\n        include = [\n            \"emscripten/cache/sysroot/lib/**\",\n            \"emscripten/node_modules/**\",\n            \"emscripten/src/**\",\n        ],\n    ),\n)\n\nfilegroup(\n    name = \"ar_files\",\n    srcs = [\n        \"bin/llvm-ar\",\n        \"emscripten/emar.py\",\n        \"emscripten/emscripten-version.txt\",\n        \"emscripten/src/settings.js\",\n        \"emscripten/src/settings_internal.js\",\n    ] + glob(\n        include = [\n            \"emscripten/tools/**\",\n        ],\n        exclude = [\n            \"**/__pycache__/**\",\n        ],\n    ),\n)\n",
++              "sha256": "d74803ef563511b9cc1e5cde5016f06d161ffd2b6223135a8aeeef44194594e7",
++              "strip_prefix": "install",
++              "type": "tar.xz",
++              "url": "https://storage.googleapis.com/webassembly/emscripten-releases-builds/linux/004876f1984e18a9eb0736c5ca417ac86d386fb8/wasm-binaries-arm64.tar.xz"
++            }
++          },
++          "emscripten_bin_mac": {
++            "repoRuleId": "@@bazel_tools//tools/build_defs/repo:http.bzl%http_archive",
++            "attributes": {
++              "build_file_content": "\npackage(default_visibility = ['//visibility:public'])\n\nfilegroup(\n    name = \"all\",\n    srcs = glob([\"**\"]),\n)\n\nfilegroup(\n    name = \"includes\",\n    srcs = glob([\n        \"emscripten/cache/sysroot/include/c++/v1/**\",\n        \"emscripten/cache/sysroot/include/compat/**\",\n        \"emscripten/cache/sysroot/include/**\",\n        \"lib/clang/**/include/**\",\n    ]),\n)\n\nfilegroup(\n    name = \"builtin_cache\",\n    srcs = glob([\n        \"emscripten/cache/**\",\n    ]),\n)\n\nfilegroup(\n    name = \"emcc_common\",\n    srcs = [\n        \"emscripten/emcc.py\",\n        \"emscripten/embuilder.py\",\n        \"emscripten/emscripten-version.txt\",\n        \"emscripten/cache/sysroot_install.stamp\",\n        \"emscripten/src/settings.js\",\n        \"emscripten/src/settings_internal.js\",\n    ] + glob(\n        include = [\n            \"emscripten/third_party/**\",\n            \"emscripten/tools/**\",\n        ],\n        exclude = [\n            \"**/__pycache__/**\",\n        ],\n    ),\n)\n\nfilegroup(\n    name = \"compiler_files\",\n    srcs = [\n        \"bin/clang\",\n        \"bin/clang++\",\n        \":emcc_common\",\n        \":includes\",\n    ],\n)\n\nfilegroup(\n    name = \"linker_files\",\n    srcs = [\n        \"bin/clang\",\n        \"bin/llvm-ar\",\n        \"bin/llvm-dwarfdump\",\n        \"bin/llvm-nm\",\n        \"bin/llvm-objcopy\",\n        \"bin/wasm-ctor-eval\",\n        \"bin/wasm-emscripten-finalize\",\n        \"bin/wasm-ld\",\n        \"bin/wasm-metadce\",\n        \"bin/wasm-opt\",\n        \"bin/wasm-split\",\n        \"bin/wasm2js\",\n        \":emcc_common\",\n    ] + glob(\n        include = [\n            \"emscripten/cache/sysroot/lib/**\",\n            \"emscripten/node_modules/**\",\n            \"emscripten/src/**\",\n        ],\n    ),\n)\n\nfilegroup(\n    name = \"ar_files\",\n    srcs = [\n        \"bin/llvm-ar\",\n        \"emscripten/emar.py\",\n        \"emscripten/emscripten-version.txt\",\n        \"emscripten/src/settings.js\",\n        \"emscripten/src/settings_internal.js\",\n    ] + glob(\n        include = [\n            \"emscripten/tools/**\",\n        ],\n        exclude = [\n            \"**/__pycache__/**\",\n        ],\n    ),\n)\n",
++              "sha256": "356f36ba04a54edb029c658dd1b547c5c8a8f3c166b09654c1efcb9cf7bf8a57",
++              "strip_prefix": "install",
++              "type": "tar.xz",
++              "url": "https://storage.googleapis.com/webassembly/emscripten-releases-builds/mac/004876f1984e18a9eb0736c5ca417ac86d386fb8/wasm-binaries.tar.xz"
++            }
++          },
++          "emscripten_bin_mac_arm64": {
++            "repoRuleId": "@@bazel_tools//tools/build_defs/repo:http.bzl%http_archive",
++            "attributes": {
++              "build_file_content": "\npackage(default_visibility = ['//visibility:public'])\n\nfilegroup(\n    name = \"all\",\n    srcs = glob([\"**\"]),\n)\n\nfilegroup(\n    name = \"includes\",\n    srcs = glob([\n        \"emscripten/cache/sysroot/include/c++/v1/**\",\n        \"emscripten/cache/sysroot/include/compat/**\",\n        \"emscripten/cache/sysroot/include/**\",\n        \"lib/clang/**/include/**\",\n    ]),\n)\n\nfilegroup(\n    name = \"builtin_cache\",\n    srcs = glob([\n        \"emscripten/cache/**\",\n    ]),\n)\n\nfilegroup(\n    name = \"emcc_common\",\n    srcs = [\n        \"emscripten/emcc.py\",\n        \"emscripten/embuilder.py\",\n        \"emscripten/emscripten-version.txt\",\n        \"emscripten/cache/sysroot_install.stamp\",\n        \"emscripten/src/settings.js\",\n        \"emscripten/src/settings_internal.js\",\n    ] + glob(\n        include = [\n            \"emscripten/third_party/**\",\n            \"emscripten/tools/**\",\n        ],\n        exclude = [\n            \"**/__pycache__/**\",\n        ],\n    ),\n)\n\nfilegroup(\n    name = \"compiler_files\",\n    srcs = [\n        \"bin/clang\",\n        \"bin/clang++\",\n        \":emcc_common\",\n        \":includes\",\n    ],\n)\n\nfilegroup(\n    name = \"linker_files\",\n    srcs = [\n        \"bin/clang\",\n        \"bin/llvm-ar\",\n        \"bin/llvm-dwarfdump\",\n        \"bin/llvm-nm\",\n        \"bin/llvm-objcopy\",\n        \"bin/wasm-ctor-eval\",\n        \"bin/wasm-emscripten-finalize\",\n        \"bin/wasm-ld\",\n        \"bin/wasm-metadce\",\n        \"bin/wasm-opt\",\n        \"bin/wasm-split\",\n        \"bin/wasm2js\",\n        \":emcc_common\",\n    ] + glob(\n        include = [\n            \"emscripten/cache/sysroot/lib/**\",\n            \"emscripten/node_modules/**\",\n            \"emscripten/src/**\",\n        ],\n    ),\n)\n\nfilegroup(\n    name = \"ar_files\",\n    srcs = [\n        \"bin/llvm-ar\",\n        \"emscripten/emar.py\",\n        \"emscripten/emscripten-version.txt\",\n        \"emscripten/src/settings.js\",\n        \"emscripten/src/settings_internal.js\",\n    ] + glob(\n        include = [\n            \"emscripten/tools/**\",\n        ],\n        exclude = [\n            \"**/__pycache__/**\",\n        ],\n    ),\n)\n",
++              "sha256": "ded3bb783e7aa3dda576955dd0aa3a71dd21789e42befb63ee14f7d9f9b6aa32",
++              "strip_prefix": "install",
++              "type": "tar.xz",
++              "url": "https://storage.googleapis.com/webassembly/emscripten-releases-builds/mac/004876f1984e18a9eb0736c5ca417ac86d386fb8/wasm-binaries-arm64.tar.xz"
++            }
++          },
++          "emscripten_bin_win": {
++            "repoRuleId": "@@bazel_tools//tools/build_defs/repo:http.bzl%http_archive",
++            "attributes": {
++              "build_file_content": "\npackage(default_visibility = ['//visibility:public'])\n\nfilegroup(\n    name = \"all\",\n    srcs = glob([\"**\"]),\n)\n\nfilegroup(\n    name = \"includes\",\n    srcs = glob([\n        \"emscripten/cache/sysroot/include/c++/v1/**\",\n        \"emscripten/cache/sysroot/include/compat/**\",\n        \"emscripten/cache/sysroot/include/**\",\n        \"lib/clang/**/include/**\",\n    ]),\n)\n\nfilegroup(\n    name = \"builtin_cache\",\n    srcs = glob([\n        \"emscripten/cache/**\",\n    ]),\n)\n\nfilegroup(\n    name = \"emcc_common\",\n    srcs = [\n        \"emscripten/emcc.py\",\n        \"emscripten/embuilder.py\",\n        \"emscripten/emscripten-version.txt\",\n        \"emscripten/cache/sysroot_install.stamp\",\n        \"emscripten/src/settings.js\",\n        \"emscripten/src/settings_internal.js\",\n    ] + glob(\n        include = [\n            \"emscripten/third_party/**\",\n            \"emscripten/tools/**\",\n        ],\n        exclude = [\n            \"**/__pycache__/**\",\n        ],\n    ),\n)\n\nfilegroup(\n    name = \"compiler_files\",\n    srcs = [\n        \"bin/clang.exe\",\n        \"bin/clang++.exe\",\n        \":emcc_common\",\n        \":includes\",\n    ],\n)\n\nfilegroup(\n    name = \"linker_files\",\n    srcs = [\n        \"bin/clang.exe\",\n        \"bin/llvm-ar.exe\",\n        \"bin/llvm-dwarfdump.exe\",\n        \"bin/llvm-nm.exe\",\n        \"bin/llvm-objcopy.exe\",\n        \"bin/wasm-ctor-eval.exe\",\n        \"bin/wasm-emscripten-finalize.exe\",\n        \"bin/wasm-ld.exe\",\n        \"bin/wasm-metadce.exe\",\n        \"bin/wasm-opt.exe\",\n        \"bin/wasm-split.exe\",\n        \"bin/wasm2js.exe\",\n        \":emcc_common\",\n    ] + glob(\n        include = [\n            \"emscripten/cache/sysroot/lib/**\",\n            \"emscripten/node_modules/**\",\n            \"emscripten/src/**\",\n        ],\n    ),\n)\n\nfilegroup(\n    name = \"ar_files\",\n    srcs = [\n        \"bin/llvm-ar.exe\",\n        \"emscripten/emar.py\",\n        \"emscripten/emscripten-version.txt\",\n        \"emscripten/src/settings.js\",\n        \"emscripten/src/settings_internal.js\",\n    ] + glob(\n        include = [\n            \"emscripten/tools/**\",\n        ],\n        exclude = [\n            \"**/__pycache__/**\",\n        ],\n    ),\n)\n",
++              "sha256": "e5f9250a9cf4ff6ed16d57d6b5e177c844067381d31cd0c1a607c1ee1d2ba088",
++              "strip_prefix": "install",
++              "type": "zip",
++              "url": "https://storage.googleapis.com/webassembly/emscripten-releases-builds/win/004876f1984e18a9eb0736c5ca417ac86d386fb8/wasm-binaries.zip"
++            }
++          }
++        },
++        "recordedRepoMappingEntries": [
++          [
++            "emsdk+",
++            "bazel_tools",
++            "bazel_tools"
++          ],
++          [
++            "emsdk+",
++            "rules_cc",
++            "rules_cc+"
++          ],
++          [
++            "rules_cc+",
++            "bazel_tools",
++            "bazel_tools"
++          ],
++          [
++            "rules_cc+",
++            "cc_compatibility_proxy",
++            "rules_cc++compatibility_proxy+cc_compatibility_proxy"
++          ],
++          [
++            "rules_cc+",
++            "rules_cc",
++            "rules_cc+"
++          ],
++          [
++            "rules_cc++compatibility_proxy+cc_compatibility_proxy",
++            "rules_cc",
++            "rules_cc+"
++          ]
++        ]
++      }
++    },
++    "@@protobuf+//python/dist:system_python.bzl%system_python_extension": {
++      "general": {
++        "bzlTransitiveDigest": "qh0n9IrXU/xS94wxKQrG1J63zrLkA1Wy2Y3BQxptPcI=",
++        "usagesDigest": "tCi55FyqtOJ2jXh9vcjrHCl4ov3kpWiwKl103nA9BOI=",
++        "recordedFileInputs": {},
++        "recordedDirentsInputs": {},
++        "envVariables": {},
++        "generatedRepoSpecs": {
++          "system_python": {
++            "repoRuleId": "@@protobuf+//python/dist:system_python.bzl%system_python",
++            "attributes": {
++              "minimum_python_version": "3.9"
++            }
++          }
++        },
++        "recordedRepoMappingEntries": []
++      }
++    },
+     "@@pybind11_bazel+//:internal_configure.bzl%internal_configure_extension": {
+       "general": {
+-        "bzlTransitiveDigest": "NFQjcZF+fAvf5fDH+pqsx4JrfzP9PuHBz6S6ZutIbnw=",
++        "bzlTransitiveDigest": "7zBsfo5dyMqKT23rXrvWqJMx0AugwL6NyirkmvzKcqU=",
+         "usagesDigest": "D1r3lfzMuUBFxgG8V6o0bQTLMk3GkaGOaPzw53wrwyw=",
+         "recordedFileInputs": {
+           "@@pybind11_bazel+//MODULE.bazel": "e6f4c20442eaa7c90d7190d8dc539d0ab422f95c65a57cc59562170c58ae3d34"
+@@ -380,8 +519,8 @@
+     },
+     "@@rules_android+//bzlmod_extensions:apksig.bzl%apksig_extension": {
+       "general": {
+-        "bzlTransitiveDigest": "By9qVNN7G4oL1vYOJXye7Dp/CbR2ar9oxAW8WXAVcVw=",
+-        "usagesDigest": "xq6OVkELeJvOgYo3oY/sUBsGFbcqdV+9BYiNgSPV/po=",
++        "bzlTransitiveDigest": "15xx/lo4VYL9KdLW0Cc94ebALMF07+XZH8dZcVU8/LI=",
++        "usagesDigest": "S8lLnnZxdeYUYq3kIGhVMk0wQ9Fd6elmCskvn+SL6iw=",
+         "recordedFileInputs": {},
+         "recordedDirentsInputs": {},
+         "envVariables": {},
+@@ -389,7 +528,10 @@
+           "apksig": {
+             "repoRuleId": "@@bazel_tools//tools/build_defs/repo:http.bzl%http_archive",
+             "attributes": {
+-              "url": "https://android.googlesource.com/platform/tools/apksig/+archive/24e3075e68ebe17c0b529bb24bfda819db5e2f3b.tar.gz",
++              "urls": [
++                "https://mirror.bazel.build/android.googlesource.com/platform/tools/apksig/+archive/24e3075e68ebe17c0b529bb24bfda819db5e2f3b.tar.gz"
++              ],
++              "sha256": "12e44fdbd219c5e1cc62099c2a01d775957603d2d4f693f8285f9d95d9a04e77",
+               "build_file": "@@rules_android+//bzlmod_extensions:apksig.BUILD"
+             }
+           }
+@@ -405,8 +547,8 @@
+     },
+     "@@rules_android+//bzlmod_extensions:com_android_dex.bzl%com_android_dex_extension": {
+       "general": {
+-        "bzlTransitiveDigest": "rvWbJQc8jInfIAaXIMhSOqUlwM9HVeLey6q0ISvg08Y=",
+-        "usagesDigest": "toF8IFMu98H/VU2p1sfVC5fVXVYJunpbbmtM6tOsQXY=",
++        "bzlTransitiveDigest": "K0jbWcRwfM8njdIXNRjRvdApKmBfKeFLScDH+5LSSE0=",
++        "usagesDigest": "0hluQmaWiWak6sVMP5L4wXhNyIwv9fw0y5JJ8lnPb1c=",
+         "recordedFileInputs": {},
+         "recordedDirentsInputs": {},
+         "envVariables": {},
+@@ -414,8 +556,11 @@
+           "com_android_dex": {
+             "repoRuleId": "@@bazel_tools//tools/build_defs/repo:http.bzl%http_archive",
+             "attributes": {
+-              "url": "https://android.googlesource.com/platform/dalvik/+archive/5a81c499a569731e2395f7c8d13c0e0d4e17a2b6.tar.gz",
+-              "build_file": "@@rules_android+//bzlmod_extensions:com_android_dex.BUILD"
++              "urls": [
++                "https://mirror.bazel.build/android.googlesource.com/platform/dalvik/+archive/5a81c499a569731e2395f7c8d13c0e0d4e17a2b6.tar.gz"
++              ],
++              "build_file": "@@rules_android+//bzlmod_extensions:com_android_dex.BUILD",
++              "sha256": "86b4848c038bf687fadc812239cb01fb8d1d15cef3125b480a0448360992b95d"
+             }
+           }
+         },
+@@ -444,10 +589,144 @@
+         "recordedRepoMappingEntries": []
+       }
+     },
++    "@@rules_nodejs+//nodejs:extensions.bzl%node": {
++      "general": {
++        "bzlTransitiveDigest": "4pUxCNc22K4I+6+4Nxu52Hur12tFRfa1JMsN5mdDv60=",
++        "usagesDigest": "dqOjZvNvw6/DVBPAiKrXJNA0Tx4GT4Vj/VdUyGMpDL8=",
++        "recordedFileInputs": {},
++        "recordedDirentsInputs": {},
++        "envVariables": {},
++        "generatedRepoSpecs": {
++          "nodejs_linux_amd64": {
++            "repoRuleId": "@@rules_nodejs+//nodejs:repositories.bzl%_nodejs_repositories",
++            "attributes": {
++              "node_download_auth": {},
++              "node_repositories": {},
++              "node_urls": [
++                "https://nodejs.org/dist/v{version}/{filename}"
++              ],
++              "node_version": "20.18.0",
++              "include_headers": false,
++              "platform": "linux_amd64"
++            }
++          },
++          "nodejs_linux_arm64": {
++            "repoRuleId": "@@rules_nodejs+//nodejs:repositories.bzl%_nodejs_repositories",
++            "attributes": {
++              "node_download_auth": {},
++              "node_repositories": {},
++              "node_urls": [
++                "https://nodejs.org/dist/v{version}/{filename}"
++              ],
++              "node_version": "20.18.0",
++              "include_headers": false,
++              "platform": "linux_arm64"
++            }
++          },
++          "nodejs_linux_s390x": {
++            "repoRuleId": "@@rules_nodejs+//nodejs:repositories.bzl%_nodejs_repositories",
++            "attributes": {
++              "node_download_auth": {},
++              "node_repositories": {},
++              "node_urls": [
++                "https://nodejs.org/dist/v{version}/{filename}"
++              ],
++              "node_version": "20.18.0",
++              "include_headers": false,
++              "platform": "linux_s390x"
++            }
++          },
++          "nodejs_linux_ppc64le": {
++            "repoRuleId": "@@rules_nodejs+//nodejs:repositories.bzl%_nodejs_repositories",
++            "attributes": {
++              "node_download_auth": {},
++              "node_repositories": {},
++              "node_urls": [
++                "https://nodejs.org/dist/v{version}/{filename}"
++              ],
++              "node_version": "20.18.0",
++              "include_headers": false,
++              "platform": "linux_ppc64le"
++            }
++          },
++          "nodejs_darwin_amd64": {
++            "repoRuleId": "@@rules_nodejs+//nodejs:repositories.bzl%_nodejs_repositories",
++            "attributes": {
++              "node_download_auth": {},
++              "node_repositories": {},
++              "node_urls": [
++                "https://nodejs.org/dist/v{version}/{filename}"
++              ],
++              "node_version": "20.18.0",
++              "include_headers": false,
++              "platform": "darwin_amd64"
++            }
++          },
++          "nodejs_darwin_arm64": {
++            "repoRuleId": "@@rules_nodejs+//nodejs:repositories.bzl%_nodejs_repositories",
++            "attributes": {
++              "node_download_auth": {},
++              "node_repositories": {},
++              "node_urls": [
++                "https://nodejs.org/dist/v{version}/{filename}"
++              ],
++              "node_version": "20.18.0",
++              "include_headers": false,
++              "platform": "darwin_arm64"
++            }
++          },
++          "nodejs_windows_amd64": {
++            "repoRuleId": "@@rules_nodejs+//nodejs:repositories.bzl%_nodejs_repositories",
++            "attributes": {
++              "node_download_auth": {},
++              "node_repositories": {},
++              "node_urls": [
++                "https://nodejs.org/dist/v{version}/{filename}"
++              ],
++              "node_version": "20.18.0",
++              "include_headers": false,
++              "platform": "windows_amd64"
++            }
++          },
++          "nodejs_windows_arm64": {
++            "repoRuleId": "@@rules_nodejs+//nodejs:repositories.bzl%_nodejs_repositories",
++            "attributes": {
++              "node_download_auth": {},
++              "node_repositories": {},
++              "node_urls": [
++                "https://nodejs.org/dist/v{version}/{filename}"
++              ],
++              "node_version": "20.18.0",
++              "include_headers": false,
++              "platform": "windows_arm64"
++            }
++          },
++          "nodejs": {
++            "repoRuleId": "@@rules_nodejs+//nodejs/private:nodejs_repo_host_os_alias.bzl%nodejs_repo_host_os_alias",
++            "attributes": {
++              "user_node_repository_name": "nodejs"
++            }
++          },
++          "nodejs_host": {
++            "repoRuleId": "@@rules_nodejs+//nodejs/private:nodejs_repo_host_os_alias.bzl%nodejs_repo_host_os_alias",
++            "attributes": {
++              "user_node_repository_name": "nodejs"
++            }
++          },
++          "nodejs_toolchains": {
++            "repoRuleId": "@@rules_nodejs+//nodejs/private:nodejs_toolchains_repo.bzl%nodejs_toolchains_repo",
++            "attributes": {
++              "user_node_repository_name": "nodejs"
++            }
++          }
++        },
++        "recordedRepoMappingEntries": []
++      }
++    },
+     "@@rules_python+//python/extensions:config.bzl%config": {
+       "general": {
+         "bzlTransitiveDigest": "EcMcbtKZvYmd5Mi1Fpg4EeBBztLHEE5tjO5tLDBYDuU=",
+-        "usagesDigest": "EocbSr4I3/Shk4QaFool8b8navUiUFqgzF9bOaaYfFk=",
++        "usagesDigest": "p2al+dDKI5UlCyNvheMVynbWSGbdiji/jMz53fMNfJA=",
+         "recordedFileInputs": {},
+         "recordedDirentsInputs": {},
+         "envVariables": {},
+@@ -682,7 +961,7 @@
+     "@@rules_python+//python/uv:uv.bzl%uv": {
+       "general": {
+         "bzlTransitiveDigest": "ijW9KS7qsIY+yBVvJ+Nr1mzwQox09j13DnE3iIwaeTM=",
+-        "usagesDigest": "yXvWfXAzpBeW71mWgwU3AqAzXX/dFACnx12eYvBsJ8w=",
++        "usagesDigest": "/HRt5Hw/vpDr9CDrKEPjeDIjxo4307VLxMu8BNAEDWA=",
+         "recordedFileInputs": {},
+         "recordedDirentsInputs": {},
+         "envVariables": {},
+@@ -719,6 +998,533 @@
+           ]
+         ]
+       }
++    },
++    "@@rules_rust+//crate_universe:extension.bzl%crate": {
++      "general": {
++        "bzlTransitiveDigest": "VVbU93QvGxFMzb9BcpYTYyyYDpj10Ya6Zm5RH1JEUhw=",
++        "usagesDigest": "EuFUqVKVHF263jHTWOHXs4tFACdRNVOhwpoytdk19bs=",
++        "recordedFileInputs": {},
++        "recordedDirentsInputs": {},
++        "envVariables": {
++          "CARGO_BAZEL_DEBUG": null,
++          "CARGO_BAZEL_GENERATOR_SHA256": null,
++          "CARGO_BAZEL_GENERATOR_URL": null,
++          "CARGO_BAZEL_ISOLATED": null,
++          "CARGO_BAZEL_REPIN": null,
++          "CARGO_BAZEL_REPIN_ONLY": null,
++          "CARGO_BAZEL_TIMEOUT": null,
++          "REPIN": null
++        },
++        "generatedRepoSpecs": {
++          "crates": {
++            "repoRuleId": "@@rules_rust+//crate_universe:extensions.bzl%_generate_repo",
++            "attributes": {
++              "contents": {
++                "BUILD.bazel": "###############################################################################\n# @generated\n# DO NOT MODIFY: This file is auto-generated by a crate_universe tool. To \n# regenerate this file, run the following:\n#\n#     bazel mod show_repo 'protobuf'\n###############################################################################\n\npackage(default_visibility = [\"//visibility:public\"])\n\nexports_files(\n    [\n        \"cargo-bazel.json\",\n        \"crates.bzl\",\n        \"defs.bzl\",\n    ] + glob(\n        allow_empty = True,\n        include = [\"*.bazel\"],\n    ),\n)\n\nfilegroup(\n    name = \"srcs\",\n    srcs = glob(\n        allow_empty = True,\n        include = [\n            \"*.bazel\",\n            \"*.bzl\",\n        ],\n    ),\n)\n\n# Workspace Member Dependencies\nalias(\n    name = \"googletest-0.14.3\",\n    actual = \"@crates__googletest-0.14.3//:googletest\",\n    tags = [\"manual\"],\n)\n\nalias(\n    name = \"googletest\",\n    actual = \"@crates__googletest-0.14.3//:googletest\",\n    tags = [\"manual\"],\n)\n\nalias(\n    name = \"linkme-0.3.37\",\n    actual = \"@crates__linkme-0.3.37//:linkme\",\n    tags = [\"manual\"],\n)\n\nalias(\n    name = \"linkme\",\n    actual = \"@crates__linkme-0.3.37//:linkme\",\n    tags = [\"manual\"],\n)\n\nalias(\n    name = \"paste-1.0.15\",\n    actual = \"@crates__paste-1.0.15//:paste\",\n    tags = [\"manual\"],\n)\n\nalias(\n    name = \"paste\",\n    actual = \"@crates__paste-1.0.15//:paste\",\n    tags = [\"manual\"],\n)\n\nalias(\n    name = \"quote-1.0.47\",\n    actual = \"@crates__quote-1.0.47//:quote\",\n    tags = [\"manual\"],\n)\n\nalias(\n    name = \"quote\",\n    actual = \"@crates__quote-1.0.47//:quote\",\n    tags = [\"manual\"],\n)\n\nalias(\n    name = \"syn-3.0.3\",\n    actual = \"@crates__syn-3.0.3//:syn\",\n    tags = [\"manual\"],\n)\n\nalias(\n    name = \"syn\",\n    actual = \"@crates__syn-3.0.3//:syn\",\n    tags = [\"manual\"],\n)\n",
++                "alias_rules.bzl": "\"\"\"Alias that transitions its target to `compilation_mode=opt`.  Use `transition_alias=\"opt\"` to enable.\"\"\"\n\nload(\"@rules_cc//cc:defs.bzl\", \"CcInfo\")\nload(\"@rules_rust//rust:rust_common.bzl\", \"COMMON_PROVIDERS\")\n\ndef _transition_alias_impl(ctx):\n    # `ctx.attr.actual` is a list of 1 item due to the transition\n    providers = [ctx.attr.actual[0][provider] for provider in COMMON_PROVIDERS]\n    if CcInfo in ctx.attr.actual[0]:\n        providers.append(ctx.attr.actual[0][CcInfo])\n    return providers\n\ndef _change_compilation_mode(compilation_mode):\n    def _change_compilation_mode_impl(_settings, _attr):\n        return {\n            \"//command_line_option:compilation_mode\": compilation_mode,\n        }\n\n    return transition(\n        implementation = _change_compilation_mode_impl,\n        inputs = [],\n        outputs = [\n            \"//command_line_option:compilation_mode\",\n        ],\n    )\n\ndef _transition_alias_rule(compilation_mode):\n    return rule(\n        implementation = _transition_alias_impl,\n        provides = COMMON_PROVIDERS,\n        attrs = {\n            \"actual\": attr.label(\n                mandatory = True,\n                doc = \"`rust_library()` target to transition to `compilation_mode=opt`.\",\n                providers = COMMON_PROVIDERS,\n                cfg = _change_compilation_mode(compilation_mode),\n            ),\n            \"_allowlist_function_transition\": attr.label(\n                default = \"@bazel_tools//tools/allowlists/function_transition_allowlist\",\n            ),\n        },\n        doc = \"Transitions a Rust library crate to the `compilation_mode=opt`.\",\n    )\n\ntransition_alias_dbg = _transition_alias_rule(\"dbg\")\ntransition_alias_fastbuild = _transition_alias_rule(\"fastbuild\")\ntransition_alias_opt = _transition_alias_rule(\"opt\")\n",
++                "defs.bzl": "###############################################################################\n# @generated\n# DO NOT MODIFY: This file is auto-generated by a crate_universe tool. To \n# regenerate this file, run the following:\n#\n#     bazel mod show_repo 'protobuf'\n###############################################################################\n\"\"\"\n# `crates_repository` API\n\n- [aliases](#aliases)\n- [crate_deps](#crate_deps)\n- [all_crate_deps](#all_crate_deps)\n- [crate_repositories](#crate_repositories)\n\n\"\"\"\n\nload(\"@bazel_tools//tools/build_defs/repo:git.bzl\", \"new_git_repository\")\nload(\"@bazel_tools//tools/build_defs/repo:http.bzl\", \"http_archive\")\nload(\"@bazel_tools//tools/build_defs/repo:utils.bzl\", \"maybe\")\nload(\"@bazel_skylib//lib:selects.bzl\", \"selects\")\nload(\"@rules_rust//crate_universe/private:local_crate_mirror.bzl\", \"local_crate_mirror\")\n\n###############################################################################\n# MACROS API\n###############################################################################\n\n# An identifier that represent common dependencies (unconditional).\n_COMMON_CONDITION = \"\"\n\ndef _flatten_dependency_maps(all_dependency_maps):\n    \"\"\"Flatten a list of dependency maps into one dictionary.\n\n    Dependency maps have the following structure:\n\n    ```python\n    DEPENDENCIES_MAP = {\n        # The first key in the map is a Bazel package\n        # name of the workspace this file is defined in.\n        \"workspace_member_package\": {\n\n            # Not all dependencies are supported for all platforms.\n            # the condition key is the condition required to be true\n            # on the host platform.\n            \"condition\": {\n\n                # An alias to a crate target.     # The label of the crate target the\n                # Aliases are only crate names.   # package name refers to.\n                \"package_name\":                   \"@full//:label\",\n            }\n        }\n    }\n    ```\n\n    Args:\n        all_dependency_maps (list): A list of dicts as described above\n\n    Returns:\n        dict: A dictionary as described above\n    \"\"\"\n    dependencies = {}\n\n    for workspace_deps_map in all_dependency_maps:\n        for pkg_name, conditional_deps_map in workspace_deps_map.items():\n            if pkg_name not in dependencies:\n                non_frozen_map = dict()\n                for key, values in conditional_deps_map.items():\n                    non_frozen_map.update({key: dict(values.items())})\n                dependencies.setdefault(pkg_name, non_frozen_map)\n                continue\n\n            for condition, deps_map in conditional_deps_map.items():\n                # If the condition has not been recorded, do so and continue\n                if condition not in dependencies[pkg_name]:\n                    dependencies[pkg_name].setdefault(condition, dict(deps_map.items()))\n                    continue\n\n                # Alert on any miss-matched dependencies\n                inconsistent_entries = []\n                for crate_name, crate_label in deps_map.items():\n                    existing = dependencies[pkg_name][condition].get(crate_name)\n                    if existing and existing != crate_label:\n                        inconsistent_entries.append((crate_name, existing, crate_label))\n                    dependencies[pkg_name][condition].update({crate_name: crate_label})\n\n    return dependencies\n\ndef crate_deps(deps, package_name = None):\n    \"\"\"Finds the fully qualified label of the requested crates for the package where this macro is called.\n\n    Args:\n        deps (list): The desired list of crate targets.\n        package_name (str, optional): The package name of the set of dependencies to look up.\n            Defaults to `native.package_name()`.\n\n    Returns:\n        list: A list of labels to generated rust targets (str)\n    \"\"\"\n\n    if not deps:\n        return []\n\n    if package_name == None:\n        package_name = native.package_name()\n\n    # Join both sets of dependencies\n    dependencies = _flatten_dependency_maps([\n        _NORMAL_DEPENDENCIES,\n        _NORMAL_DEV_DEPENDENCIES,\n        _PROC_MACRO_DEPENDENCIES,\n        _PROC_MACRO_DEV_DEPENDENCIES,\n        _BUILD_DEPENDENCIES,\n        _BUILD_PROC_MACRO_DEPENDENCIES,\n    ]).pop(package_name, {})\n\n    # Combine all conditional packages so we can easily index over a flat list\n    # TODO: Perhaps this should actually return select statements and maintain\n    # the conditionals of the dependencies\n    flat_deps = {}\n    for deps_set in dependencies.values():\n        for crate_name, crate_label in deps_set.items():\n            flat_deps.update({crate_name: crate_label})\n\n    missing_crates = []\n    crate_targets = []\n    for crate_target in deps:\n        if crate_target not in flat_deps:\n            missing_crates.append(crate_target)\n        else:\n            crate_targets.append(flat_deps[crate_target])\n\n    if missing_crates:\n        fail(\"Could not find crates `{}` among dependencies of `{}`. Available dependencies were `{}`\".format(\n            missing_crates,\n            package_name,\n            dependencies,\n        ))\n\n    return crate_targets\n\ndef all_crate_deps(\n        normal = False, \n        normal_dev = False, \n        proc_macro = False, \n        proc_macro_dev = False,\n        build = False,\n        build_proc_macro = False,\n        package_name = None):\n    \"\"\"Finds the fully qualified label of all requested direct crate dependencies \\\n    for the package where this macro is called.\n\n    If no parameters are set, all normal dependencies are returned. Setting any one flag will\n    otherwise impact the contents of the returned list.\n\n    Args:\n        normal (bool, optional): If True, normal dependencies are included in the\n            output list.\n        normal_dev (bool, optional): If True, normal dev dependencies will be\n            included in the output list.\n        proc_macro (bool, optional): If True, proc_macro dependencies are included\n            in the output list.\n        proc_macro_dev (bool, optional): If True, dev proc_macro dependencies are\n            included in the output list.\n        build (bool, optional): If True, build dependencies are included\n            in the output list.\n        build_proc_macro (bool, optional): If True, build proc_macro dependencies are\n            included in the output list.\n        package_name (str, optional): The package name of the set of dependencies to look up.\n            Defaults to `native.package_name()` when unset.\n\n    Returns:\n        list: A list of labels to generated rust targets (str)\n    \"\"\"\n\n    if package_name == None:\n        package_name = native.package_name()\n\n    # Determine the relevant maps to use\n    all_dependency_maps = []\n    if normal:\n        all_dependency_maps.append(_NORMAL_DEPENDENCIES)\n    if normal_dev:\n        all_dependency_maps.append(_NORMAL_DEV_DEPENDENCIES)\n    if proc_macro:\n        all_dependency_maps.append(_PROC_MACRO_DEPENDENCIES)\n    if proc_macro_dev:\n        all_dependency_maps.append(_PROC_MACRO_DEV_DEPENDENCIES)\n    if build:\n        all_dependency_maps.append(_BUILD_DEPENDENCIES)\n    if build_proc_macro:\n        all_dependency_maps.append(_BUILD_PROC_MACRO_DEPENDENCIES)\n\n    # Default to always using normal dependencies\n    if not all_dependency_maps:\n        all_dependency_maps.append(_NORMAL_DEPENDENCIES)\n\n    dependencies = _flatten_dependency_maps(all_dependency_maps).pop(package_name, None)\n\n    if not dependencies:\n        if dependencies == None:\n            fail(\"Tried to get all_crate_deps for package \" + package_name + \" but that package had no Cargo.toml file\")\n        else:\n            return []\n\n    crate_deps = list(dependencies.pop(_COMMON_CONDITION, {}).values())\n    for condition, deps in dependencies.items():\n        crate_deps += selects.with_or({\n            tuple(_CONDITIONS[condition]): deps.values(),\n            \"//conditions:default\": [],\n        })\n\n    return crate_deps\n\ndef aliases(\n        normal = False,\n        normal_dev = False,\n        proc_macro = False,\n        proc_macro_dev = False,\n        build = False,\n        build_proc_macro = False,\n        package_name = None):\n    \"\"\"Produces a map of Crate alias names to their original label\n\n    If no dependency kinds are specified, `normal` and `proc_macro` are used by default.\n    Setting any one flag will otherwise determine the contents of the returned dict.\n\n    Args:\n        normal (bool, optional): If True, normal dependencies are included in the\n            output list.\n        normal_dev (bool, optional): If True, normal dev dependencies will be\n            included in the output list..\n        proc_macro (bool, optional): If True, proc_macro dependencies are included\n            in the output list.\n        proc_macro_dev (bool, optional): If True, dev proc_macro dependencies are\n            included in the output list.\n        build (bool, optional): If True, build dependencies are included\n            in the output list.\n        build_proc_macro (bool, optional): If True, build proc_macro dependencies are\n            included in the output list.\n        package_name (str, optional): The package name of the set of dependencies to look up.\n            Defaults to `native.package_name()` when unset.\n\n    Returns:\n        dict: The aliases of all associated packages\n    \"\"\"\n    if package_name == None:\n        package_name = native.package_name()\n\n    # Determine the relevant maps to use\n    all_aliases_maps = []\n    if normal:\n        all_aliases_maps.append(_NORMAL_ALIASES)\n    if normal_dev:\n        all_aliases_maps.append(_NORMAL_DEV_ALIASES)\n    if proc_macro:\n        all_aliases_maps.append(_PROC_MACRO_ALIASES)\n    if proc_macro_dev:\n        all_aliases_maps.append(_PROC_MACRO_DEV_ALIASES)\n    if build:\n        all_aliases_maps.append(_BUILD_ALIASES)\n    if build_proc_macro:\n        all_aliases_maps.append(_BUILD_PROC_MACRO_ALIASES)\n\n    # Default to always using normal aliases\n    if not all_aliases_maps:\n        all_aliases_maps.append(_NORMAL_ALIASES)\n        all_aliases_maps.append(_PROC_MACRO_ALIASES)\n\n    aliases = _flatten_dependency_maps(all_aliases_maps).pop(package_name, None)\n\n    if not aliases:\n        return dict()\n\n    common_items = aliases.pop(_COMMON_CONDITION, {}).items()\n\n    # If there are only common items in the dictionary, immediately return them\n    if not len(aliases.keys()) == 1:\n        return dict(common_items)\n\n    # Build a single select statement where each conditional has accounted for the\n    # common set of aliases.\n    crate_aliases = {\"//conditions:default\": dict(common_items)}\n    for condition, deps in aliases.items():\n        condition_triples = _CONDITIONS[condition]\n        for triple in condition_triples:\n            if triple in crate_aliases:\n                crate_aliases[triple].update(deps)\n            else:\n                crate_aliases.update({triple: dict(deps.items() + common_items)})\n\n    return select(crate_aliases)\n\n###############################################################################\n# WORKSPACE MEMBER DEPS AND ALIASES\n###############################################################################\n\n_NORMAL_DEPENDENCIES = {\n    \"\": {\n        _COMMON_CONDITION: {\n            \"googletest\": Label(\"@crates//:googletest-0.14.3\"),\n            \"linkme\": Label(\"@crates//:linkme-0.3.37\"),\n            \"quote\": Label(\"@crates//:quote-1.0.47\"),\n            \"syn\": Label(\"@crates//:syn-3.0.3\"),\n        },\n    },\n}\n\n\n_NORMAL_ALIASES = {\n    \"\": {\n        _COMMON_CONDITION: {\n        },\n    },\n}\n\n\n_NORMAL_DEV_DEPENDENCIES = {\n    \"\": {\n    },\n}\n\n\n_NORMAL_DEV_ALIASES = {\n    \"\": {\n    },\n}\n\n\n_PROC_MACRO_DEPENDENCIES = {\n    \"\": {\n        _COMMON_CONDITION: {\n            \"paste\": Label(\"@crates//:paste-1.0.15\"),\n        },\n    },\n}\n\n\n_PROC_MACRO_ALIASES = {\n    \"\": {\n    },\n}\n\n\n_PROC_MACRO_DEV_DEPENDENCIES = {\n    \"\": {\n    },\n}\n\n\n_PROC_MACRO_DEV_ALIASES = {\n    \"\": {\n    },\n}\n\n\n_BUILD_DEPENDENCIES = {\n    \"\": {\n    },\n}\n\n\n_BUILD_ALIASES = {\n    \"\": {\n    },\n}\n\n\n_BUILD_PROC_MACRO_DEPENDENCIES = {\n    \"\": {\n    },\n}\n\n\n_BUILD_PROC_MACRO_ALIASES = {\n    \"\": {\n    },\n}\n\n\n_CONDITIONS = {\n    \"aarch64-apple-darwin\": [\"@rules_rust//rust/platform:aarch64-apple-darwin\"],\n    \"aarch64-unknown-linux-gnu\": [\"@rules_rust//rust/platform:aarch64-unknown-linux-gnu\"],\n    \"wasm32-unknown-unknown\": [\"@rules_rust//rust/platform:wasm32-unknown-unknown\"],\n    \"wasm32-wasip1\": [\"@rules_rust//rust/platform:wasm32-wasip1\"],\n    \"x86_64-pc-windows-msvc\": [\"@rules_rust//rust/platform:x86_64-pc-windows-msvc\"],\n    \"x86_64-unknown-linux-gnu\": [\"@rules_rust//rust/platform:x86_64-unknown-linux-gnu\"],\n    \"x86_64-unknown-nixos-gnu\": [\"@rules_rust//rust/platform:x86_64-unknown-nixos-gnu\"],\n}\n\n###############################################################################\n\ndef crate_repositories():\n    \"\"\"A macro for defining repositories for all generated crates.\n\n    Returns:\n      A list of repos visible to the module through the module extension.\n    \"\"\"\n    maybe(\n        http_archive,\n        name = \"crates__aho-corasick-1.1.5\",\n        sha256 = \"c982642fa9e8606056828ee9a8505737230110bb1099153c79efe865c59d12ba\",\n        type = \"tar.gz\",\n        urls = [\"https://static.crates.io/crates/aho-corasick/1.1.5/download\"],\n        strip_prefix = \"aho-corasick-1.1.5\",\n        build_file = Label(\"@crates//crates:BUILD.aho-corasick-1.1.5.bazel\"),\n    )\n\n    maybe(\n        http_archive,\n        name = \"crates__autocfg-1.5.1\",\n        sha256 = \"f2032f911046de80f0a198e0901378627c33f59ea0ac00e363d481118bd70a53\",\n        type = \"tar.gz\",\n        urls = [\"https://static.crates.io/crates/autocfg/1.5.1/download\"],\n        strip_prefix = \"autocfg-1.5.1\",\n        build_file = Label(\"@crates//crates:BUILD.autocfg-1.5.1.bazel\"),\n    )\n\n    maybe(\n        http_archive,\n        name = \"crates__googletest-0.14.3\",\n        sha256 = \"f6b5e2f2b556b7b90297a5a35c8267dd43a537923d2b329beefdba2b4ec19d94\",\n        type = \"tar.gz\",\n        urls = [\"https://static.crates.io/crates/googletest/0.14.3/download\"],\n        strip_prefix = \"googletest-0.14.3\",\n        build_file = Label(\"@crates//crates:BUILD.googletest-0.14.3.bazel\"),\n    )\n\n    maybe(\n        http_archive,\n        name = \"crates__googletest_macro-0.14.3\",\n        sha256 = \"2ae6abc96141edd26bf5aeec0f119c129c44de3ced09e5073711a02cb74725d0\",\n        type = \"tar.gz\",\n        urls = [\"https://static.crates.io/crates/googletest_macro/0.14.3/download\"],\n        strip_prefix = \"googletest_macro-0.14.3\",\n        build_file = Label(\"@crates//crates:BUILD.googletest_macro-0.14.3.bazel\"),\n    )\n\n    maybe(\n        http_archive,\n        name = \"crates__linkme-0.3.37\",\n        sha256 = \"3045e122bd98aef8ec3ad58ce84f0791f64e70163d1a02710af4aa11a4d54cc5\",\n        type = \"tar.gz\",\n        urls = [\"https://static.crates.io/crates/linkme/0.3.37/download\"],\n        strip_prefix = \"linkme-0.3.37\",\n        build_file = Label(\"@crates//crates:BUILD.linkme-0.3.37.bazel\"),\n    )\n\n    maybe(\n        http_archive,\n        name = \"crates__linkme-impl-0.3.37\",\n        sha256 = \"77060ebe535362c3da75682cd17b0431017b6e7c5661e714fc69a7ad017d1301\",\n        type = \"tar.gz\",\n        urls = [\"https://static.crates.io/crates/linkme-impl/0.3.37/download\"],\n        strip_prefix = \"linkme-impl-0.3.37\",\n        build_file = Label(\"@crates//crates:BUILD.linkme-impl-0.3.37.bazel\"),\n    )\n\n    maybe(\n        http_archive,\n        name = \"crates__memchr-2.8.3\",\n        sha256 = \"cf8baf1c55e62ffcace7a9f06f4bd9cd3f0c4beb022d3b367256b91b87513d98\",\n        type = \"tar.gz\",\n        urls = [\"https://static.crates.io/crates/memchr/2.8.3/download\"],\n        strip_prefix = \"memchr-2.8.3\",\n        build_file = Label(\"@crates//crates:BUILD.memchr-2.8.3.bazel\"),\n    )\n\n    maybe(\n        http_archive,\n        name = \"crates__num-traits-0.2.19\",\n        sha256 = \"071dfc062690e90b734c0b2273ce72ad0ffa95f0c74596bc250dcfd960262841\",\n        type = \"tar.gz\",\n        urls = [\"https://static.crates.io/crates/num-traits/0.2.19/download\"],\n        strip_prefix = \"num-traits-0.2.19\",\n        build_file = Label(\"@crates//crates:BUILD.num-traits-0.2.19.bazel\"),\n    )\n\n    maybe(\n        http_archive,\n        name = \"crates__paste-1.0.15\",\n        sha256 = \"57c0d7b74b563b49d38dae00a0c37d4d6de9b432382b2892f0574ddcae73fd0a\",\n        type = \"tar.gz\",\n        urls = [\"https://static.crates.io/crates/paste/1.0.15/download\"],\n        strip_prefix = \"paste-1.0.15\",\n        build_file = Label(\"@crates//crates:BUILD.paste-1.0.15.bazel\"),\n    )\n\n    maybe(\n        http_archive,\n        name = \"crates__proc-macro2-1.0.107\",\n        sha256 = \"985e7ec9bb745e6ce6535b544d84d6cd6f7ad8bd711c398938ae983b91a766d9\",\n        type = \"tar.gz\",\n        urls = [\"https://static.crates.io/crates/proc-macro2/1.0.107/download\"],\n        strip_prefix = \"proc-macro2-1.0.107\",\n        build_file = Label(\"@crates//crates:BUILD.proc-macro2-1.0.107.bazel\"),\n    )\n\n    maybe(\n        http_archive,\n        name = \"crates__quote-1.0.47\",\n        sha256 = \"1fbf4db142a473a8d80c26bbf18454ed458bf8d26c8219c331daecfdbd079001\",\n        type = \"tar.gz\",\n        urls = [\"https://static.crates.io/crates/quote/1.0.47/download\"],\n        strip_prefix = \"quote-1.0.47\",\n        build_file = Label(\"@crates//crates:BUILD.quote-1.0.47.bazel\"),\n    )\n\n    maybe(\n        http_archive,\n        name = \"crates__regex-1.13.1\",\n        sha256 = \"f020237b6c8eed93db2e2cb53c00c60a8e1bc73da7d073199a1180401450218d\",\n        type = \"tar.gz\",\n        urls = [\"https://static.crates.io/crates/regex/1.13.1/download\"],\n        strip_prefix = \"regex-1.13.1\",\n        build_file = Label(\"@crates//crates:BUILD.regex-1.13.1.bazel\"),\n    )\n\n    maybe(\n        http_archive,\n        name = \"crates__regex-automata-0.4.18\",\n        sha256 = \"ad8553b9b26413251cbf30e620595c7a41b3887f03da04579c0e6b0d6a06b4b2\",\n        type = \"tar.gz\",\n        urls = [\"https://static.crates.io/crates/regex-automata/0.4.18/download\"],\n        strip_prefix = \"regex-automata-0.4.18\",\n        build_file = Label(\"@crates//crates:BUILD.regex-automata-0.4.18.bazel\"),\n    )\n\n    maybe(\n        http_archive,\n        name = \"crates__regex-syntax-0.8.11\",\n        sha256 = \"d6f6ff9a378485b298a5286656da665ba74413d36db0979633275d2e708145d4\",\n        type = \"tar.gz\",\n        urls = [\"https://static.crates.io/crates/regex-syntax/0.8.11/download\"],\n        strip_prefix = \"regex-syntax-0.8.11\",\n        build_file = Label(\"@crates//crates:BUILD.regex-syntax-0.8.11.bazel\"),\n    )\n\n    maybe(\n        http_archive,\n        name = \"crates__rustversion-1.0.23\",\n        sha256 = \"cf54715a573b99ac80df0bc206da022bcd442c974952c7b9720069370852e21f\",\n        type = \"tar.gz\",\n        urls = [\"https://static.crates.io/crates/rustversion/1.0.23/download\"],\n        strip_prefix = \"rustversion-1.0.23\",\n        build_file = Label(\"@crates//crates:BUILD.rustversion-1.0.23.bazel\"),\n    )\n\n    maybe(\n        http_archive,\n        name = \"crates__syn-2.0.119\",\n        sha256 = \"872831b642d1a07999a962a351ed35b955ea2cfc8f3862091e2a240a84f17297\",\n        type = \"tar.gz\",\n        urls = [\"https://static.crates.io/crates/syn/2.0.119/download\"],\n        strip_prefix = \"syn-2.0.119\",\n        build_file = Label(\"@crates//crates:BUILD.syn-2.0.119.bazel\"),\n    )\n\n    maybe(\n        http_archive,\n        name = \"crates__syn-3.0.3\",\n        sha256 = \"53e9bae58849f64dfa4f5d5ae372c8341f7305f82a3868709269343628b659a3\",\n        type = \"tar.gz\",\n        urls = [\"https://static.crates.io/crates/syn/3.0.3/download\"],\n        strip_prefix = \"syn-3.0.3\",\n        build_file = Label(\"@crates//crates:BUILD.syn-3.0.3.bazel\"),\n    )\n\n    maybe(\n        http_archive,\n        name = \"crates__unicode-ident-1.0.24\",\n        sha256 = \"e6e4313cd5fcd3dad5cafa179702e2b244f760991f45397d14d4ebf38247da75\",\n        type = \"tar.gz\",\n        urls = [\"https://static.crates.io/crates/unicode-ident/1.0.24/download\"],\n        strip_prefix = \"unicode-ident-1.0.24\",\n        build_file = Label(\"@crates//crates:BUILD.unicode-ident-1.0.24.bazel\"),\n    )\n\n    return [\n       struct(repo=\"crates__googletest-0.14.3\", is_dev_dep = False),\n       struct(repo=\"crates__linkme-0.3.37\", is_dev_dep = False),\n       struct(repo=\"crates__paste-1.0.15\", is_dev_dep = False),\n       struct(repo=\"crates__quote-1.0.47\", is_dev_dep = False),\n       struct(repo=\"crates__syn-3.0.3\", is_dev_dep = False),\n    ]\n"
++              }
++            }
++          },
++          "crates__aho-corasick-1.1.5": {
++            "repoRuleId": "@@bazel_tools//tools/build_defs/repo:http.bzl%http_archive",
++            "attributes": {
++              "patch_args": [],
++              "patch_tool": "",
++              "patches": [],
++              "remote_patch_strip": 1,
++              "sha256": "c982642fa9e8606056828ee9a8505737230110bb1099153c79efe865c59d12ba",
++              "type": "tar.gz",
++              "urls": [
++                "https://static.crates.io/crates/aho-corasick/1.1.5/download"
++              ],
++              "strip_prefix": "aho-corasick-1.1.5",
++              "build_file_content": "###############################################################################\n# @generated\n# DO NOT MODIFY: This file is auto-generated by a crate_universe tool. To \n# regenerate this file, run the following:\n#\n#     bazel mod show_repo 'protobuf'\n###############################################################################\n\nload(\"@rules_rust//cargo:defs.bzl\", \"cargo_toml_env_vars\")\n\nload(\"@rules_rust//rust:defs.bzl\", \"rust_library\")\n\n# buildifier: disable=bzl-visibility\nload(\"@rules_rust//crate_universe/private:selects.bzl\", \"selects\")\n\npackage(default_visibility = [\"//visibility:public\"])\n\ncargo_toml_env_vars(\n    name = \"cargo_toml_env_vars\",\n    src = \"Cargo.toml\",\n)\n\nrust_library(\n    name = \"aho_corasick\",\n    deps = [\n        \"@crates__memchr-2.8.3//:memchr\",\n    ],\n    compile_data = glob(\n        allow_empty = True,\n        include = [\"**\"],\n        exclude = [\n            \"**/* *\",\n            \".tmp_git_root/**/*\",\n            \"BUILD\",\n            \"BUILD.bazel\",\n            \"WORKSPACE\",\n            \"WORKSPACE.bazel\",\n        ],\n    ),\n    crate_features = [\n        \"perf-literal\",\n        \"std\",\n    ],\n    crate_root = \"src/lib.rs\",\n    edition = \"2021\",\n    rustc_env_files = [\n        \":cargo_toml_env_vars\",\n    ],\n    rustc_flags = [\n        \"--cap-lints=allow\",\n    ],\n    srcs = glob(\n        allow_empty = True,\n        include = [\"**/*.rs\"],\n    ),\n    tags = [\n        \"cargo-bazel\",\n        \"crate-name=aho-corasick\",\n        \"manual\",\n        \"noclippy\",\n        \"norustfmt\",\n    ],\n    target_compatible_with = select({\n        \"@rules_rust//rust/platform:aarch64-apple-darwin\": [],\n        \"@rules_rust//rust/platform:aarch64-unknown-linux-gnu\": [],\n        \"@rules_rust//rust/platform:wasm32-unknown-unknown\": [],\n        \"@rules_rust//rust/platform:wasm32-wasip1\": [],\n        \"@rules_rust//rust/platform:x86_64-pc-windows-msvc\": [],\n        \"@rules_rust//rust/platform:x86_64-unknown-linux-gnu\": [],\n        \"@rules_rust//rust/platform:x86_64-unknown-nixos-gnu\": [],\n        \"//conditions:default\": [\"@platforms//:incompatible\"],\n    }),\n    version = \"1.1.5\",\n)\n"
++            }
++          },
++          "crates__autocfg-1.5.1": {
++            "repoRuleId": "@@bazel_tools//tools/build_defs/repo:http.bzl%http_archive",
++            "attributes": {
++              "patch_args": [],
++              "patch_tool": "",
++              "patches": [],
++              "remote_patch_strip": 1,
++              "sha256": "f2032f911046de80f0a198e0901378627c33f59ea0ac00e363d481118bd70a53",
++              "type": "tar.gz",
++              "urls": [
++                "https://static.crates.io/crates/autocfg/1.5.1/download"
++              ],
++              "strip_prefix": "autocfg-1.5.1",
++              "build_file_content": "###############################################################################\n# @generated\n# DO NOT MODIFY: This file is auto-generated by a crate_universe tool. To \n# regenerate this file, run the following:\n#\n#     bazel mod show_repo 'protobuf'\n###############################################################################\n\nload(\"@rules_rust//cargo:defs.bzl\", \"cargo_toml_env_vars\")\n\nload(\"@rules_rust//rust:defs.bzl\", \"rust_library\")\n\n# buildifier: disable=bzl-visibility\nload(\"@rules_rust//crate_universe/private:selects.bzl\", \"selects\")\n\npackage(default_visibility = [\"//visibility:public\"])\n\ncargo_toml_env_vars(\n    name = \"cargo_toml_env_vars\",\n    src = \"Cargo.toml\",\n)\n\nrust_library(\n    name = \"autocfg\",\n    compile_data = glob(\n        allow_empty = True,\n        include = [\"**\"],\n        exclude = [\n            \"**/* *\",\n            \".tmp_git_root/**/*\",\n            \"BUILD\",\n            \"BUILD.bazel\",\n            \"WORKSPACE\",\n            \"WORKSPACE.bazel\",\n        ],\n    ),\n    crate_root = \"src/lib.rs\",\n    edition = \"2015\",\n    rustc_env_files = [\n        \":cargo_toml_env_vars\",\n    ],\n    rustc_flags = [\n        \"--cap-lints=allow\",\n    ],\n    srcs = glob(\n        allow_empty = True,\n        include = [\"**/*.rs\"],\n    ),\n    tags = [\n        \"cargo-bazel\",\n        \"crate-name=autocfg\",\n        \"manual\",\n        \"noclippy\",\n        \"norustfmt\",\n    ],\n    target_compatible_with = select({\n        \"@rules_rust//rust/platform:aarch64-apple-darwin\": [],\n        \"@rules_rust//rust/platform:aarch64-unknown-linux-gnu\": [],\n        \"@rules_rust//rust/platform:wasm32-unknown-unknown\": [],\n        \"@rules_rust//rust/platform:wasm32-wasip1\": [],\n        \"@rules_rust//rust/platform:x86_64-pc-windows-msvc\": [],\n        \"@rules_rust//rust/platform:x86_64-unknown-linux-gnu\": [],\n        \"@rules_rust//rust/platform:x86_64-unknown-nixos-gnu\": [],\n        \"//conditions:default\": [\"@platforms//:incompatible\"],\n    }),\n    version = \"1.5.1\",\n)\n"
++            }
++          },
++          "crates__googletest-0.14.3": {
++            "repoRuleId": "@@bazel_tools//tools/build_defs/repo:http.bzl%http_archive",
++            "attributes": {
++              "patch_args": [],
++              "patch_tool": "",
++              "patches": [],
++              "remote_patch_strip": 1,
++              "sha256": "f6b5e2f2b556b7b90297a5a35c8267dd43a537923d2b329beefdba2b4ec19d94",
++              "type": "tar.gz",
++              "urls": [
++                "https://static.crates.io/crates/googletest/0.14.3/download"
++              ],
++              "strip_prefix": "googletest-0.14.3",
++              "build_file_content": "###############################################################################\n# @generated\n# DO NOT MODIFY: This file is auto-generated by a crate_universe tool. To \n# regenerate this file, run the following:\n#\n#     bazel mod show_repo 'protobuf'\n###############################################################################\n\nload(\"@rules_rust//cargo:defs.bzl\", \"cargo_toml_env_vars\")\n\nload(\"@rules_rust//rust:defs.bzl\", \"rust_library\")\n\n# buildifier: disable=bzl-visibility\nload(\"@rules_rust//crate_universe/private:selects.bzl\", \"selects\")\n\npackage(default_visibility = [\"//visibility:public\"])\n\ncargo_toml_env_vars(\n    name = \"cargo_toml_env_vars\",\n    src = \"Cargo.toml\",\n)\n\nrust_library(\n    name = \"googletest\",\n    deps = [\n        \"@crates__num-traits-0.2.19//:num_traits\",\n        \"@crates__regex-1.13.1//:regex\",\n    ],\n    proc_macro_deps = [\n        \"@crates__googletest_macro-0.14.3//:googletest_macro\",\n        \"@crates__rustversion-1.0.23//:rustversion\",\n    ],\n    compile_data = glob(\n        allow_empty = True,\n        include = [\"**\"],\n        exclude = [\n            \"**/* *\",\n            \".tmp_git_root/**/*\",\n            \"BUILD\",\n            \"BUILD.bazel\",\n            \"WORKSPACE\",\n            \"WORKSPACE.bazel\",\n        ],\n    ),\n    crate_root = \"src/lib.rs\",\n    edition = \"2021\",\n    rustc_env_files = [\n        \":cargo_toml_env_vars\",\n    ],\n    rustc_flags = [\n        \"--cap-lints=allow\",\n    ],\n    srcs = glob(\n        allow_empty = True,\n        include = [\"**/*.rs\"],\n    ),\n    tags = [\n        \"cargo-bazel\",\n        \"crate-name=googletest\",\n        \"manual\",\n        \"noclippy\",\n        \"norustfmt\",\n    ],\n    target_compatible_with = select({\n        \"@rules_rust//rust/platform:aarch64-apple-darwin\": [],\n        \"@rules_rust//rust/platform:aarch64-unknown-linux-gnu\": [],\n        \"@rules_rust//rust/platform:wasm32-unknown-unknown\": [],\n        \"@rules_rust//rust/platform:wasm32-wasip1\": [],\n        \"@rules_rust//rust/platform:x86_64-pc-windows-msvc\": [],\n        \"@rules_rust//rust/platform:x86_64-unknown-linux-gnu\": [],\n        \"@rules_rust//rust/platform:x86_64-unknown-nixos-gnu\": [],\n        \"//conditions:default\": [\"@platforms//:incompatible\"],\n    }),\n    version = \"0.14.3\",\n)\n"
++            }
++          },
++          "crates__googletest_macro-0.14.3": {
++            "repoRuleId": "@@bazel_tools//tools/build_defs/repo:http.bzl%http_archive",
++            "attributes": {
++              "patch_args": [],
++              "patch_tool": "",
++              "patches": [],
++              "remote_patch_strip": 1,
++              "sha256": "2ae6abc96141edd26bf5aeec0f119c129c44de3ced09e5073711a02cb74725d0",
++              "type": "tar.gz",
++              "urls": [
++                "https://static.crates.io/crates/googletest_macro/0.14.3/download"
++              ],
++              "strip_prefix": "googletest_macro-0.14.3",
++              "build_file_content": "###############################################################################\n# @generated\n# DO NOT MODIFY: This file is auto-generated by a crate_universe tool. To \n# regenerate this file, run the following:\n#\n#     bazel mod show_repo 'protobuf'\n###############################################################################\n\nload(\"@rules_rust//cargo:defs.bzl\", \"cargo_toml_env_vars\")\n\nload(\"@rules_rust//rust:defs.bzl\", \"rust_proc_macro\")\n\n# buildifier: disable=bzl-visibility\nload(\"@rules_rust//crate_universe/private:selects.bzl\", \"selects\")\n\npackage(default_visibility = [\"//visibility:public\"])\n\ncargo_toml_env_vars(\n    name = \"cargo_toml_env_vars\",\n    src = \"Cargo.toml\",\n)\n\nrust_proc_macro(\n    name = \"googletest_macro\",\n    deps = [\n        \"@crates__proc-macro2-1.0.107//:proc_macro2\",\n        \"@crates__quote-1.0.47//:quote\",\n        \"@crates__syn-2.0.119//:syn\",\n    ],\n    compile_data = glob(\n        allow_empty = True,\n        include = [\"**\"],\n        exclude = [\n            \"**/* *\",\n            \".tmp_git_root/**/*\",\n            \"BUILD\",\n            \"BUILD.bazel\",\n            \"WORKSPACE\",\n            \"WORKSPACE.bazel\",\n        ],\n    ),\n    crate_root = \"src/lib.rs\",\n    edition = \"2021\",\n    rustc_env_files = [\n        \":cargo_toml_env_vars\",\n    ],\n    rustc_flags = [\n        \"--cap-lints=allow\",\n    ],\n    srcs = glob(\n        allow_empty = True,\n        include = [\"**/*.rs\"],\n    ),\n    tags = [\n        \"cargo-bazel\",\n        \"crate-name=googletest_macro\",\n        \"manual\",\n        \"noclippy\",\n        \"norustfmt\",\n    ],\n    target_compatible_with = select({\n        \"@rules_rust//rust/platform:aarch64-apple-darwin\": [],\n        \"@rules_rust//rust/platform:aarch64-unknown-linux-gnu\": [],\n        \"@rules_rust//rust/platform:wasm32-unknown-unknown\": [],\n        \"@rules_rust//rust/platform:wasm32-wasip1\": [],\n        \"@rules_rust//rust/platform:x86_64-pc-windows-msvc\": [],\n        \"@rules_rust//rust/platform:x86_64-unknown-linux-gnu\": [],\n        \"@rules_rust//rust/platform:x86_64-unknown-nixos-gnu\": [],\n        \"//conditions:default\": [\"@platforms//:incompatible\"],\n    }),\n    version = \"0.14.3\",\n)\n"
++            }
++          },
++          "crates__linkme-0.3.37": {
++            "repoRuleId": "@@bazel_tools//tools/build_defs/repo:http.bzl%http_archive",
++            "attributes": {
++              "patch_args": [],
++              "patch_tool": "",
++              "patches": [],
++              "remote_patch_strip": 1,
++              "sha256": "3045e122bd98aef8ec3ad58ce84f0791f64e70163d1a02710af4aa11a4d54cc5",
++              "type": "tar.gz",
++              "urls": [
++                "https://static.crates.io/crates/linkme/0.3.37/download"
++              ],
++              "strip_prefix": "linkme-0.3.37",
++              "build_file_content": "###############################################################################\n# @generated\n# DO NOT MODIFY: This file is auto-generated by a crate_universe tool. To \n# regenerate this file, run the following:\n#\n#     bazel mod show_repo 'protobuf'\n###############################################################################\n\nload(\n    \"@rules_rust//cargo:defs.bzl\",\n    \"cargo_build_script\",\n    \"cargo_toml_env_vars\",\n)\n\nload(\"@rules_rust//rust:defs.bzl\", \"rust_library\")\n\n# buildifier: disable=bzl-visibility\nload(\"@rules_rust//crate_universe/private:selects.bzl\", \"selects\")\n\npackage(default_visibility = [\"//visibility:public\"])\n\ncargo_toml_env_vars(\n    name = \"cargo_toml_env_vars\",\n    src = \"Cargo.toml\",\n)\n\nrust_library(\n    name = \"linkme\",\n    deps = [\n        \"@crates__linkme-0.3.37//:build_script_build\",\n    ],\n    proc_macro_deps = [\n        \"@crates__linkme-impl-0.3.37//:linkme_impl\",\n    ],\n    compile_data = glob(\n        allow_empty = True,\n        include = [\"**\"],\n        exclude = [\n            \"**/* *\",\n            \".tmp_git_root/**/*\",\n            \"BUILD\",\n            \"BUILD.bazel\",\n            \"WORKSPACE\",\n            \"WORKSPACE.bazel\",\n        ],\n    ),\n    crate_root = \"src/lib.rs\",\n    edition = \"2021\",\n    rustc_env_files = [\n        \":cargo_toml_env_vars\",\n    ],\n    rustc_flags = [\n        \"--cap-lints=allow\",\n    ],\n    srcs = glob(\n        allow_empty = True,\n        include = [\"**/*.rs\"],\n    ),\n    tags = [\n        \"cargo-bazel\",\n        \"crate-name=linkme\",\n        \"manual\",\n        \"noclippy\",\n        \"norustfmt\",\n    ],\n    target_compatible_with = select({\n        \"@rules_rust//rust/platform:aarch64-apple-darwin\": [],\n        \"@rules_rust//rust/platform:aarch64-unknown-linux-gnu\": [],\n        \"@rules_rust//rust/platform:wasm32-unknown-unknown\": [],\n        \"@rules_rust//rust/platform:wasm32-wasip1\": [],\n        \"@rules_rust//rust/platform:x86_64-pc-windows-msvc\": [],\n        \"@rules_rust//rust/platform:x86_64-unknown-linux-gnu\": [],\n        \"@rules_rust//rust/platform:x86_64-unknown-nixos-gnu\": [],\n        \"//conditions:default\": [\"@platforms//:incompatible\"],\n    }),\n    version = \"0.3.37\",\n)\n\ncargo_build_script(\n    name = \"_bs\",\n    compile_data = glob(\n        allow_empty = True,\n        include = [\"**\"],\n        exclude = [\n            \"**/* *\",\n            \"**/*.rs\",\n            \".tmp_git_root/**/*\",\n            \"BUILD\",\n            \"BUILD.bazel\",\n            \"WORKSPACE\",\n            \"WORKSPACE.bazel\",\n        ],\n    ),\n    crate_name = \"build_script_build\",\n    crate_root = \"build.rs\",\n    data = glob(\n        allow_empty = True,\n        include = [\"**\"],\n        exclude = [\n            \"**/* *\",\n            \".tmp_git_root/**/*\",\n            \"BUILD\",\n            \"BUILD.bazel\",\n            \"WORKSPACE\",\n            \"WORKSPACE.bazel\",\n        ],\n    ),\n    edition = \"2021\",\n    pkg_name = \"linkme\",\n    rustc_env_files = [\n        \":cargo_toml_env_vars\",\n    ],\n    rustc_flags = [\n        \"--cap-lints=allow\",\n    ],\n    srcs = glob(\n        allow_empty = True,\n        include = [\"**/*.rs\"],\n    ),\n    tags = [\n        \"cargo-bazel\",\n        \"crate-name=linkme\",\n        \"manual\",\n        \"noclippy\",\n        \"norustfmt\",\n    ],\n    version = \"0.3.37\",\n    visibility = [\"//visibility:private\"],\n)\n\nalias(\n    name = \"build_script_build\",\n    actual = \":_bs\",\n    tags = [\"manual\"],\n)\n"
++            }
++          },
++          "crates__linkme-impl-0.3.37": {
++            "repoRuleId": "@@bazel_tools//tools/build_defs/repo:http.bzl%http_archive",
++            "attributes": {
++              "patch_args": [],
++              "patch_tool": "",
++              "patches": [],
++              "remote_patch_strip": 1,
++              "sha256": "77060ebe535362c3da75682cd17b0431017b6e7c5661e714fc69a7ad017d1301",
++              "type": "tar.gz",
++              "urls": [
++                "https://static.crates.io/crates/linkme-impl/0.3.37/download"
++              ],
++              "strip_prefix": "linkme-impl-0.3.37",
++              "build_file_content": "###############################################################################\n# @generated\n# DO NOT MODIFY: This file is auto-generated by a crate_universe tool. To \n# regenerate this file, run the following:\n#\n#     bazel mod show_repo 'protobuf'\n###############################################################################\n\nload(\n    \"@rules_rust//cargo:defs.bzl\",\n    \"cargo_build_script\",\n    \"cargo_toml_env_vars\",\n)\n\nload(\"@rules_rust//rust:defs.bzl\", \"rust_proc_macro\")\n\n# buildifier: disable=bzl-visibility\nload(\"@rules_rust//crate_universe/private:selects.bzl\", \"selects\")\n\npackage(default_visibility = [\"//visibility:public\"])\n\ncargo_toml_env_vars(\n    name = \"cargo_toml_env_vars\",\n    src = \"Cargo.toml\",\n)\n\nrust_proc_macro(\n    name = \"linkme_impl\",\n    deps = [\n        \"@crates__linkme-impl-0.3.37//:build_script_build\",\n        \"@crates__proc-macro2-1.0.107//:proc_macro2\",\n        \"@crates__quote-1.0.47//:quote\",\n        \"@crates__syn-3.0.3//:syn\",\n    ],\n    compile_data = glob(\n        allow_empty = True,\n        include = [\"**\"],\n        exclude = [\n            \"**/* *\",\n            \".tmp_git_root/**/*\",\n            \"BUILD\",\n            \"BUILD.bazel\",\n            \"WORKSPACE\",\n            \"WORKSPACE.bazel\",\n        ],\n    ),\n    crate_root = \"src/lib.rs\",\n    edition = \"2021\",\n    rustc_env_files = [\n        \":cargo_toml_env_vars\",\n    ],\n    rustc_flags = [\n        \"--cap-lints=allow\",\n    ],\n    srcs = glob(\n        allow_empty = True,\n        include = [\"**/*.rs\"],\n    ),\n    tags = [\n        \"cargo-bazel\",\n        \"crate-name=linkme-impl\",\n        \"manual\",\n        \"noclippy\",\n        \"norustfmt\",\n    ],\n    target_compatible_with = select({\n        \"@rules_rust//rust/platform:aarch64-apple-darwin\": [],\n        \"@rules_rust//rust/platform:aarch64-unknown-linux-gnu\": [],\n        \"@rules_rust//rust/platform:wasm32-unknown-unknown\": [],\n        \"@rules_rust//rust/platform:wasm32-wasip1\": [],\n        \"@rules_rust//rust/platform:x86_64-pc-windows-msvc\": [],\n        \"@rules_rust//rust/platform:x86_64-unknown-linux-gnu\": [],\n        \"@rules_rust//rust/platform:x86_64-unknown-nixos-gnu\": [],\n        \"//conditions:default\": [\"@platforms//:incompatible\"],\n    }),\n    version = \"0.3.37\",\n)\n\ncargo_build_script(\n    name = \"_bs\",\n    compile_data = glob(\n        allow_empty = True,\n        include = [\"**\"],\n        exclude = [\n            \"**/* *\",\n            \"**/*.rs\",\n            \".tmp_git_root/**/*\",\n            \"BUILD\",\n            \"BUILD.bazel\",\n            \"WORKSPACE\",\n            \"WORKSPACE.bazel\",\n        ],\n    ),\n    crate_name = \"build_script_build\",\n    crate_root = \"build.rs\",\n    data = glob(\n        allow_empty = True,\n        include = [\"**\"],\n        exclude = [\n            \"**/* *\",\n            \".tmp_git_root/**/*\",\n            \"BUILD\",\n            \"BUILD.bazel\",\n            \"WORKSPACE\",\n            \"WORKSPACE.bazel\",\n        ],\n    ),\n    edition = \"2021\",\n    pkg_name = \"linkme-impl\",\n    rustc_env_files = [\n        \":cargo_toml_env_vars\",\n    ],\n    rustc_flags = [\n        \"--cap-lints=allow\",\n    ],\n    srcs = glob(\n        allow_empty = True,\n        include = [\"**/*.rs\"],\n    ),\n    tags = [\n        \"cargo-bazel\",\n        \"crate-name=linkme-impl\",\n        \"manual\",\n        \"noclippy\",\n        \"norustfmt\",\n    ],\n    version = \"0.3.37\",\n    visibility = [\"//visibility:private\"],\n)\n\nalias(\n    name = \"build_script_build\",\n    actual = \":_bs\",\n    tags = [\"manual\"],\n)\n"
++            }
++          },
++          "crates__memchr-2.8.3": {
++            "repoRuleId": "@@bazel_tools//tools/build_defs/repo:http.bzl%http_archive",
++            "attributes": {
++              "patch_args": [],
++              "patch_tool": "",
++              "patches": [],
++              "remote_patch_strip": 1,
++              "sha256": "cf8baf1c55e62ffcace7a9f06f4bd9cd3f0c4beb022d3b367256b91b87513d98",
++              "type": "tar.gz",
++              "urls": [
++                "https://static.crates.io/crates/memchr/2.8.3/download"
++              ],
++              "strip_prefix": "memchr-2.8.3",
++              "build_file_content": "###############################################################################\n# @generated\n# DO NOT MODIFY: This file is auto-generated by a crate_universe tool. To \n# regenerate this file, run the following:\n#\n#     bazel mod show_repo 'protobuf'\n###############################################################################\n\nload(\"@rules_rust//cargo:defs.bzl\", \"cargo_toml_env_vars\")\n\nload(\"@rules_rust//rust:defs.bzl\", \"rust_library\")\n\n# buildifier: disable=bzl-visibility\nload(\"@rules_rust//crate_universe/private:selects.bzl\", \"selects\")\n\npackage(default_visibility = [\"//visibility:public\"])\n\ncargo_toml_env_vars(\n    name = \"cargo_toml_env_vars\",\n    src = \"Cargo.toml\",\n)\n\nrust_library(\n    name = \"memchr\",\n    compile_data = glob(\n        allow_empty = True,\n        include = [\"**\"],\n        exclude = [\n            \"**/* *\",\n            \".tmp_git_root/**/*\",\n            \"BUILD\",\n            \"BUILD.bazel\",\n            \"WORKSPACE\",\n            \"WORKSPACE.bazel\",\n        ],\n    ),\n    crate_features = [\n        \"alloc\",\n        \"std\",\n    ],\n    crate_root = \"src/lib.rs\",\n    edition = \"2021\",\n    rustc_env_files = [\n        \":cargo_toml_env_vars\",\n    ],\n    rustc_flags = [\n        \"--cap-lints=allow\",\n    ],\n    srcs = glob(\n        allow_empty = True,\n        include = [\"**/*.rs\"],\n    ),\n    tags = [\n        \"cargo-bazel\",\n        \"crate-name=memchr\",\n        \"manual\",\n        \"noclippy\",\n        \"norustfmt\",\n    ],\n    target_compatible_with = select({\n        \"@rules_rust//rust/platform:aarch64-apple-darwin\": [],\n        \"@rules_rust//rust/platform:aarch64-unknown-linux-gnu\": [],\n        \"@rules_rust//rust/platform:wasm32-unknown-unknown\": [],\n        \"@rules_rust//rust/platform:wasm32-wasip1\": [],\n        \"@rules_rust//rust/platform:x86_64-pc-windows-msvc\": [],\n        \"@rules_rust//rust/platform:x86_64-unknown-linux-gnu\": [],\n        \"@rules_rust//rust/platform:x86_64-unknown-nixos-gnu\": [],\n        \"//conditions:default\": [\"@platforms//:incompatible\"],\n    }),\n    version = \"2.8.3\",\n)\n"
++            }
++          },
++          "crates__num-traits-0.2.19": {
++            "repoRuleId": "@@bazel_tools//tools/build_defs/repo:http.bzl%http_archive",
++            "attributes": {
++              "patch_args": [],
++              "patch_tool": "",
++              "patches": [],
++              "remote_patch_strip": 1,
++              "sha256": "071dfc062690e90b734c0b2273ce72ad0ffa95f0c74596bc250dcfd960262841",
++              "type": "tar.gz",
++              "urls": [
++                "https://static.crates.io/crates/num-traits/0.2.19/download"
++              ],
++              "strip_prefix": "num-traits-0.2.19",
++              "build_file_content": "###############################################################################\n# @generated\n# DO NOT MODIFY: This file is auto-generated by a crate_universe tool. To \n# regenerate this file, run the following:\n#\n#     bazel mod show_repo 'protobuf'\n###############################################################################\n\nload(\n    \"@rules_rust//cargo:defs.bzl\",\n    \"cargo_build_script\",\n    \"cargo_toml_env_vars\",\n)\n\nload(\"@rules_rust//rust:defs.bzl\", \"rust_library\")\n\n# buildifier: disable=bzl-visibility\nload(\"@rules_rust//crate_universe/private:selects.bzl\", \"selects\")\n\npackage(default_visibility = [\"//visibility:public\"])\n\ncargo_toml_env_vars(\n    name = \"cargo_toml_env_vars\",\n    src = \"Cargo.toml\",\n)\n\nrust_library(\n    name = \"num_traits\",\n    deps = [\n        \"@crates__num-traits-0.2.19//:build_script_build\",\n    ],\n    compile_data = glob(\n        allow_empty = True,\n        include = [\"**\"],\n        exclude = [\n            \"**/* *\",\n            \".tmp_git_root/**/*\",\n            \"BUILD\",\n            \"BUILD.bazel\",\n            \"WORKSPACE\",\n            \"WORKSPACE.bazel\",\n        ],\n    ),\n    crate_features = [\n        \"default\",\n        \"std\",\n    ],\n    crate_root = \"src/lib.rs\",\n    edition = \"2021\",\n    rustc_env_files = [\n        \":cargo_toml_env_vars\",\n    ],\n    rustc_flags = [\n        \"--cap-lints=allow\",\n    ],\n    srcs = glob(\n        allow_empty = True,\n        include = [\"**/*.rs\"],\n    ),\n    tags = [\n        \"cargo-bazel\",\n        \"crate-name=num-traits\",\n        \"manual\",\n        \"noclippy\",\n        \"norustfmt\",\n    ],\n    target_compatible_with = select({\n        \"@rules_rust//rust/platform:aarch64-apple-darwin\": [],\n        \"@rules_rust//rust/platform:aarch64-unknown-linux-gnu\": [],\n        \"@rules_rust//rust/platform:wasm32-unknown-unknown\": [],\n        \"@rules_rust//rust/platform:wasm32-wasip1\": [],\n        \"@rules_rust//rust/platform:x86_64-pc-windows-msvc\": [],\n        \"@rules_rust//rust/platform:x86_64-unknown-linux-gnu\": [],\n        \"@rules_rust//rust/platform:x86_64-unknown-nixos-gnu\": [],\n        \"//conditions:default\": [\"@platforms//:incompatible\"],\n    }),\n    version = \"0.2.19\",\n)\n\ncargo_build_script(\n    name = \"_bs\",\n    compile_data = glob(\n        allow_empty = True,\n        include = [\"**\"],\n        exclude = [\n            \"**/* *\",\n            \"**/*.rs\",\n            \".tmp_git_root/**/*\",\n            \"BUILD\",\n            \"BUILD.bazel\",\n            \"WORKSPACE\",\n            \"WORKSPACE.bazel\",\n        ],\n    ),\n    crate_features = [\n        \"default\",\n        \"std\",\n    ],\n    crate_name = \"build_script_build\",\n    crate_root = \"build.rs\",\n    data = glob(\n        allow_empty = True,\n        include = [\"**\"],\n        exclude = [\n            \"**/* *\",\n            \".tmp_git_root/**/*\",\n            \"BUILD\",\n            \"BUILD.bazel\",\n            \"WORKSPACE\",\n            \"WORKSPACE.bazel\",\n        ],\n    ),\n    deps = [\n        \"@crates__autocfg-1.5.1//:autocfg\",\n    ],\n    edition = \"2021\",\n    pkg_name = \"num-traits\",\n    rustc_env_files = [\n        \":cargo_toml_env_vars\",\n    ],\n    rustc_flags = [\n        \"--cap-lints=allow\",\n    ],\n    srcs = glob(\n        allow_empty = True,\n        include = [\"**/*.rs\"],\n    ),\n    tags = [\n        \"cargo-bazel\",\n        \"crate-name=num-traits\",\n        \"manual\",\n        \"noclippy\",\n        \"norustfmt\",\n    ],\n    version = \"0.2.19\",\n    visibility = [\"//visibility:private\"],\n)\n\nalias(\n    name = \"build_script_build\",\n    actual = \":_bs\",\n    tags = [\"manual\"],\n)\n"
++            }
++          },
++          "crates__paste-1.0.15": {
++            "repoRuleId": "@@bazel_tools//tools/build_defs/repo:http.bzl%http_archive",
++            "attributes": {
++              "patch_args": [],
++              "patch_tool": "",
++              "patches": [],
++              "remote_patch_strip": 1,
++              "sha256": "57c0d7b74b563b49d38dae00a0c37d4d6de9b432382b2892f0574ddcae73fd0a",
++              "type": "tar.gz",
++              "urls": [
++                "https://static.crates.io/crates/paste/1.0.15/download"
++              ],
++              "strip_prefix": "paste-1.0.15",
++              "build_file_content": "###############################################################################\n# @generated\n# DO NOT MODIFY: This file is auto-generated by a crate_universe tool. To \n# regenerate this file, run the following:\n#\n#     bazel mod show_repo 'protobuf'\n###############################################################################\n\nload(\n    \"@rules_rust//cargo:defs.bzl\",\n    \"cargo_build_script\",\n    \"cargo_toml_env_vars\",\n)\n\nload(\"@rules_rust//rust:defs.bzl\", \"rust_proc_macro\")\n\n# buildifier: disable=bzl-visibility\nload(\"@rules_rust//crate_universe/private:selects.bzl\", \"selects\")\n\npackage(default_visibility = [\"//visibility:public\"])\n\ncargo_toml_env_vars(\n    name = \"cargo_toml_env_vars\",\n    src = \"Cargo.toml\",\n)\n\nrust_proc_macro(\n    name = \"paste\",\n    deps = [\n        \"@crates__paste-1.0.15//:build_script_build\",\n    ],\n    compile_data = glob(\n        allow_empty = True,\n        include = [\"**\"],\n        exclude = [\n            \"**/* *\",\n            \".tmp_git_root/**/*\",\n            \"BUILD\",\n            \"BUILD.bazel\",\n            \"WORKSPACE\",\n            \"WORKSPACE.bazel\",\n        ],\n    ),\n    crate_root = \"src/lib.rs\",\n    edition = \"2018\",\n    rustc_env_files = [\n        \":cargo_toml_env_vars\",\n    ],\n    rustc_flags = [\n        \"--cap-lints=allow\",\n    ],\n    srcs = glob(\n        allow_empty = True,\n        include = [\"**/*.rs\"],\n    ),\n    tags = [\n        \"cargo-bazel\",\n        \"crate-name=paste\",\n        \"manual\",\n        \"noclippy\",\n        \"norustfmt\",\n    ],\n    target_compatible_with = select({\n        \"@rules_rust//rust/platform:aarch64-apple-darwin\": [],\n        \"@rules_rust//rust/platform:aarch64-unknown-linux-gnu\": [],\n        \"@rules_rust//rust/platform:wasm32-unknown-unknown\": [],\n        \"@rules_rust//rust/platform:wasm32-wasip1\": [],\n        \"@rules_rust//rust/platform:x86_64-pc-windows-msvc\": [],\n        \"@rules_rust//rust/platform:x86_64-unknown-linux-gnu\": [],\n        \"@rules_rust//rust/platform:x86_64-unknown-nixos-gnu\": [],\n        \"//conditions:default\": [\"@platforms//:incompatible\"],\n    }),\n    version = \"1.0.15\",\n)\n\ncargo_build_script(\n    name = \"_bs\",\n    compile_data = glob(\n        allow_empty = True,\n        include = [\"**\"],\n        exclude = [\n            \"**/* *\",\n            \"**/*.rs\",\n            \".tmp_git_root/**/*\",\n            \"BUILD\",\n            \"BUILD.bazel\",\n            \"WORKSPACE\",\n            \"WORKSPACE.bazel\",\n        ],\n    ),\n    crate_name = \"build_script_build\",\n    crate_root = \"build.rs\",\n    data = glob(\n        allow_empty = True,\n        include = [\"**\"],\n        exclude = [\n            \"**/* *\",\n            \".tmp_git_root/**/*\",\n            \"BUILD\",\n            \"BUILD.bazel\",\n            \"WORKSPACE\",\n            \"WORKSPACE.bazel\",\n        ],\n    ),\n    edition = \"2018\",\n    pkg_name = \"paste\",\n    rustc_env_files = [\n        \":cargo_toml_env_vars\",\n    ],\n    rustc_flags = [\n        \"--cap-lints=allow\",\n    ],\n    srcs = glob(\n        allow_empty = True,\n        include = [\"**/*.rs\"],\n    ),\n    tags = [\n        \"cargo-bazel\",\n        \"crate-name=paste\",\n        \"manual\",\n        \"noclippy\",\n        \"norustfmt\",\n    ],\n    version = \"1.0.15\",\n    visibility = [\"//visibility:private\"],\n)\n\nalias(\n    name = \"build_script_build\",\n    actual = \":_bs\",\n    tags = [\"manual\"],\n)\n"
++            }
++          },
++          "crates__proc-macro2-1.0.107": {
++            "repoRuleId": "@@bazel_tools//tools/build_defs/repo:http.bzl%http_archive",
++            "attributes": {
++              "patch_args": [],
++              "patch_tool": "",
++              "patches": [],
++              "remote_patch_strip": 1,
++              "sha256": "985e7ec9bb745e6ce6535b544d84d6cd6f7ad8bd711c398938ae983b91a766d9",
++              "type": "tar.gz",
++              "urls": [
++                "https://static.crates.io/crates/proc-macro2/1.0.107/download"
++              ],
++              "strip_prefix": "proc-macro2-1.0.107",
++              "build_file_content": "###############################################################################\n# @generated\n# DO NOT MODIFY: This file is auto-generated by a crate_universe tool. To \n# regenerate this file, run the following:\n#\n#     bazel mod show_repo 'protobuf'\n###############################################################################\n\nload(\n    \"@rules_rust//cargo:defs.bzl\",\n    \"cargo_build_script\",\n    \"cargo_toml_env_vars\",\n)\n\nload(\"@rules_rust//rust:defs.bzl\", \"rust_library\")\n\n# buildifier: disable=bzl-visibility\nload(\"@rules_rust//crate_universe/private:selects.bzl\", \"selects\")\n\npackage(default_visibility = [\"//visibility:public\"])\n\ncargo_toml_env_vars(\n    name = \"cargo_toml_env_vars\",\n    src = \"Cargo.toml\",\n)\n\nrust_library(\n    name = \"proc_macro2\",\n    deps = [\n        \"@crates__proc-macro2-1.0.107//:build_script_build\",\n        \"@crates__unicode-ident-1.0.24//:unicode_ident\",\n    ],\n    compile_data = glob(\n        allow_empty = True,\n        include = [\"**\"],\n        exclude = [\n            \"**/* *\",\n            \".tmp_git_root/**/*\",\n            \"BUILD\",\n            \"BUILD.bazel\",\n            \"WORKSPACE\",\n            \"WORKSPACE.bazel\",\n        ],\n    ),\n    crate_features = [\n        \"proc-macro\",\n    ] + select({\n        \"@rules_rust//rust/platform:aarch64-apple-darwin\": [\n            \"default\",  # aarch64-apple-darwin\n        ],\n        \"@rules_rust//rust/platform:aarch64-unknown-linux-gnu\": [\n            \"default\",  # aarch64-unknown-linux-gnu\n        ],\n        \"@rules_rust//rust/platform:x86_64-pc-windows-msvc\": [\n            \"default\",  # x86_64-pc-windows-msvc\n        ],\n        \"@rules_rust//rust/platform:x86_64-unknown-linux-gnu\": [\n            \"default\",  # x86_64-unknown-linux-gnu\n        ],\n        \"@rules_rust//rust/platform:x86_64-unknown-nixos-gnu\": [\n            \"default\",  # x86_64-unknown-nixos-gnu\n        ],\n        \"//conditions:default\": [],\n    }),\n    crate_root = \"src/lib.rs\",\n    edition = \"2021\",\n    rustc_env_files = [\n        \":cargo_toml_env_vars\",\n    ],\n    rustc_flags = [\n        \"--cap-lints=allow\",\n    ],\n    srcs = glob(\n        allow_empty = True,\n        include = [\"**/*.rs\"],\n    ),\n    tags = [\n        \"cargo-bazel\",\n        \"crate-name=proc-macro2\",\n        \"manual\",\n        \"noclippy\",\n        \"norustfmt\",\n    ],\n    target_compatible_with = select({\n        \"@rules_rust//rust/platform:aarch64-apple-darwin\": [],\n        \"@rules_rust//rust/platform:aarch64-unknown-linux-gnu\": [],\n        \"@rules_rust//rust/platform:wasm32-unknown-unknown\": [],\n        \"@rules_rust//rust/platform:wasm32-wasip1\": [],\n        \"@rules_rust//rust/platform:x86_64-pc-windows-msvc\": [],\n        \"@rules_rust//rust/platform:x86_64-unknown-linux-gnu\": [],\n        \"@rules_rust//rust/platform:x86_64-unknown-nixos-gnu\": [],\n        \"//conditions:default\": [\"@platforms//:incompatible\"],\n    }),\n    version = \"1.0.107\",\n)\n\ncargo_build_script(\n    name = \"_bs\",\n    compile_data = glob(\n        allow_empty = True,\n        include = [\"**\"],\n        exclude = [\n            \"**/* *\",\n            \"**/*.rs\",\n            \".tmp_git_root/**/*\",\n            \"BUILD\",\n            \"BUILD.bazel\",\n            \"WORKSPACE\",\n            \"WORKSPACE.bazel\",\n        ],\n    ),\n    crate_features = [\n        \"proc-macro\",\n    ] + select({\n        \"@rules_rust//rust/platform:aarch64-apple-darwin\": [\n            \"default\",  # aarch64-apple-darwin\n        ],\n        \"@rules_rust//rust/platform:aarch64-unknown-linux-gnu\": [\n            \"default\",  # aarch64-unknown-linux-gnu\n        ],\n        \"@rules_rust//rust/platform:x86_64-pc-windows-msvc\": [\n            \"default\",  # x86_64-pc-windows-msvc\n        ],\n        \"@rules_rust//rust/platform:x86_64-unknown-linux-gnu\": [\n            \"default\",  # x86_64-unknown-linux-gnu\n        ],\n        \"@rules_rust//rust/platform:x86_64-unknown-nixos-gnu\": [\n            \"default\",  # x86_64-unknown-nixos-gnu\n        ],\n        \"//conditions:default\": [],\n    }),\n    crate_name = \"build_script_build\",\n    crate_root = \"build.rs\",\n    data = glob(\n        allow_empty = True,\n        include = [\"**\"],\n        exclude = [\n            \"**/* *\",\n            \".tmp_git_root/**/*\",\n            \"BUILD\",\n            \"BUILD.bazel\",\n            \"WORKSPACE\",\n            \"WORKSPACE.bazel\",\n        ],\n    ),\n    edition = \"2021\",\n    pkg_name = \"proc-macro2\",\n    rustc_env_files = [\n        \":cargo_toml_env_vars\",\n    ],\n    rustc_flags = [\n        \"--cap-lints=allow\",\n    ],\n    srcs = glob(\n        allow_empty = True,\n        include = [\"**/*.rs\"],\n    ),\n    tags = [\n        \"cargo-bazel\",\n        \"crate-name=proc-macro2\",\n        \"manual\",\n        \"noclippy\",\n        \"norustfmt\",\n    ],\n    version = \"1.0.107\",\n    visibility = [\"//visibility:private\"],\n)\n\nalias(\n    name = \"build_script_build\",\n    actual = \":_bs\",\n    tags = [\"manual\"],\n)\n"
++            }
++          },
++          "crates__quote-1.0.47": {
++            "repoRuleId": "@@bazel_tools//tools/build_defs/repo:http.bzl%http_archive",
++            "attributes": {
++              "patch_args": [],
++              "patch_tool": "",
++              "patches": [],
++              "remote_patch_strip": 1,
++              "sha256": "1fbf4db142a473a8d80c26bbf18454ed458bf8d26c8219c331daecfdbd079001",
++              "type": "tar.gz",
++              "urls": [
++                "https://static.crates.io/crates/quote/1.0.47/download"
++              ],
++              "strip_prefix": "quote-1.0.47",
++              "build_file_content": "###############################################################################\n# @generated\n# DO NOT MODIFY: This file is auto-generated by a crate_universe tool. To \n# regenerate this file, run the following:\n#\n#     bazel mod show_repo 'protobuf'\n###############################################################################\n\nload(\n    \"@rules_rust//cargo:defs.bzl\",\n    \"cargo_build_script\",\n    \"cargo_toml_env_vars\",\n)\n\nload(\"@rules_rust//rust:defs.bzl\", \"rust_library\")\n\n# buildifier: disable=bzl-visibility\nload(\"@rules_rust//crate_universe/private:selects.bzl\", \"selects\")\n\npackage(default_visibility = [\"//visibility:public\"])\n\ncargo_toml_env_vars(\n    name = \"cargo_toml_env_vars\",\n    src = \"Cargo.toml\",\n)\n\nrust_library(\n    name = \"quote\",\n    deps = [\n        \"@crates__proc-macro2-1.0.107//:proc_macro2\",\n        \"@crates__quote-1.0.47//:build_script_build\",\n    ],\n    compile_data = glob(\n        allow_empty = True,\n        include = [\"**\"],\n        exclude = [\n            \"**/* *\",\n            \".tmp_git_root/**/*\",\n            \"BUILD\",\n            \"BUILD.bazel\",\n            \"WORKSPACE\",\n            \"WORKSPACE.bazel\",\n        ],\n    ),\n    crate_features = [\n        \"default\",\n        \"proc-macro\",\n    ],\n    crate_root = \"src/lib.rs\",\n    edition = \"2021\",\n    rustc_env_files = [\n        \":cargo_toml_env_vars\",\n    ],\n    rustc_flags = [\n        \"--cap-lints=allow\",\n    ],\n    srcs = glob(\n        allow_empty = True,\n        include = [\"**/*.rs\"],\n    ),\n    tags = [\n        \"cargo-bazel\",\n        \"crate-name=quote\",\n        \"manual\",\n        \"noclippy\",\n        \"norustfmt\",\n    ],\n    target_compatible_with = select({\n        \"@rules_rust//rust/platform:aarch64-apple-darwin\": [],\n        \"@rules_rust//rust/platform:aarch64-unknown-linux-gnu\": [],\n        \"@rules_rust//rust/platform:wasm32-unknown-unknown\": [],\n        \"@rules_rust//rust/platform:wasm32-wasip1\": [],\n        \"@rules_rust//rust/platform:x86_64-pc-windows-msvc\": [],\n        \"@rules_rust//rust/platform:x86_64-unknown-linux-gnu\": [],\n        \"@rules_rust//rust/platform:x86_64-unknown-nixos-gnu\": [],\n        \"//conditions:default\": [\"@platforms//:incompatible\"],\n    }),\n    version = \"1.0.47\",\n)\n\ncargo_build_script(\n    name = \"_bs\",\n    compile_data = glob(\n        allow_empty = True,\n        include = [\"**\"],\n        exclude = [\n            \"**/* *\",\n            \"**/*.rs\",\n            \".tmp_git_root/**/*\",\n            \"BUILD\",\n            \"BUILD.bazel\",\n            \"WORKSPACE\",\n            \"WORKSPACE.bazel\",\n        ],\n    ),\n    crate_features = [\n        \"default\",\n        \"proc-macro\",\n    ],\n    crate_name = \"build_script_build\",\n    crate_root = \"build.rs\",\n    data = glob(\n        allow_empty = True,\n        include = [\"**\"],\n        exclude = [\n            \"**/* *\",\n            \".tmp_git_root/**/*\",\n            \"BUILD\",\n            \"BUILD.bazel\",\n            \"WORKSPACE\",\n            \"WORKSPACE.bazel\",\n        ],\n    ),\n    edition = \"2021\",\n    pkg_name = \"quote\",\n    rustc_env_files = [\n        \":cargo_toml_env_vars\",\n    ],\n    rustc_flags = [\n        \"--cap-lints=allow\",\n    ],\n    srcs = glob(\n        allow_empty = True,\n        include = [\"**/*.rs\"],\n    ),\n    tags = [\n        \"cargo-bazel\",\n        \"crate-name=quote\",\n        \"manual\",\n        \"noclippy\",\n        \"norustfmt\",\n    ],\n    version = \"1.0.47\",\n    visibility = [\"//visibility:private\"],\n)\n\nalias(\n    name = \"build_script_build\",\n    actual = \":_bs\",\n    tags = [\"manual\"],\n)\n"
++            }
++          },
++          "crates__regex-1.13.1": {
++            "repoRuleId": "@@bazel_tools//tools/build_defs/repo:http.bzl%http_archive",
++            "attributes": {
++              "patch_args": [],
++              "patch_tool": "",
++              "patches": [],
++              "remote_patch_strip": 1,
++              "sha256": "f020237b6c8eed93db2e2cb53c00c60a8e1bc73da7d073199a1180401450218d",
++              "type": "tar.gz",
++              "urls": [
++                "https://static.crates.io/crates/regex/1.13.1/download"
++              ],
++              "strip_prefix": "regex-1.13.1",
++              "build_file_content": "###############################################################################\n# @generated\n# DO NOT MODIFY: This file is auto-generated by a crate_universe tool. To \n# regenerate this file, run the following:\n#\n#     bazel mod show_repo 'protobuf'\n###############################################################################\n\nload(\"@rules_rust//cargo:defs.bzl\", \"cargo_toml_env_vars\")\n\nload(\"@rules_rust//rust:defs.bzl\", \"rust_library\")\n\n# buildifier: disable=bzl-visibility\nload(\"@rules_rust//crate_universe/private:selects.bzl\", \"selects\")\n\npackage(default_visibility = [\"//visibility:public\"])\n\ncargo_toml_env_vars(\n    name = \"cargo_toml_env_vars\",\n    src = \"Cargo.toml\",\n)\n\nrust_library(\n    name = \"regex\",\n    deps = [\n        \"@crates__aho-corasick-1.1.5//:aho_corasick\",\n        \"@crates__memchr-2.8.3//:memchr\",\n        \"@crates__regex-automata-0.4.18//:regex_automata\",\n        \"@crates__regex-syntax-0.8.11//:regex_syntax\",\n    ],\n    compile_data = glob(\n        allow_empty = True,\n        include = [\"**\"],\n        exclude = [\n            \"**/* *\",\n            \".tmp_git_root/**/*\",\n            \"BUILD\",\n            \"BUILD.bazel\",\n            \"WORKSPACE\",\n            \"WORKSPACE.bazel\",\n        ],\n    ),\n    crate_features = [\n        \"default\",\n        \"perf\",\n        \"perf-backtrack\",\n        \"perf-cache\",\n        \"perf-dfa\",\n        \"perf-inline\",\n        \"perf-literal\",\n        \"perf-onepass\",\n        \"std\",\n        \"unicode\",\n        \"unicode-age\",\n        \"unicode-bool\",\n        \"unicode-case\",\n        \"unicode-gencat\",\n        \"unicode-perl\",\n        \"unicode-script\",\n        \"unicode-segment\",\n    ],\n    crate_root = \"src/lib.rs\",\n    edition = \"2021\",\n    rustc_env_files = [\n        \":cargo_toml_env_vars\",\n    ],\n    rustc_flags = [\n        \"--cap-lints=allow\",\n    ],\n    srcs = glob(\n        allow_empty = True,\n        include = [\"**/*.rs\"],\n    ),\n    tags = [\n        \"cargo-bazel\",\n        \"crate-name=regex\",\n        \"manual\",\n        \"noclippy\",\n        \"norustfmt\",\n    ],\n    target_compatible_with = select({\n        \"@rules_rust//rust/platform:aarch64-apple-darwin\": [],\n        \"@rules_rust//rust/platform:aarch64-unknown-linux-gnu\": [],\n        \"@rules_rust//rust/platform:wasm32-unknown-unknown\": [],\n        \"@rules_rust//rust/platform:wasm32-wasip1\": [],\n        \"@rules_rust//rust/platform:x86_64-pc-windows-msvc\": [],\n        \"@rules_rust//rust/platform:x86_64-unknown-linux-gnu\": [],\n        \"@rules_rust//rust/platform:x86_64-unknown-nixos-gnu\": [],\n        \"//conditions:default\": [\"@platforms//:incompatible\"],\n    }),\n    version = \"1.13.1\",\n)\n"
++            }
++          },
++          "crates__regex-automata-0.4.18": {
++            "repoRuleId": "@@bazel_tools//tools/build_defs/repo:http.bzl%http_archive",
++            "attributes": {
++              "patch_args": [],
++              "patch_tool": "",
++              "patches": [],
++              "remote_patch_strip": 1,
++              "sha256": "ad8553b9b26413251cbf30e620595c7a41b3887f03da04579c0e6b0d6a06b4b2",
++              "type": "tar.gz",
++              "urls": [
++                "https://static.crates.io/crates/regex-automata/0.4.18/download"
++              ],
++              "strip_prefix": "regex-automata-0.4.18",
++              "build_file_content": "###############################################################################\n# @generated\n# DO NOT MODIFY: This file is auto-generated by a crate_universe tool. To \n# regenerate this file, run the following:\n#\n#     bazel mod show_repo 'protobuf'\n###############################################################################\n\nload(\"@rules_rust//cargo:defs.bzl\", \"cargo_toml_env_vars\")\n\nload(\"@rules_rust//rust:defs.bzl\", \"rust_library\")\n\n# buildifier: disable=bzl-visibility\nload(\"@rules_rust//crate_universe/private:selects.bzl\", \"selects\")\n\npackage(default_visibility = [\"//visibility:public\"])\n\ncargo_toml_env_vars(\n    name = \"cargo_toml_env_vars\",\n    src = \"Cargo.toml\",\n)\n\nrust_library(\n    name = \"regex_automata\",\n    deps = [\n        \"@crates__aho-corasick-1.1.5//:aho_corasick\",\n        \"@crates__memchr-2.8.3//:memchr\",\n        \"@crates__regex-syntax-0.8.11//:regex_syntax\",\n    ],\n    compile_data = glob(\n        allow_empty = True,\n        include = [\"**\"],\n        exclude = [\n            \"**/* *\",\n            \".tmp_git_root/**/*\",\n            \"BUILD\",\n            \"BUILD.bazel\",\n            \"WORKSPACE\",\n            \"WORKSPACE.bazel\",\n        ],\n    ),\n    crate_features = [\n        \"alloc\",\n        \"dfa-onepass\",\n        \"hybrid\",\n        \"meta\",\n        \"nfa-backtrack\",\n        \"nfa-pikevm\",\n        \"nfa-thompson\",\n        \"perf-inline\",\n        \"perf-literal\",\n        \"perf-literal-multisubstring\",\n        \"perf-literal-substring\",\n        \"std\",\n        \"syntax\",\n        \"unicode\",\n        \"unicode-age\",\n        \"unicode-bool\",\n        \"unicode-case\",\n        \"unicode-gencat\",\n        \"unicode-perl\",\n        \"unicode-script\",\n        \"unicode-segment\",\n        \"unicode-word-boundary\",\n    ],\n    crate_root = \"src/lib.rs\",\n    edition = \"2021\",\n    rustc_env_files = [\n        \":cargo_toml_env_vars\",\n    ],\n    rustc_flags = [\n        \"--cap-lints=allow\",\n    ],\n    srcs = glob(\n        allow_empty = True,\n        include = [\"**/*.rs\"],\n    ),\n    tags = [\n        \"cargo-bazel\",\n        \"crate-name=regex-automata\",\n        \"manual\",\n        \"noclippy\",\n        \"norustfmt\",\n    ],\n    target_compatible_with = select({\n        \"@rules_rust//rust/platform:aarch64-apple-darwin\": [],\n        \"@rules_rust//rust/platform:aarch64-unknown-linux-gnu\": [],\n        \"@rules_rust//rust/platform:wasm32-unknown-unknown\": [],\n        \"@rules_rust//rust/platform:wasm32-wasip1\": [],\n        \"@rules_rust//rust/platform:x86_64-pc-windows-msvc\": [],\n        \"@rules_rust//rust/platform:x86_64-unknown-linux-gnu\": [],\n        \"@rules_rust//rust/platform:x86_64-unknown-nixos-gnu\": [],\n        \"//conditions:default\": [\"@platforms//:incompatible\"],\n    }),\n    version = \"0.4.18\",\n)\n"
++            }
++          },
++          "crates__regex-syntax-0.8.11": {
++            "repoRuleId": "@@bazel_tools//tools/build_defs/repo:http.bzl%http_archive",
++            "attributes": {
++              "patch_args": [],
++              "patch_tool": "",
++              "patches": [],
++              "remote_patch_strip": 1,
++              "sha256": "d6f6ff9a378485b298a5286656da665ba74413d36db0979633275d2e708145d4",
++              "type": "tar.gz",
++              "urls": [
++                "https://static.crates.io/crates/regex-syntax/0.8.11/download"
++              ],
++              "strip_prefix": "regex-syntax-0.8.11",
++              "build_file_content": "###############################################################################\n# @generated\n# DO NOT MODIFY: This file is auto-generated by a crate_universe tool. To \n# regenerate this file, run the following:\n#\n#     bazel mod show_repo 'protobuf'\n###############################################################################\n\nload(\"@rules_rust//cargo:defs.bzl\", \"cargo_toml_env_vars\")\n\nload(\"@rules_rust//rust:defs.bzl\", \"rust_library\")\n\n# buildifier: disable=bzl-visibility\nload(\"@rules_rust//crate_universe/private:selects.bzl\", \"selects\")\n\npackage(default_visibility = [\"//visibility:public\"])\n\ncargo_toml_env_vars(\n    name = \"cargo_toml_env_vars\",\n    src = \"Cargo.toml\",\n)\n\nrust_library(\n    name = \"regex_syntax\",\n    compile_data = glob(\n        allow_empty = True,\n        include = [\"**\"],\n        exclude = [\n            \"**/* *\",\n            \".tmp_git_root/**/*\",\n            \"BUILD\",\n            \"BUILD.bazel\",\n            \"WORKSPACE\",\n            \"WORKSPACE.bazel\",\n        ],\n    ),\n    crate_features = [\n        \"default\",\n        \"std\",\n        \"unicode\",\n        \"unicode-age\",\n        \"unicode-bool\",\n        \"unicode-case\",\n        \"unicode-gencat\",\n        \"unicode-perl\",\n        \"unicode-script\",\n        \"unicode-segment\",\n    ],\n    crate_root = \"src/lib.rs\",\n    edition = \"2021\",\n    rustc_env_files = [\n        \":cargo_toml_env_vars\",\n    ],\n    rustc_flags = [\n        \"--cap-lints=allow\",\n    ],\n    srcs = glob(\n        allow_empty = True,\n        include = [\"**/*.rs\"],\n    ),\n    tags = [\n        \"cargo-bazel\",\n        \"crate-name=regex-syntax\",\n        \"manual\",\n        \"noclippy\",\n        \"norustfmt\",\n    ],\n    target_compatible_with = select({\n        \"@rules_rust//rust/platform:aarch64-apple-darwin\": [],\n        \"@rules_rust//rust/platform:aarch64-unknown-linux-gnu\": [],\n        \"@rules_rust//rust/platform:wasm32-unknown-unknown\": [],\n        \"@rules_rust//rust/platform:wasm32-wasip1\": [],\n        \"@rules_rust//rust/platform:x86_64-pc-windows-msvc\": [],\n        \"@rules_rust//rust/platform:x86_64-unknown-linux-gnu\": [],\n        \"@rules_rust//rust/platform:x86_64-unknown-nixos-gnu\": [],\n        \"//conditions:default\": [\"@platforms//:incompatible\"],\n    }),\n    version = \"0.8.11\",\n)\n"
++            }
++          },
++          "crates__rustversion-1.0.23": {
++            "repoRuleId": "@@bazel_tools//tools/build_defs/repo:http.bzl%http_archive",
++            "attributes": {
++              "patch_args": [],
++              "patch_tool": "",
++              "patches": [],
++              "remote_patch_strip": 1,
++              "sha256": "cf54715a573b99ac80df0bc206da022bcd442c974952c7b9720069370852e21f",
++              "type": "tar.gz",
++              "urls": [
++                "https://static.crates.io/crates/rustversion/1.0.23/download"
++              ],
++              "strip_prefix": "rustversion-1.0.23",
++              "build_file_content": "###############################################################################\n# @generated\n# DO NOT MODIFY: This file is auto-generated by a crate_universe tool. To \n# regenerate this file, run the following:\n#\n#     bazel mod show_repo 'protobuf'\n###############################################################################\n\nload(\n    \"@rules_rust//cargo:defs.bzl\",\n    \"cargo_build_script\",\n    \"cargo_toml_env_vars\",\n)\n\nload(\"@rules_rust//rust:defs.bzl\", \"rust_proc_macro\")\n\n# buildifier: disable=bzl-visibility\nload(\"@rules_rust//crate_universe/private:selects.bzl\", \"selects\")\n\npackage(default_visibility = [\"//visibility:public\"])\n\ncargo_toml_env_vars(\n    name = \"cargo_toml_env_vars\",\n    src = \"Cargo.toml\",\n)\n\nrust_proc_macro(\n    name = \"rustversion\",\n    deps = [\n        \"@crates__rustversion-1.0.23//:build_script_build\",\n    ],\n    compile_data = glob(\n        allow_empty = True,\n        include = [\"**\"],\n        exclude = [\n            \"**/* *\",\n            \".tmp_git_root/**/*\",\n            \"BUILD\",\n            \"BUILD.bazel\",\n            \"WORKSPACE\",\n            \"WORKSPACE.bazel\",\n        ],\n    ),\n    crate_root = \"src/lib.rs\",\n    edition = \"2018\",\n    rustc_env_files = [\n        \":cargo_toml_env_vars\",\n    ],\n    rustc_flags = [\n        \"--cap-lints=allow\",\n    ],\n    srcs = glob(\n        allow_empty = True,\n        include = [\"**/*.rs\"],\n    ),\n    tags = [\n        \"cargo-bazel\",\n        \"crate-name=rustversion\",\n        \"manual\",\n        \"noclippy\",\n        \"norustfmt\",\n    ],\n    target_compatible_with = select({\n        \"@rules_rust//rust/platform:aarch64-apple-darwin\": [],\n        \"@rules_rust//rust/platform:aarch64-unknown-linux-gnu\": [],\n        \"@rules_rust//rust/platform:wasm32-unknown-unknown\": [],\n        \"@rules_rust//rust/platform:wasm32-wasip1\": [],\n        \"@rules_rust//rust/platform:x86_64-pc-windows-msvc\": [],\n        \"@rules_rust//rust/platform:x86_64-unknown-linux-gnu\": [],\n        \"@rules_rust//rust/platform:x86_64-unknown-nixos-gnu\": [],\n        \"//conditions:default\": [\"@platforms//:incompatible\"],\n    }),\n    version = \"1.0.23\",\n)\n\ncargo_build_script(\n    name = \"_bs\",\n    compile_data = glob(\n        allow_empty = True,\n        include = [\"**\"],\n        exclude = [\n            \"**/* *\",\n            \"**/*.rs\",\n            \".tmp_git_root/**/*\",\n            \"BUILD\",\n            \"BUILD.bazel\",\n            \"WORKSPACE\",\n            \"WORKSPACE.bazel\",\n        ],\n    ),\n    crate_name = \"build_script_build\",\n    crate_root = \"build/build.rs\",\n    data = glob(\n        allow_empty = True,\n        include = [\"**\"],\n        exclude = [\n            \"**/* *\",\n            \".tmp_git_root/**/*\",\n            \"BUILD\",\n            \"BUILD.bazel\",\n            \"WORKSPACE\",\n            \"WORKSPACE.bazel\",\n        ],\n    ),\n    edition = \"2018\",\n    pkg_name = \"rustversion\",\n    rustc_env_files = [\n        \":cargo_toml_env_vars\",\n    ],\n    rustc_flags = [\n        \"--cap-lints=allow\",\n    ],\n    srcs = glob(\n        allow_empty = True,\n        include = [\"**/*.rs\"],\n    ),\n    tags = [\n        \"cargo-bazel\",\n        \"crate-name=rustversion\",\n        \"manual\",\n        \"noclippy\",\n        \"norustfmt\",\n    ],\n    version = \"1.0.23\",\n    visibility = [\"//visibility:private\"],\n)\n\nalias(\n    name = \"build_script_build\",\n    actual = \":_bs\",\n    tags = [\"manual\"],\n)\n"
++            }
++          },
++          "crates__syn-2.0.119": {
++            "repoRuleId": "@@bazel_tools//tools/build_defs/repo:http.bzl%http_archive",
++            "attributes": {
++              "patch_args": [],
++              "patch_tool": "",
++              "patches": [],
++              "remote_patch_strip": 1,
++              "sha256": "872831b642d1a07999a962a351ed35b955ea2cfc8f3862091e2a240a84f17297",
++              "type": "tar.gz",
++              "urls": [
++                "https://static.crates.io/crates/syn/2.0.119/download"
++              ],
++              "strip_prefix": "syn-2.0.119",
++              "build_file_content": "###############################################################################\n# @generated\n# DO NOT MODIFY: This file is auto-generated by a crate_universe tool. To \n# regenerate this file, run the following:\n#\n#     bazel mod show_repo 'protobuf'\n###############################################################################\n\nload(\"@rules_rust//cargo:defs.bzl\", \"cargo_toml_env_vars\")\n\nload(\"@rules_rust//rust:defs.bzl\", \"rust_library\")\n\n# buildifier: disable=bzl-visibility\nload(\"@rules_rust//crate_universe/private:selects.bzl\", \"selects\")\n\npackage(default_visibility = [\"//visibility:public\"])\n\ncargo_toml_env_vars(\n    name = \"cargo_toml_env_vars\",\n    src = \"Cargo.toml\",\n)\n\nrust_library(\n    name = \"syn\",\n    deps = [\n        \"@crates__proc-macro2-1.0.107//:proc_macro2\",\n        \"@crates__quote-1.0.47//:quote\",\n        \"@crates__unicode-ident-1.0.24//:unicode_ident\",\n    ],\n    compile_data = glob(\n        allow_empty = True,\n        include = [\"**\"],\n        exclude = [\n            \"**/* *\",\n            \".tmp_git_root/**/*\",\n            \"BUILD\",\n            \"BUILD.bazel\",\n            \"WORKSPACE\",\n            \"WORKSPACE.bazel\",\n        ],\n    ),\n    crate_features = [\n        \"clone-impls\",\n        \"default\",\n        \"derive\",\n        \"extra-traits\",\n        \"full\",\n        \"parsing\",\n        \"printing\",\n        \"proc-macro\",\n    ],\n    crate_root = \"src/lib.rs\",\n    edition = \"2021\",\n    rustc_env_files = [\n        \":cargo_toml_env_vars\",\n    ],\n    rustc_flags = [\n        \"--cap-lints=allow\",\n    ],\n    srcs = glob(\n        allow_empty = True,\n        include = [\"**/*.rs\"],\n    ),\n    tags = [\n        \"cargo-bazel\",\n        \"crate-name=syn\",\n        \"manual\",\n        \"noclippy\",\n        \"norustfmt\",\n    ],\n    target_compatible_with = select({\n        \"@rules_rust//rust/platform:aarch64-apple-darwin\": [],\n        \"@rules_rust//rust/platform:aarch64-unknown-linux-gnu\": [],\n        \"@rules_rust//rust/platform:wasm32-unknown-unknown\": [],\n        \"@rules_rust//rust/platform:wasm32-wasip1\": [],\n        \"@rules_rust//rust/platform:x86_64-pc-windows-msvc\": [],\n        \"@rules_rust//rust/platform:x86_64-unknown-linux-gnu\": [],\n        \"@rules_rust//rust/platform:x86_64-unknown-nixos-gnu\": [],\n        \"//conditions:default\": [\"@platforms//:incompatible\"],\n    }),\n    version = \"2.0.119\",\n)\n"
++            }
++          },
++          "crates__syn-3.0.3": {
++            "repoRuleId": "@@bazel_tools//tools/build_defs/repo:http.bzl%http_archive",
++            "attributes": {
++              "patch_args": [],
++              "patch_tool": "",
++              "patches": [],
++              "remote_patch_strip": 1,
++              "sha256": "53e9bae58849f64dfa4f5d5ae372c8341f7305f82a3868709269343628b659a3",
++              "type": "tar.gz",
++              "urls": [
++                "https://static.crates.io/crates/syn/3.0.3/download"
++              ],
++              "strip_prefix": "syn-3.0.3",
++              "build_file_content": "###############################################################################\n# @generated\n# DO NOT MODIFY: This file is auto-generated by a crate_universe tool. To \n# regenerate this file, run the following:\n#\n#     bazel mod show_repo 'protobuf'\n###############################################################################\n\nload(\"@rules_rust//cargo:defs.bzl\", \"cargo_toml_env_vars\")\n\nload(\"@rules_rust//rust:defs.bzl\", \"rust_library\")\n\n# buildifier: disable=bzl-visibility\nload(\"@rules_rust//crate_universe/private:selects.bzl\", \"selects\")\n\npackage(default_visibility = [\"//visibility:public\"])\n\ncargo_toml_env_vars(\n    name = \"cargo_toml_env_vars\",\n    src = \"Cargo.toml\",\n)\n\nrust_library(\n    name = \"syn\",\n    deps = [\n        \"@crates__proc-macro2-1.0.107//:proc_macro2\",\n        \"@crates__quote-1.0.47//:quote\",\n        \"@crates__unicode-ident-1.0.24//:unicode_ident\",\n    ],\n    compile_data = glob(\n        allow_empty = True,\n        include = [\"**\"],\n        exclude = [\n            \"**/* *\",\n            \".tmp_git_root/**/*\",\n            \"BUILD\",\n            \"BUILD.bazel\",\n            \"WORKSPACE\",\n            \"WORKSPACE.bazel\",\n        ],\n    ),\n    crate_features = [\n        \"clone-impls\",\n        \"default\",\n        \"derive\",\n        \"parsing\",\n        \"printing\",\n        \"proc-macro\",\n    ],\n    crate_root = \"src/lib.rs\",\n    edition = \"2021\",\n    rustc_env_files = [\n        \":cargo_toml_env_vars\",\n    ],\n    rustc_flags = [\n        \"--cap-lints=allow\",\n    ],\n    srcs = glob(\n        allow_empty = True,\n        include = [\"**/*.rs\"],\n    ),\n    tags = [\n        \"cargo-bazel\",\n        \"crate-name=syn\",\n        \"manual\",\n        \"noclippy\",\n        \"norustfmt\",\n    ],\n    target_compatible_with = select({\n        \"@rules_rust//rust/platform:aarch64-apple-darwin\": [],\n        \"@rules_rust//rust/platform:aarch64-unknown-linux-gnu\": [],\n        \"@rules_rust//rust/platform:wasm32-unknown-unknown\": [],\n        \"@rules_rust//rust/platform:wasm32-wasip1\": [],\n        \"@rules_rust//rust/platform:x86_64-pc-windows-msvc\": [],\n        \"@rules_rust//rust/platform:x86_64-unknown-linux-gnu\": [],\n        \"@rules_rust//rust/platform:x86_64-unknown-nixos-gnu\": [],\n        \"//conditions:default\": [\"@platforms//:incompatible\"],\n    }),\n    version = \"3.0.3\",\n)\n"
++            }
++          },
++          "crates__unicode-ident-1.0.24": {
++            "repoRuleId": "@@bazel_tools//tools/build_defs/repo:http.bzl%http_archive",
++            "attributes": {
++              "patch_args": [],
++              "patch_tool": "",
++              "patches": [],
++              "remote_patch_strip": 1,
++              "sha256": "e6e4313cd5fcd3dad5cafa179702e2b244f760991f45397d14d4ebf38247da75",
++              "type": "tar.gz",
++              "urls": [
++                "https://static.crates.io/crates/unicode-ident/1.0.24/download"
++              ],
++              "strip_prefix": "unicode-ident-1.0.24",
++              "build_file_content": "###############################################################################\n# @generated\n# DO NOT MODIFY: This file is auto-generated by a crate_universe tool. To \n# regenerate this file, run the following:\n#\n#     bazel mod show_repo 'protobuf'\n###############################################################################\n\nload(\"@rules_rust//cargo:defs.bzl\", \"cargo_toml_env_vars\")\n\nload(\"@rules_rust//rust:defs.bzl\", \"rust_library\")\n\n# buildifier: disable=bzl-visibility\nload(\"@rules_rust//crate_universe/private:selects.bzl\", \"selects\")\n\npackage(default_visibility = [\"//visibility:public\"])\n\ncargo_toml_env_vars(\n    name = \"cargo_toml_env_vars\",\n    src = \"Cargo.toml\",\n)\n\nrust_library(\n    name = \"unicode_ident\",\n    compile_data = glob(\n        allow_empty = True,\n        include = [\"**\"],\n        exclude = [\n            \"**/* *\",\n            \".tmp_git_root/**/*\",\n            \"BUILD\",\n            \"BUILD.bazel\",\n            \"WORKSPACE\",\n            \"WORKSPACE.bazel\",\n        ],\n    ),\n    crate_root = \"src/lib.rs\",\n    edition = \"2021\",\n    rustc_env_files = [\n        \":cargo_toml_env_vars\",\n    ],\n    rustc_flags = [\n        \"--cap-lints=allow\",\n    ],\n    srcs = glob(\n        allow_empty = True,\n        include = [\"**/*.rs\"],\n    ),\n    tags = [\n        \"cargo-bazel\",\n        \"crate-name=unicode-ident\",\n        \"manual\",\n        \"noclippy\",\n        \"norustfmt\",\n    ],\n    target_compatible_with = select({\n        \"@rules_rust//rust/platform:aarch64-apple-darwin\": [],\n        \"@rules_rust//rust/platform:aarch64-unknown-linux-gnu\": [],\n        \"@rules_rust//rust/platform:wasm32-unknown-unknown\": [],\n        \"@rules_rust//rust/platform:wasm32-wasip1\": [],\n        \"@rules_rust//rust/platform:x86_64-pc-windows-msvc\": [],\n        \"@rules_rust//rust/platform:x86_64-unknown-linux-gnu\": [],\n        \"@rules_rust//rust/platform:x86_64-unknown-nixos-gnu\": [],\n        \"//conditions:default\": [\"@platforms//:incompatible\"],\n    }),\n    version = \"1.0.24\",\n)\n"
++            }
++          }
++        },
++        "recordedRepoMappingEntries": [
++          [
++            "bazel_features+",
++            "bazel_features_globals",
++            "bazel_features++version_extension+bazel_features_globals"
++          ],
++          [
++            "bazel_features+",
++            "bazel_features_version",
++            "bazel_features++version_extension+bazel_features_version"
++          ],
++          [
++            "rules_cc+",
++            "bazel_tools",
++            "bazel_tools"
++          ],
++          [
++            "rules_cc+",
++            "cc_compatibility_proxy",
++            "rules_cc++compatibility_proxy+cc_compatibility_proxy"
++          ],
++          [
++            "rules_cc+",
++            "rules_cc",
++            "rules_cc+"
++          ],
++          [
++            "rules_cc++compatibility_proxy+cc_compatibility_proxy",
++            "rules_cc",
++            "rules_cc+"
++          ],
++          [
++            "rules_rust+",
++            "bazel_features",
++            "bazel_features+"
++          ],
++          [
++            "rules_rust+",
++            "bazel_skylib",
++            "bazel_skylib+"
++          ],
++          [
++            "rules_rust+",
++            "bazel_tools",
++            "bazel_tools"
++          ],
++          [
++            "rules_rust+",
++            "rules_cc",
++            "rules_cc+"
++          ],
++          [
++            "rules_rust+",
++            "rules_rust",
++            "rules_rust+"
++          ]
++        ]
++      }
++    },
++    "@@rules_rust+//crate_universe/private:internal_extensions.bzl%cu_nr": {
++      "general": {
++        "bzlTransitiveDigest": "GOOgbXFJQhO4daGipwnspaixIHp6AWTvXRBe2wMULd4=",
++        "usagesDigest": "tG3p3Nb5XxC7vWY/bcKdb//g0HoAxpxxH3F5/jBVlk4=",
++        "recordedFileInputs": {},
++        "recordedDirentsInputs": {},
++        "envVariables": {},
++        "generatedRepoSpecs": {
++          "cargo_bazel_bootstrap": {
++            "repoRuleId": "@@rules_rust+//cargo/private:cargo_bootstrap.bzl%cargo_bootstrap_repository",
++            "attributes": {
++              "srcs": [
++                "@@rules_rust+//crate_universe:src/api.rs",
++                "@@rules_rust+//crate_universe:src/api/lockfile.rs",
++                "@@rules_rust+//crate_universe:src/cli.rs",
++                "@@rules_rust+//crate_universe:src/cli/generate.rs",
++                "@@rules_rust+//crate_universe:src/cli/query.rs",
++                "@@rules_rust+//crate_universe:src/cli/render.rs",
++                "@@rules_rust+//crate_universe:src/cli/splice.rs",
++                "@@rules_rust+//crate_universe:src/cli/vendor.rs",
++                "@@rules_rust+//crate_universe:src/config.rs",
++                "@@rules_rust+//crate_universe:src/context.rs",
++                "@@rules_rust+//crate_universe:src/context/crate_context.rs",
++                "@@rules_rust+//crate_universe:src/context/platforms.rs",
++                "@@rules_rust+//crate_universe:src/lib.rs",
++                "@@rules_rust+//crate_universe:src/lockfile.rs",
++                "@@rules_rust+//crate_universe:src/main.rs",
++                "@@rules_rust+//crate_universe:src/metadata.rs",
++                "@@rules_rust+//crate_universe:src/metadata/cargo_bin.rs",
++                "@@rules_rust+//crate_universe:src/metadata/cargo_tree_resolver.rs",
++                "@@rules_rust+//crate_universe:src/metadata/cargo_tree_rustc_wrapper.bat",
++                "@@rules_rust+//crate_universe:src/metadata/cargo_tree_rustc_wrapper.sh",
++                "@@rules_rust+//crate_universe:src/metadata/dependency.rs",
++                "@@rules_rust+//crate_universe:src/metadata/metadata_annotation.rs",
++                "@@rules_rust+//crate_universe:src/rendering.rs",
++                "@@rules_rust+//crate_universe:src/rendering/template_engine.rs",
++                "@@rules_rust+//crate_universe:src/rendering/templates/module_bzl.j2",
++                "@@rules_rust+//crate_universe:src/rendering/templates/partials/header.j2",
++                "@@rules_rust+//crate_universe:src/rendering/templates/partials/module/aliases_map.j2",
++                "@@rules_rust+//crate_universe:src/rendering/templates/partials/module/deps_map.j2",
++                "@@rules_rust+//crate_universe:src/rendering/templates/partials/module/repo_git.j2",
++                "@@rules_rust+//crate_universe:src/rendering/templates/partials/module/repo_http.j2",
++                "@@rules_rust+//crate_universe:src/rendering/templates/vendor_module.j2",
++                "@@rules_rust+//crate_universe:src/rendering/verbatim/alias_rules.bzl",
++                "@@rules_rust+//crate_universe:src/select.rs",
++                "@@rules_rust+//crate_universe:src/splicing.rs",
++                "@@rules_rust+//crate_universe:src/splicing/cargo_config.rs",
++                "@@rules_rust+//crate_universe:src/splicing/crate_index_lookup.rs",
++                "@@rules_rust+//crate_universe:src/splicing/splicer.rs",
++                "@@rules_rust+//crate_universe:src/test.rs",
++                "@@rules_rust+//crate_universe:src/utils.rs",
++                "@@rules_rust+//crate_universe:src/utils/starlark.rs",
++                "@@rules_rust+//crate_universe:src/utils/starlark/glob.rs",
++                "@@rules_rust+//crate_universe:src/utils/starlark/label.rs",
++                "@@rules_rust+//crate_universe:src/utils/starlark/select.rs",
++                "@@rules_rust+//crate_universe:src/utils/starlark/select_dict.rs",
++                "@@rules_rust+//crate_universe:src/utils/starlark/select_list.rs",
++                "@@rules_rust+//crate_universe:src/utils/starlark/select_scalar.rs",
++                "@@rules_rust+//crate_universe:src/utils/starlark/select_set.rs",
++                "@@rules_rust+//crate_universe:src/utils/starlark/serialize.rs",
++                "@@rules_rust+//crate_universe:src/utils/starlark/target_compatible_with.rs",
++                "@@rules_rust+//crate_universe:src/utils/symlink.rs",
++                "@@rules_rust+//crate_universe:src/utils/target_triple.rs"
++              ],
++              "binary": "cargo-bazel",
++              "cargo_lockfile": "@@rules_rust+//crate_universe:Cargo.lock",
++              "cargo_toml": "@@rules_rust+//crate_universe:Cargo.toml",
++              "version": "1.93.1",
++              "timeout": 900,
++              "rust_toolchain_cargo_template": "@rust_host_tools//:bin/{tool}",
++              "rust_toolchain_rustc_template": "@rust_host_tools//:bin/{tool}",
++              "compressed_windows_toolchain_names": false
++            }
++          }
++        },
++        "moduleExtensionMetadata": {
++          "explicitRootModuleDirectDeps": [
++            "cargo_bazel_bootstrap"
++          ],
++          "explicitRootModuleDirectDevDeps": [],
++          "useAllRepos": "NO",
++          "reproducible": false
++        },
++        "recordedRepoMappingEntries": [
++          [
++            "bazel_features+",
++            "bazel_features_globals",
++            "bazel_features++version_extension+bazel_features_globals"
++          ],
++          [
++            "bazel_features+",
++            "bazel_features_version",
++            "bazel_features++version_extension+bazel_features_version"
++          ],
++          [
++            "rules_cc+",
++            "bazel_tools",
++            "bazel_tools"
++          ],
++          [
++            "rules_cc+",
++            "cc_compatibility_proxy",
++            "rules_cc++compatibility_proxy+cc_compatibility_proxy"
++          ],
++          [
++            "rules_cc+",
++            "rules_cc",
++            "rules_cc+"
++          ],
++          [
++            "rules_cc++compatibility_proxy+cc_compatibility_proxy",
++            "rules_cc",
++            "rules_cc+"
++          ],
++          [
++            "rules_rust+",
++            "bazel_features",
++            "bazel_features+"
++          ],
++          [
++            "rules_rust+",
++            "bazel_skylib",
++            "bazel_skylib+"
++          ],
++          [
++            "rules_rust+",
++            "bazel_tools",
++            "bazel_tools"
++          ],
++          [
++            "rules_rust+",
++            "cui",
++            "rules_rust++cu+cui"
++          ],
++          [
++            "rules_rust+",
++            "rrc",
++            "rules_rust++i2+rrc"
++          ],
++          [
++            "rules_rust+",
++            "rules_cc",
++            "rules_cc+"
++          ],
++          [
++            "rules_rust+",
++            "rules_rust",
++            "rules_rust+"
++          ]
++        ]
++      }
+     }
+   },
+   "facts": {

--- a/tests/Transforms/convert_to_ciphertext_semantics/insert_slice.mlir
+++ b/tests/Transforms/convert_to_ciphertext_semantics/insert_slice.mlir
@@ -10,7 +10,6 @@ module {
     // CHECK: secret.generic
     // CHECK: %[[v0:.*]] = tensor.empty() : tensor<2x32xf32>
     // CHECK: %[[v3:.*]] = tensor.empty() : tensor<2x32xf32>
-    // CHECK: arith.addf
     // CHECK-COUNT-2: tensor.insert_slice
     // CHECK-COUNT-2: tensor.insert_slice
     // CHECK: arith.addf
@@ -40,7 +39,6 @@ module {
     // CHECK: tensor.empty() : tensor<2x32xf32>
     // CHECK: tensor_ext.remap
     // CHECK: %[[v3:.*]] = tensor.empty() : tensor<2x32xf32>
-    // CHECK: arith.addf
     // CHECK-COUNT-2: tensor.insert_slice
     // CHECK: arith.addf
     // CHECK: return


### PR DESCRIPTION
Adds the optional scale-snu CHEDDAR dependency and its opt-in CUDA build configuration.

This branch currently also carries the close-to-main integration and preprocessing resource-loading change that the rest of the Cheddar stack depends on. Those commits are temporary stack-base dependencies and will disappear from this PR as their upstream changes land.
